### PR TITLE
fix: normalise in place to reduce memory

### DIFF
--- a/models/src/anemoi/models/preprocessing/normalizer.py
+++ b/models/src/anemoi/models/preprocessing/normalizer.py
@@ -198,9 +198,9 @@ class InputNormalizer(BasePreprocessor):
         # input and predicted tensors have different shapes
         # hence, we mask out the forcing indices
         if data_index is not None:
-            x[..., :].subtract_(self._norm_add[data_index]).div_(self._norm_mul[data_index])
+            x.subtract_(self._norm_add[data_index]).div_(self._norm_mul[data_index])
         elif x.shape[-1] == len(self._output_idx):
-            x[..., :].subtract_(self._norm_add[self._output_idx]).div_(self._norm_mul[self._output_idx])
+            x.subtract_(self._norm_add[self._output_idx]).div_(self._norm_mul[self._output_idx])
         else:
-            x[..., :].subtract_(self._norm_add).div_(self._norm_mul)
+            x.subtract_(self._norm_add).div_(self._norm_mul)
         return x

--- a/models/src/anemoi/models/preprocessing/normalizer.py
+++ b/models/src/anemoi/models/preprocessing/normalizer.py
@@ -159,11 +159,12 @@ class InputNormalizer(BasePreprocessor):
             x = x.clone()
 
         if data_index is not None:
-            x[..., :] = x[..., :] * self._norm_mul[data_index] + self._norm_add[data_index]
+            x.mul_(self._norm_mul[data_index]).add_(self._norm_add[data_index])
         elif x.shape[-1] == len(self._input_idx):
-            x[..., :] = x[..., :] * self._norm_mul[self._input_idx] + self._norm_add[self._input_idx]
+            x.mul_(self._norm_mul[self._input_idx]).add_(self._norm_add[self._input_idx])
         else:
-            x[..., :] = x[..., :] * self._norm_mul + self._norm_add
+            x.mul_(self._norm_mul).add_(self._norm_add)
+
         return x
 
     def inverse_transform(
@@ -197,9 +198,9 @@ class InputNormalizer(BasePreprocessor):
         # input and predicted tensors have different shapes
         # hence, we mask out the forcing indices
         if data_index is not None:
-            x[..., :] = (x[..., :] - self._norm_add[data_index]) / self._norm_mul[data_index]
+            x[..., :].subtract_(self._norm_add[data_index]).div_(self._norm_mul[data_index])
         elif x.shape[-1] == len(self._output_idx):
-            x[..., :] = (x[..., :] - self._norm_add[self._output_idx]) / self._norm_mul[self._output_idx]
+            x[..., :].subtract_(self._norm_add[self._output_idx]).div_(self._norm_mul[self._output_idx])
         else:
-            x[..., :] = (x[..., :] - self._norm_add) / self._norm_mul
+            x[..., :].subtract_(self._norm_add).div_(self._norm_mul)
         return x


### PR DESCRIPTION
This PR avoids storing large intermediate results during the normalization by computing it in-place, e.g.

``
x[..., :] = x[..., :] * self._norm_mul + self._norm_add # old version
x.mul_(self._norm_mul).add_(self._norm_add) # new version
``

Note that the in_place argument still works as expected, only the actual calculation is changed to be done in-place.

For 9km data the old version resulted in mini-peaks during the normalizer: 

| Version | Peak memory (GB, during normalization) |
|------|------|
| old | 32.62 |
| new | 17.73 |

This lines up with storing two additional intermediate results (multiplication, addition) @~8GB batch size in the old version.
