### PR TITLE
feat: Checkpointed mapper head chunking

### DIFF
--- a/models/src/anemoi/models/layers/block.py
+++ b/models/src/anemoi/models/layers/block.py
@@ -474,6 +474,9 @@ class GraphTransformerMapperBlock(GraphTransformerBaseBlock):
             **kwargs,
         )
 
+        self.lin_x0_skip = nn.Linear(in_channels, out_channels)  # to match x_skip.shape[1] shape with out shape
+        self.lin_x1_skip = nn.Linear(in_channels, out_channels)  # to match x_skip.shape[1] shape with out shape
+
         self.layer_norm2 = nn.LayerNorm(in_channels)
 
     def forward(
@@ -486,24 +489,37 @@ class GraphTransformerMapperBlock(GraphTransformerBaseBlock):
         model_comm_group: Optional[ProcessGroup] = None,
         size: Optional[Size] = None,
     ):
-        x_skip = x
+        x_skip = (
+            self.lin_x0_skip(x[0]),
+            self.lin_x1_skip(x[1]),
+        )
 
         x = (
             self.layer_norm1(x[0]),
             self.layer_norm2(x[1]),
-        )  # Why does this use layer_norm2? And only is a mapper thing?
+        )
+
         x_r = self.lin_self(x[1])
         query = self.lin_query(x[1])
         key = self.lin_key(x[0])
         value = self.lin_value(x[0])
         edges = self.lin_edge(edge_attr)
 
+        # sync node sharded q k v
+        query = sync_tensor(query, 0, shapes[1], model_comm_group)
+        key = sync_tensor(key, 0, shapes[0], model_comm_group)
+        value = sync_tensor(value, 0, shapes[0], model_comm_group)
+
+        # expand head dimension
+        query = query.view(-1, self.num_heads, self.out_channels_conv)
+        key = key.view(-1, self.num_heads, self.out_channels_conv)
+        value = value.view(-1, self.num_heads, self.out_channels_conv)
+        edges = edges.view(-1, self.num_heads, self.out_channels_conv)
+
         if model_comm_group is not None:
             assert (
                 model_comm_group.size() == 1 or batch_size == 1
             ), "Only batch size of 1 is supported when model is sharded across GPUs"
-
-        query, key, value, edges = self.shard_qkve_heads(query, key, value, edges, shapes, batch_size, model_comm_group)
 
         num_chunks = self.num_chunks if self.training else NUM_CHUNKS_INFERENCE
 
@@ -512,7 +528,7 @@ class GraphTransformerMapperBlock(GraphTransformerBaseBlock):
             edge_attr_list, edge_index_list = sort_edges_1hop_chunks(
                 num_nodes=size, edge_attr=edges, edge_index=edge_index, num_chunks=num_chunks
             )
-            out = torch.zeros((x[1].shape[0], self.num_heads, self.out_channels_conv), device=x[1].device)
+            out = torch.zeros((query.shape[0], self.num_heads, self.out_channels_conv), device=query.device)
             for i in range(num_chunks):
                 out += self.conv(
                     query=query,
@@ -525,7 +541,9 @@ class GraphTransformerMapperBlock(GraphTransformerBaseBlock):
         else:
             out = self.conv(query=query, key=key, value=value, edge_attr=edges, edge_index=edge_index, size=size)
 
-        out = self.shard_output_seq(out, shapes, batch_size, model_comm_group)
+        # go back to original shape and shard nodes again
+        out = out.view(-1, self.num_heads * self.out_channels_conv)
+        out = shard_tensor(out, 0, shapes[1], model_comm_group)
 
         # compute out = self.projection(out + x_r) in chunks:
         out = torch.cat([self.projection(chunk) for chunk in torch.tensor_split(out + x_r, num_chunks, dim=0)], dim=0)

--- a/models/src/anemoi/models/layers/block.py
+++ b/models/src/anemoi/models/layers/block.py
@@ -406,8 +406,8 @@ class GraphTransformerBaseBlock(BaseBlock, ABC):
         """Shards Tensor sequence dimension."""
         shape_dst_nodes = shapes[1]
 
-        out = shard_tensor(out, dim=0, shapes=shape_dst_nodes, mgroup=model_comm_group)
         out = einops.rearrange(out, "(batch grid) heads vars -> (batch grid) (heads vars)", batch=batch_size)
+        out = shard_tensor(out, dim=0, shapes=shape_dst_nodes, mgroup=model_comm_group)
 
         return out
 

--- a/models/src/anemoi/models/layers/block.py
+++ b/models/src/anemoi/models/layers/block.py
@@ -472,10 +472,6 @@ class GraphTransformerMapperBlock(GraphTransformerBaseBlock):
             **kwargs,
         )
 
