### PR TITLE
feature(models): Add model comm group to predict_step 

### DIFF
--- a/models/CHANGELOG.md
+++ b/models/CHANGELOG.md
@@ -18,6 +18,7 @@ Keep it human-readable, your future self will thank you!
 - Reduced memory usage when using chunking in the mapper [#84](https://github.com/ecmwf/anemoi-models/pull/84)
 - Added `supporting_arrays` argument, which contains arrays to store in checkpoints. [#97](https://github.com/ecmwf/anemoi-models/pull/97)
 - Add remappers, e.g. link functions to apply during training to facilitate learning of variables with a difficult distribution [#88](https://github.com/ecmwf/anemoi-models/pull/88)
+- 'predict\_step' can take an optional model comm group. [#77](https://github.com/ecmwf/anemoi-core/pull/77)
 
 ## [0.4.0](https://github.com/ecmwf/anemoi-models/compare/0.3.0...0.4.0) - Improvements to Model Design
 

--- a/models/src/anemoi/models/interface/__init__.py
+++ b/models/src/anemoi/models/interface/__init__.py
@@ -96,7 +96,9 @@ class AnemoiModelInterface(torch.nn.Module):
         # Use the forward method of the model directly
         self.forward = self.model.forward
 
-    def predict_step(self, batch: torch.Tensor, model_comm_group: Optional[ProcessGroup] = None) -> torch.Tensor:
+    def predict_step(
+        self, batch: torch.Tensor, model_comm_group: Optional[ProcessGroup] = None, **kwargs
+    ) -> torch.Tensor:
         """Prediction step for the model.
 
         Parameters

--- a/models/src/anemoi/models/interface/__init__.py
+++ b/models/src/anemoi/models/interface/__init__.py
@@ -8,9 +8,11 @@
 # nor does it submit to any jurisdiction.
 
 import uuid
+from typing import Optional
 
 import torch
 from hydra.utils import instantiate
+from torch.distributed.distributed_c10d import ProcessGroup
 from torch_geometric.data import HeteroData
 
 from anemoi.models.preprocessing import Processors
@@ -94,7 +96,7 @@ class AnemoiModelInterface(torch.nn.Module):
         # Use the forward method of the model directly
         self.forward = self.model.forward
 
-    def predict_step(self, batch: torch.Tensor) -> torch.Tensor:
+    def predict_step(self, batch: torch.Tensor, model_comm_group: Optional[ProcessGroup] = None) -> torch.Tensor:
         """Prediction step for the model.
 
         Parameters
@@ -118,6 +120,6 @@ class AnemoiModelInterface(torch.nn.Module):
             # batch, timesteps, horizonal space, variables
             x = batch[:, 0 : self.multi_step, None, ...]  # add dummy ensemble dimension as 3rd index
 
-            y_hat = self(x)
+            y_hat = self(x, model_comm_group)
 
         return self.post_processors(y_hat, in_place=False)


### PR DESCRIPTION
Small change to allow predict_step to take an optional model_comm_group, like model.forward does.

This is needed for parallel-inference, which calls predict_step