### PR TITLE
fix: update graph configs to avoid DeprecationWarning for area weights

### DIFF
--- a/training/src/anemoi/training/config/graph/encoder_decoder_only.yaml
+++ b/training/src/anemoi/training/config/graph/encoder_decoder_only.yaml
@@ -38,7 +38,7 @@ edges:
 attributes:
   nodes:
     area_weight:
-      _target_: anemoi.graphs.nodes.attributes.AreaWeights # options: Area, Uniform
+      _target_: anemoi.graphs.nodes.attributes.SphericalAreaWeights # options: Area, Uniform
       norm: unit-max # options: l1, l2, unit-max, unit-sum, unit-std
   edges:
     edge_length:

--- a/training/src/anemoi/training/config/graph/limited_area.yaml
+++ b/training/src/anemoi/training/config/graph/limited_area.yaml
@@ -56,7 +56,7 @@ attributes:
   nodes:
     # Attributes for data nodes
     area_weight:
-      _target_: anemoi.graphs.nodes.attributes.AreaWeights # options: Area, Uniform
+      _target_: anemoi.graphs.nodes.attributes.PlanarAreaWeights # options: Area, Uniform
       norm: unit-max # options: l1, l2, unit-max, unit-sum, unit-std
     cutout_mask:
       _target_: anemoi.graphs.nodes.attributes.CutOutMask

--- a/training/src/anemoi/training/config/graph/multi_scale.yaml
+++ b/training/src/anemoi/training/config/graph/multi_scale.yaml
@@ -45,7 +45,7 @@ edges:
 attributes:
   nodes:
     area_weight:
-      _target_: anemoi.graphs.nodes.attributes.AreaWeights # options: Area, Uniform
+      _target_: anemoi.graphs.nodes.attributes.SphericalAreaWeights # options: Area, Uniform
       norm: unit-max # options: l1, l2, unit-max, unit-sum, unit-std
   edges:
     edge_length:

--- a/training/src/anemoi/training/config/graph/stretched_grid.yaml
+++ b/training/src/anemoi/training/config/graph/stretched_grid.yaml
@@ -48,7 +48,7 @@ attributes:
   nodes:
     # Attributes for data nodes
     area_weight:
-      _target_: anemoi.graphs.nodes.attributes.AreaWeights
+      _target_: anemoi.graphs.nodes.attributes.SphericalAreaWeights
       norm: unit-max
     cutout:
       _target_: anemoi.graphs.nodes.attributes.CutOutMask


### PR DESCRIPTION
This PR updates the default graph configuration files. These changes suppress a deprecation warning generated by anemoi-graphs. `AreaWeights` class is dropped in favour of `SphericalAreaWeights` and `PlanarAreaWeights`. 