### PR TITLE
Fix crash in diagnostic plots (colorbar limits)

### DIFF
--- a/training/src/anemoi/training/diagnostics/plots.py
+++ b/training/src/anemoi/training/diagnostics/plots.py
@@ -584,7 +584,9 @@ def plot_flat_sample(
         # For 'errors', only persistence and increments need identical colorbar-limits
         combined_error = np.concatenate(((pred - input_), (truth - input_)))
         norm = Normalize(vmin=np.nanmin(combined_data), vmax=np.nanmax(combined_data))
-        norm_error = TwoSlopeNorm(vmin=min(np.nanmin(combined_error),-1e-5), vcenter=0.0, vmax=max(np.nanmax(combined_error),1e-5))
+        norm_error = TwoSlopeNorm(
+            vmin=min(np.nanmin(combined_error), -1e-5), vcenter=0.0, vmax=max(np.nanmax(combined_error), 1e-5),
+        )
         single_plot(fig, ax[1], lon, lat, truth, norm=norm, title=f"{vname} target", datashader=datashader)
         single_plot(fig, ax[2], lon, lat, pred, norm=norm, title=f"{vname} pred", datashader=datashader)
         single_plot(

--- a/training/src/anemoi/training/diagnostics/plots.py
+++ b/training/src/anemoi/training/diagnostics/plots.py
@@ -584,7 +584,7 @@ def plot_flat_sample(
         # For 'errors', only persistence and increments need identical colorbar-limits
         combined_error = np.concatenate(((pred - input_), (truth - input_)))
         norm = Normalize(vmin=np.nanmin(combined_data), vmax=np.nanmax(combined_data))
-        norm_error = TwoSlopeNorm(vmin=np.nanmin(combined_error), vcenter=0.0, vmax=np.nanmax(combined_error))
+        norm_error = TwoSlopeNorm(vmin=min(np.nanmin(combined_error),-1e-5), vcenter=0.0, vmax=max(np.nanmax(combined_error),1e-5))
         single_plot(fig, ax[1], lon, lat, truth, norm=norm, title=f"{vname} target", datashader=datashader)
         single_plot(fig, ax[2], lon, lat, pred, norm=norm, title=f"{vname} pred", datashader=datashader)
         single_plot(


### PR DESCRIPTION
When the min or max value in the error maps is equal to zero, the plot function crashes because `vmax` or `vmin` is equal to `vcenter`.  This fix below seems to solve the problem.

I got this issue in the first epoch when trying to map the precipitation field. 