### PR TITLE
Models: GraphtransformerProcessor chunking

### DIFF
--- a/models/tests/layers/block/test_block_graphtransformer.py
+++ b/models/tests/layers/block/test_block_graphtransformer.py
@@ -188,6 +188,44 @@ def test_GraphTransformerProcessorBlock_forward_backward(init, block):
 
 
 @pytest.fixture
+def test_GraphTransformerProcessorBlock_chunking(init, block, monkeypatch):
+    (
+        in_channels,
+        _hidden_dim,
+        _out_channels,
+        edge_dim,
+        _bias,
+        _activation,
+        _num_heads,
+        _num_chunks,
+    ) = init
+    # Initialize GraphTransformerProcessorBlock
+    block = block
+
+    # Generate random input tensor
+    x = torch.randn((10, in_channels))
+    edge_attr = torch.randn((10, edge_dim))
+    edge_index = torch.randint(1, 10, (2, 10))
+    shapes = (10, 10, 10)
+    batch_size = 1
+    num_chunks = torch.randint(2, 10, (1,)).item()
+
+    # manually set to non-training mode
+    block.eval()
+
+    # result with chunks
+    monkeypatch.setenv("ANEMOI_INFERENCE_NUM_CHUNKS", str(num_chunks))
+    importlib.reload(anemoi.models.layers.block)
+    out_chunked, _ = block(x, edge_attr, edge_index, shapes, batch_size)
+    # result without chunks, reload block for new env variable
+    monkeypatch.setenv("ANEMOI_INFERENCE_NUM_CHUNKS", "1")
+    importlib.reload(anemoi.models.layers.block)
+    out, _ = block(x, edge_attr, edge_index, shapes, batch_size)
+
+    assert out.shape == out_chunked.shape, f"out.shape ({out.shape}) != out_chunked.shape ({out_chunked.shape})"
+    assert torch.allclose(out, out_chunked, atol=1e-4), "out != out_chunked"
+
+@pytest.fixture
 def mapper_block(init):
     (
         in_channels,


### PR DESCRIPTION
## Describe your changes

This PR adds chunking for the GraphTransformerProcessorBlock to reduce memory usage in inference. The functionality is equivalent to the GraphTransformerMapperBlock chunking and uses the same env variable `ANEMOI_INFERENCE_NUM_CHUNKS` to control chunking behaviour. 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation and docstrings to reflect the changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have ensured that the code is still pip-installable after the changes and runs
- [x] I have not introduced new dependencies in the inference partion of the model
- [x] I have ran this on single GPU
- [x] I have ran this on multi-GPU or multi-node
- [ ] I have ran this to work on LUMI (or made sure the changes work independently.)
- [ ] I have ran the Benchmark Profiler against the old version of the code

## Tag possible reviewers
@ssmmnn11 @gabrieloks 