-        print(
-            f"GraphTransformerMapperBlock: in_channels={in_channels}, hidden_dim={hidden_dim}, out_channels={out_channels}, edge_dim={edge_dim}, num_heads={num_heads}"
-        )
-
         self.lin_x0_skip = nn.Linear(in_channels, out_channels)  # to match x_skip.shape[1] shape with out shape
         self.lin_x1_skip = nn.Linear(in_channels, out_channels)  # to match x_skip.shape[1] shape with out shape
 

--- a/models/src/anemoi/models/layers/mapper.py
+++ b/models/src/anemoi/models/layers/mapper.py
@@ -28,6 +28,7 @@ from anemoi.models.distributed.khop_edges import sort_edges_1hop_sharding
 from anemoi.models.distributed.shapes import change_channels_in_shape
 from anemoi.models.layers.block import GraphConvMapperBlock
 from anemoi.models.layers.block import GraphTransformerMapperBlock
+from anemoi.models.layers.block import GraphTransformerMapperBlockAttention
 from anemoi.models.layers.graph import TrainableTensor
 from anemoi.models.layers.mlp import MLP
 
@@ -710,3 +711,258 @@ class GNNBackwardMapper(BackwardMapperPostProcessMixin, GNNBaseMapper):
 
         _, x_dst = super().forward(x, batch_size, shard_shapes, model_comm_group)
         return x_dst
