### PR TITLE
fix(training): bump anemoi-datasets required version to 0.5.13

### DIFF
--- a/training/pyproject.toml
+++ b/training/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
 dynamic = [ "version" ]
 
 dependencies = [
-  "anemoi-datasets>=0.5.2",
+  "anemoi-datasets>=0.5.13",
   "anemoi-graphs>=0.4.1",
   "anemoi-models>=0.4.1",
   "anemoi-utils[provenance]>=0.4.4",


### PR DESCRIPTION
This PR bumps the required `anemoi-datasets` version of `anemoi-training`.