+
+
+class GraphTransformerBaseMapperAttention(GraphEdgeMixin, BaseMapper):
+    """Graph Transformer Base Mapper from hidden -> data or data -> hidden."""
+
+    def __init__(
+        self,
+        in_channels_src: int = 0,
+        in_channels_dst: int = 0,
+        hidden_dim: int = 128,
+        trainable_size: int = 8,
+        out_channels_dst: Optional[int] = None,
+        num_chunks: int = 1,
+        cpu_offload: bool = False,
+        activation: str = "GELU",
+        num_heads: int = 16,
+        mlp_hidden_ratio: int = 4,
+        sub_graph: Optional[HeteroData] = None,
+        sub_graph_edge_attributes: Optional[list[str]] = None,
+        src_grid_size: int = 0,
+        dst_grid_size: int = 0,
+    ) -> None:
+        """Initialize GraphTransformerBaseMapper.
+
+        Parameters
+        ----------
+        in_channels_src : int
+            Input channels of the source node
+        in_channels_dst : int
+            Input channels of the destination node
+        hidden_dim : int
+            Hidden dimension
+        trainable_size : int
+            Trainable tensor of edge
+        num_heads: int
+            Number of heads to use, default 16
+        mlp_hidden_ratio: int
+            ratio of mlp hidden dimension to embedding dimension, default 4
+        activation : str, optional
+            Activation function, by default "GELU"
+        cpu_offload : bool, optional
+            Whether to offload processing to CPU, by default False
+        out_channels_dst : Optional[int], optional
+            Output channels of the destination node, by default None
+        """
+        super().__init__(
+            in_channels_src,
+            in_channels_dst,
+            hidden_dim,
+            out_channels_dst=out_channels_dst,
+            num_chunks=num_chunks,
+            cpu_offload=cpu_offload,
+            activation=activation,
+        )
+
+        self._register_edges(sub_graph, sub_graph_edge_attributes, src_grid_size, dst_grid_size, trainable_size)
+
+        self.trainable = TrainableTensor(trainable_size=trainable_size, tensor_size=self.edge_attr.shape[0])
+
+        self.proc = GraphTransformerMapperBlockAttention(
+            hidden_dim,
+            mlp_hidden_ratio * hidden_dim,
+            hidden_dim,
+            num_heads=num_heads,
+            edge_dim=self.edge_dim,
+            activation=activation,
+            num_chunks=1,  # disable "inner chunking" for now
+        )
+
+        self.offload_layers(cpu_offload)
+
+        self.emb_nodes_dst = nn.Linear(self.in_channels_dst, self.hidden_dim)
+
+    def prepare_edges(self, size, batch_size, model_comm_group=None):
+        edge_attr = self.trainable(self.edge_attr, batch_size)
+        edge_index = self._expand_edges(self.edge_index_base, self.edge_inc, batch_size)
+        edge_attr, edge_index, shapes_edge_attr, shapes_edge_idx = sort_edges_1hop_sharding(
+            size, edge_attr, edge_index, model_comm_group
+        )
+
+        edge_index = shard_tensor(edge_index, 1, shapes_edge_idx, model_comm_group)
+        edge_attr = shard_tensor(edge_attr, 0, shapes_edge_attr, model_comm_group)
+
+        return edge_attr, edge_index
+
+    def forward(
+        self,
+        x: PairTensor,
+        batch_size: int,
+        shard_shapes: tuple[tuple[int], tuple[int]],
+        model_comm_group: Optional[ProcessGroup] = None,
+    ) -> PairTensor:
+        size = (sum(x[0] for x in shard_shapes[0]), sum(x[0] for x in shard_shapes[1]))
+        edge_attr, edge_index = self.prepare_edges(size, batch_size, model_comm_group)
+        x_src, x_dst, shapes_src, shapes_dst = self.pre_process(x, shard_shapes, model_comm_group)
+
+        (x_src, x_dst), edge_attr = self.proc(
+            (x_src, x_dst),
+            edge_attr,
+            edge_index,
+            (shapes_src, shapes_dst),
+            batch_size,
+            model_comm_group,
+            size=size,
+        )
+
+        x_dst = self.post_process(x_dst, shapes_dst, model_comm_group)
+
+        return x_dst
+
+
+class GraphTransformerForwardMapperAttention(ForwardMapperPreProcessMixin, GraphTransformerBaseMapperAttention):
+    """Graph Transformer Mapper from data -> hidden."""
+
+    def __init__(
+        self,
+        in_channels_src: int = 0,
+        in_channels_dst: int = 0,
+        hidden_dim: int = 128,
+        trainable_size: int = 8,
+        out_channels_dst: Optional[int] = None,
+        num_chunks: int = 1,
+        cpu_offload: bool = False,
+        activation: str = "GELU",
+        num_heads: int = 16,
+        mlp_hidden_ratio: int = 4,
+        sub_graph: Optional[HeteroData] = None,
+        sub_graph_edge_attributes: Optional[list[str]] = None,
+        src_grid_size: int = 0,
+        dst_grid_size: int = 0,
+    ) -> None:
+        """Initialize GraphTransformerForwardMapper.
+
+        Parameters
+        ----------
+        in_channels_src : int
+            Input channels of the source node
+        in_channels_dst : int
+            Input channels of the destination node
+        hidden_dim : int
+            Hidden dimension
+        trainable_size : int
+            Trainable tensor of edge
+        num_heads: int
+            Number of heads to use, default 16
+        mlp_hidden_ratio: int
+            ratio of mlp hidden dimension to embedding dimension, default 4
+        activation : str, optional
+            Activation function, by default "GELU"
+        cpu_offload : bool, optional
+            Whether to offload processing to CPU, by default False
+        out_channels_dst : Optional[int], optional
+            Output channels of the destination node, by default None
+        """
+        super().__init__(
+            in_channels_src,
+            in_channels_dst,
+            hidden_dim,
+            trainable_size,
+            out_channels_dst=out_channels_dst,
+            num_chunks=num_chunks,
+            cpu_offload=cpu_offload,
+            activation=activation,
+            num_heads=num_heads,
+            mlp_hidden_ratio=mlp_hidden_ratio,
+            sub_graph=sub_graph,
+            sub_graph_edge_attributes=sub_graph_edge_attributes,
+            src_grid_size=src_grid_size,
+            dst_grid_size=dst_grid_size,
+        )
+
+        self.emb_nodes_src = nn.Linear(self.in_channels_src, self.hidden_dim)
+
+    def forward(
+        self,
+        x: PairTensor,
+        batch_size: int,
+        shard_shapes: tuple[tuple[int], tuple[int]],
+        model_comm_group: Optional[ProcessGroup] = None,
+    ) -> PairTensor:
+        x_dst = super().forward(x, batch_size, shard_shapes, model_comm_group)
+        return x[0], x_dst
+
+
+class GraphTransformerBackwardMapperAttention(GraphTransformerBaseMapperAttention):  # moved PostProcessMixin up to enc_proc_dec
+    """Graph Transformer Mapper from hidden -> data."""
+
+    def __init__(
+        self,
+        in_channels_src: int = 0,
+        in_channels_dst: int = 0,
+        hidden_dim: int = 128,
+        trainable_size: int = 8,
+        out_channels_dst: Optional[int] = None,
+        num_chunks: int = 1,
+        cpu_offload: bool = False,
+        activation: str = "GELU",
+        num_heads: int = 16,
+        mlp_hidden_ratio: int = 4,
+        sub_graph: Optional[HeteroData] = None,
+        sub_graph_edge_attributes: Optional[list[str]] = None,
+        src_grid_size: int = 0,
+        dst_grid_size: int = 0,
+    ) -> None:
+        """Initialize GraphTransformerBackwardMapper.
+
+        Parameters
+        ----------
+        in_channels_src : int
+            Input channels of the source node
+        in_channels_dst : int
+            Input channels of the destination node
+        hidden_dim : int
+            Hidden dimension
+        trainable_size : int
+            Trainable tensor of edge
+        num_heads: int
+            Number of heads to use, default 16
+        mlp_hidden_ratio: int
+            ratio of mlp hidden dimension to embedding dimension, default 4
+        activation : str, optional
+            Activation function, by default "GELU"
+        cpu_offload : bool, optional
+            Whether to offload processing to CPU, by default False
+        out_channels_dst : Optional[int], optional
+            Output channels of the destination node, by default None
+        """
+        super().__init__(
+            in_channels_src,
+            in_channels_dst,
+            hidden_dim,
+            trainable_size,
+            out_channels_dst=out_channels_dst,
+            num_chunks=num_chunks,
+            cpu_offload=cpu_offload,
+            activation=activation,
+            num_heads=num_heads,
+            mlp_hidden_ratio=mlp_hidden_ratio,
+            sub_graph=sub_graph,
+            sub_graph_edge_attributes=sub_graph_edge_attributes,
+            src_grid_size=src_grid_size,
+            dst_grid_size=dst_grid_size,
+        )
+
+        self.node_data_extractor = nn.Sequential(
+            nn.LayerNorm(self.hidden_dim), nn.Linear(self.hidden_dim, self.out_channels_dst)
+        )
+
+    def pre_process(self, x, shard_shapes, model_comm_group=None):
+        x_src, x_dst, shapes_src, shapes_dst = super().pre_process(x, shard_shapes, model_comm_group)
+        shapes_src = change_channels_in_shape(shapes_src, self.hidden_dim)
+        x_dst = shard_tensor(x_dst, 0, shapes_dst, model_comm_group)
+        x_dst = self.emb_nodes_dst(x_dst)
+        shapes_dst = change_channels_in_shape(shapes_dst, self.hidden_dim)
+        return x_src, x_dst, shapes_src, shapes_dst

--- a/models/src/anemoi/models/layers/mixer.py
+++ b/models/src/anemoi/models/layers/mixer.py
@@ -26,9 +26,8 @@ class ChannelMixer(nn.Module):
 
     def __init__(
         self,
-        in_channels: int,
-        hidden_dim: int,
-        out_channels: int,
+        channels: int,
+        mlp_hidden_ratio: int = 4,
         activation: str = "GELU",
         num_chunks: int = 1,
         **kwargs,
@@ -37,12 +36,10 @@ class ChannelMixer(nn.Module):
 
         Parameters
         ----------
-        in_channels : int
-            Number of input channels.
-        hidden_dim : int,
-            hidden mlp dimension
-        out_channels : int
-            Number of output channels.
+        channels : int
+            Number of channels.
+        mlp_hidden_ratio : int,
+            factor for hidden mlp dimension
         activation : str, optional
             Activation function, by default "GELU"
         update_src_nodes: bool, by default False
@@ -59,10 +56,10 @@ class ChannelMixer(nn.Module):
             raise RuntimeError from ae
 
         self.node_dst_mlp = nn.Sequential(
-            nn.LayerNorm(out_channels),
-            nn.Linear(out_channels, hidden_dim),
+            nn.LayerNorm(channels),
+            nn.Linear(channels, channels * mlp_hidden_ratio),
             act_func(),
-            nn.Linear(hidden_dim, out_channels),
+            nn.Linear(channels * mlp_hidden_ratio, channels),
         )
 
     def forward(
@@ -71,7 +68,7 @@ class ChannelMixer(nn.Module):
     ):
         num_chunks = self.num_chunks if self.training else NUM_CHUNKS_INFERENCE
 
-        # fuse inputs, todo
+        # combine inputs
         nodes = torch.cat(x, dim=-1)
 
         # compute nodes_new_dst = self.node_dst_mlp(out) + out in chunks:
@@ -80,87 +77,3 @@ class ChannelMixer(nn.Module):
         )
 
         return nodes_new_dst
-
-# todo when updating src nodes as well..
-class ChannelMixerMapper(nn.Module):
-    """Graph Transformer Block for node embeddings."""
-
-    def __init__(
-        self,
-        in_channels: int,
-        hidden_dim: int,
-        out_channels: int,
-        activation: str = "GELU",
-        num_chunks: int = 1,
-        update_src_nodes: bool = False,
-        **kwargs,
-    ) -> None:
-        """Initialize ChannelMixerMapper.
-
-        Parameters
-        ----------
-        in_channels : int
-            Number of input channels.
-        hidden_dim : int,
-            hidden mlp dimension
-        out_channels : int
-            Number of output channels.
-        activation : str, optional
-            Activation function, by default "GELU"
-        update_src_nodes: bool, by default False
-            Update src if src and dst nodes are given
-        """
-        super().__init__(**kwargs)
-
-        self.update_src_nodes = update_src_nodes
-        self.num_chunks = num_chunks
-
-        try:
-            act_func = getattr(nn, activation)
-        except AttributeError as ae:
-            LOGGER.error("Activation function %s not supported", activation)
-            raise RuntimeError from ae
-
-        self.node_dst_mlp = nn.Sequential(
-            nn.LayerNorm(out_channels),
-            nn.Linear(out_channels, hidden_dim),
-            act_func(),
-            nn.Linear(hidden_dim, out_channels),
-        )
-
-        self.layer_norm1 = nn.LayerNorm(in_channels)
-
-        if self.update_src_nodes:
-            self.node_src_mlp = nn.Sequential(
-                nn.LayerNorm(out_channels),
-                nn.Linear(out_channels, hidden_dim),
-                act_func(),
-                nn.Linear(hidden_dim, out_channels),
-            )
-
-    def forward(
-        self,
-        x: PairTensor,
-    ):
-        num_chunks = self.num_chunks if self.training else NUM_CHUNKS_INFERENCE
-
-        nodes = x
-
-        # fuse inputs, todo
-
-        # compute nodes_new_dst = self.node_dst_mlp(out) + out in chunks:
-        nodes_new_dst = torch.cat(
-            [self.node_dst_mlp(chunk) + chunk for chunk in nodes[1].tensor_split(num_chunks, dim=0)], dim=0
-        )
-
-        if self.update_src_nodes:
-            # compute nodes_new_src = self.node_src_mlp(out) + out in chunks:
-            nodes_new_src = torch.cat(
-                [self.node_src_mlp(chunk) + chunk for chunk in nodes[0].tensor_split(num_chunks, dim=0)], dim=0
-            )
-        else:
-            nodes_new_src = nodes[0]
-
-        nodes_new = (nodes_new_src, nodes_new_dst)
-
-        return nodes_new

--- a/models/src/anemoi/models/layers/mixer.py
+++ b/models/src/anemoi/models/layers/mixer.py
@@ -1,0 +1,166 @@
+# (C) Copyright 2024 Anemoi contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+
+import logging
+import os
+
+import torch
+from torch import Tensor
+from torch import nn
+from torch_geometric.typing import PairTensor
+
+LOGGER = logging.getLogger(__name__)
+
+# Number of Mapper chunks used during inference (https://github.com/ecmwf/anemoi-models/pull/46)
+NUM_CHUNKS_INFERENCE = int(os.environ.get("ANEMOI_INFERENCE_NUM_CHUNKS", "1"))
+
+class ChannelMixer(nn.Module):
+    """Graph Transformer Block for node embeddings."""
+
+    def __init__(
+        self,
+        in_channels: int,
+        hidden_dim: int,
+        out_channels: int,
+        activation: str = "GELU",
+        num_chunks: int = 1,
+        **kwargs,
+    ) -> None:
+        """Initialize ChannelMixerMapper.
+
+        Parameters
+        ----------
+        in_channels : int
+            Number of input channels.
+        hidden_dim : int,
+            hidden mlp dimension
+        out_channels : int
+            Number of output channels.
+        activation : str, optional
+            Activation function, by default "GELU"
+        update_src_nodes: bool, by default False
+            Update src if src and dst nodes are given
+        """
+        super().__init__(**kwargs)
+
+        self.num_chunks = num_chunks
+
+        try:
+            act_func = getattr(nn, activation)
+        except AttributeError as ae:
+            LOGGER.error("Activation function %s not supported", activation)
+            raise RuntimeError from ae
+
+        self.node_dst_mlp = nn.Sequential(
+            nn.LayerNorm(out_channels),
+            nn.Linear(out_channels, hidden_dim),
+            act_func(),
+            nn.Linear(hidden_dim, out_channels),
+        )
+
+    def forward(
+        self,
+        x: PairTensor,
+    ):
+        num_chunks = self.num_chunks if self.training else NUM_CHUNKS_INFERENCE
+
+        # fuse inputs, todo
+        nodes = torch.cat(x, dim=-1)
+
+        # compute nodes_new_dst = self.node_dst_mlp(out) + out in chunks:
+        nodes_new_dst = torch.cat(
+            [self.node_dst_mlp(chunk) + chunk for chunk in nodes.tensor_split(num_chunks, dim=0)], dim=0
+        )
+
+        return nodes_new_dst
+
+# todo when updating src nodes as well..
+class ChannelMixerMapper(nn.Module):
+    """Graph Transformer Block for node embeddings."""
+
+    def __init__(
+        self,
+        in_channels: int,
+        hidden_dim: int,
+        out_channels: int,
+        activation: str = "GELU",
+        num_chunks: int = 1,
+        update_src_nodes: bool = False,
+        **kwargs,
+    ) -> None:
+        """Initialize ChannelMixerMapper.
+
+        Parameters
+        ----------
+        in_channels : int
+            Number of input channels.
+        hidden_dim : int,
+            hidden mlp dimension
+        out_channels : int
+            Number of output channels.
+        activation : str, optional
+            Activation function, by default "GELU"
+        update_src_nodes: bool, by default False
+            Update src if src and dst nodes are given
+        """
+        super().__init__(**kwargs)
+
+        self.update_src_nodes = update_src_nodes
+        self.num_chunks = num_chunks
+
+        try:
+            act_func = getattr(nn, activation)
+        except AttributeError as ae:
+            LOGGER.error("Activation function %s not supported", activation)
+            raise RuntimeError from ae
+
+        self.node_dst_mlp = nn.Sequential(
+            nn.LayerNorm(out_channels),
+            nn.Linear(out_channels, hidden_dim),
+            act_func(),
+            nn.Linear(hidden_dim, out_channels),
+        )
+
+        self.layer_norm1 = nn.LayerNorm(in_channels)
+
+        if self.update_src_nodes:
+            self.node_src_mlp = nn.Sequential(
+                nn.LayerNorm(out_channels),
+                nn.Linear(out_channels, hidden_dim),
+                act_func(),
+                nn.Linear(hidden_dim, out_channels),
+            )
+
+    def forward(
+        self,
+        x: PairTensor,
+    ):
+        num_chunks = self.num_chunks if self.training else NUM_CHUNKS_INFERENCE
+
+        nodes = x
+
+        # fuse inputs, todo
+
+        # compute nodes_new_dst = self.node_dst_mlp(out) + out in chunks:
+        nodes_new_dst = torch.cat(
+            [self.node_dst_mlp(chunk) + chunk for chunk in nodes[1].tensor_split(num_chunks, dim=0)], dim=0
+        )
+
+        if self.update_src_nodes:
+            # compute nodes_new_src = self.node_src_mlp(out) + out in chunks:
+            nodes_new_src = torch.cat(
+                [self.node_src_mlp(chunk) + chunk for chunk in nodes[0].tensor_split(num_chunks, dim=0)], dim=0
+            )
+        else:
+            nodes_new_src = nodes[0]
+
+        nodes_new = (nodes_new_src, nodes_new_dst)
+
+        return nodes_new

--- a/models/src/anemoi/models/models/encoder_processor_decoder.py
+++ b/models/src/anemoi/models/models/encoder_processor_decoder.py
@@ -17,7 +17,6 @@ from hydra.utils import instantiate
 from torch import Tensor
 from torch import nn
 from torch.distributed.distributed_c10d import ProcessGroup
-from torch.utils.checkpoint import checkpoint
 from torch_geometric.data import HeteroData
 
 from anemoi.models.distributed.shapes import get_shape_shards
@@ -156,13 +155,11 @@ class AnemoiModelEncProcDec(nn.Module):
         Tensor
             Mapped data
         """
-        return checkpoint(
-            mapper,
+        return mapper(  # no checkpoint here, mapper has checkpointing inside
             data,
             batch_size=batch_size,
             shard_shapes=shard_shapes,
             model_comm_group=model_comm_group,
-            use_reentrant=use_reentrant,
         )
 
     def forward(self, x: Tensor, model_comm_group: Optional[ProcessGroup] = None) -> Tensor:

--- a/models/src/anemoi/models/models/encoder_processor_decoder.py
+++ b/models/src/anemoi/models/models/encoder_processor_decoder.py
@@ -313,7 +313,7 @@ class AnemoiModelEncProcDec(nn.Module):
             x_out.append(
                 self._run_mapper(
                     self.decoder_list[i],
-                    (x_latent_proc_chunk[i], x_data_latent),
+                    (x_latent_proc_chunk[i], x_data),
                     batch_size=batch_size,
                     shard_shapes=(shard_shapes_hidden, shard_shapes_data),
                     model_comm_group=model_comm_group,

--- a/models/src/anemoi/models/models/encoder_processor_decoder.py
+++ b/models/src/anemoi/models/models/encoder_processor_decoder.py
@@ -109,18 +109,8 @@ class AnemoiModelEncProcDec(nn.Module):
             ]
         )
 
-        mlp_ratio_mixer = 4
-        self.encoder_mixer = ChannelMixer(
-                in_channels=self.num_channels,
-                hidden_dim=mlp_ratio_mixer * self.num_channels,
-                out_channels=self.num_channels,
-                )
-
-        self.decoder_mixer = ChannelMixer(
-                in_channels=self.num_channels,
-                hidden_dim=mlp_ratio_mixer * self.num_channels,
-                out_channels=self.num_channels,
-                )
+        self.encoder_mixer = instantiate(model_config.model.encoder_mixer)
+        self.decoder_mixer = instantiate(model_config.model.decoder_mixer)
 
         # Processor hidden -> hidden
         self.processor = instantiate(

--- a/training/src/anemoi/training/config/model/transformer.yaml
+++ b/training/src/anemoi/training/config/model/transformer.yaml
@@ -16,7 +16,7 @@ processor:
   dropout_p: 0.0 # GraphTransformer
 
 encoder:
-  _target_: anemoi.models.layers.mapper.GraphTransformerForwardMapper
+  _target_: anemoi.models.layers.mapper.GraphTransformerForwardMapperAttention
   _convert_: all
   trainable_size: ${model.trainable_parameters.data2hidden}
   sub_graph_edge_attributes: ${model.attributes.edges}
@@ -25,9 +25,20 @@ encoder:
   mlp_hidden_ratio: 4 # GraphTransformer or Transformer only
   num_heads: 16 # GraphTransformer or Transformer only
 
+encoder_mixer:
+  _target_: anemoi.models.layers.mixer.ChannelMixer
+  activation: ${model.activation}  
+  mlp_hidden_ratio: 4
+  channels: ${model.num_channels}
+
+decoder_mixer:
+  _target_: anemoi.models.layers.mixer.ChannelMixer
+  activation: ${model.activation}  
+  mlp_hidden_ratio: 4
+  channels: ${model.num_channels}
 
 decoder:
-  _target_: anemoi.models.layers.mapper.GraphTransformerBackwardMapper
+  _target_: anemoi.models.layers.mapper.GraphTransformerBackwardMapperAttention
   _convert_: all
   trainable_size: ${model.trainable_parameters.hidden2data}
   sub_graph_edge_attributes: ${model.attributes.edges}


### PR DESCRIPTION
[Draft] This PR aims to add checkpointed chunking of the GraphTransformerMapper across the head dimension to reduce memory usage during training.

First results:
Training at n320 we can level out the enc/dec vs proc memory with 4 chunks:

![Screenshot 2025-02-06 at 13 51 54](https://github.com/user-attachments/assets/d56233c5-7dc3-4292-9548-7bc4d1f5bd29)


Work in progress together with @ssmmnn11 