### PR TITLE
fix(training): profiler 'Model Summary' works when sharding models over multiple GPUs

### DIFF
--- a/training/CHANGELOG.md
+++ b/training/CHANGELOG.md
@@ -10,6 +10,10 @@ Keep it human-readable, your future self will thank you!
 
 ## [Unreleased](https://github.com/ecmwf/anemoi-training/compare/0.3.2...HEAD)
 
+### Fixed
+
+- Profilers 'Model Summary' feature works when the model is sharded across GPUs [#90](https://github.com/ecmwf/anemoi-core/pull/90)
+
 ## [0.3.2 - Multiple Fixes, Checkpoint updates, Stretched-grid/LAM updates](https://github.com/ecmwf/anemoi-training/compare/0.3.1...0.3.2) - 2024-12-19
 
 ### Fixed

--- a/training/src/anemoi/training/diagnostics/profilers.py
+++ b/training/src/anemoi/training/diagnostics/profilers.py
@@ -498,7 +498,7 @@ class BenchmarkProfiler(Profiler):
             f.write(model_summary)
             f.close()
 
-    def get_model_summary(self, model: GraphForecaster, example_input_array: np.ndarray, num_gpus_per_model: int =  1 ) -> str:
+    def get_model_summary(self, model: GraphForecaster, example_input_array: np.ndarray) -> str:
 
         from torchinfo import summary
 
@@ -506,17 +506,6 @@ class BenchmarkProfiler(Profiler):
         # since FlashAttention only supports fp16 and bf16 data type
         example_input_array = example_input_array.to(dtype=torch.float16)
         example_input_array = example_input_array.to("cuda")
-        #example_input_array.shape=torch.Size([1, 2, 1, 135520, 100])
-        #RuntimeError: Sizes of tensors must match except in dimension 1. Expected size 135520 but got size 542080 for tensor number 1 in the list.
-        #        self.example_input_array = batch[
-        #    :,
-        #    0 : self.config.training.multistep_input,
-        #    ...,
-        #    self.data_indices.data.input.full,
-        #]
-        if num_gpus_per_model > 1:
-            example_input_array = torch.chunk(example_input_array, chunks=num_gpus_per_model, dim=3)[0]
-        LOGGER.info(f"{example_input_array.shape=}")
         model.half()
         model = model.to("cuda")
 

--- a/training/src/anemoi/training/train/profiler.py
+++ b/training/src/anemoi/training/train/profiler.py
@@ -167,13 +167,9 @@ class AnemoiProfiler(AnemoiTrainer):
     @cached_property
     def model_summary(self) -> str:
         if self.config.diagnostics.benchmark_profiler.model_summary.enabled:
-            if self.config.hardware.num_gpus_per_model > 1:
-                LOGGER.warning("Model Summary is not supported when using model sharding")
-                self.config.diagnostics.benchmark_profiler.model_summary.enabled = False
-                return None
             model = self.model
             example_input_array = self.example_input_array
-            return self.profiler.get_model_summary(model=model, example_input_array=example_input_array)
+            return self.profiler.get_model_summary(model=model, example_input_array=example_input_array,  num_gpus_per_model=self.config.hardware.num_gpus_per_model)
         return None
 
     @rank_zero_only

--- a/training/src/anemoi/training/train/profiler.py
+++ b/training/src/anemoi/training/train/profiler.py
@@ -95,6 +95,9 @@ class AnemoiProfiler(AnemoiTrainer):
 
         if model_summary is not None:
             self.print_report("Model Summary", model_summary, color="Orange", emoji="robot")
+            num_gpus = self.config.hardware.num_gpus_per_node * self.config.hardware.num_nodes
+            if num_gpus > 1:
+                LOGGER.info("Model Summary displays the stats for a single GPU.")
 
     @staticmethod
     def write_benchmark_profiler_report() -> None:
@@ -108,6 +111,7 @@ class AnemoiProfiler(AnemoiTrainer):
         return df
 
     @cached_property
+    @rank_zero_only
     def speed_profile(self) -> None:
         """Speed profiler Report.
 
@@ -137,6 +141,7 @@ class AnemoiProfiler(AnemoiTrainer):
         return logger_info
 
     @cached_property
+    @rank_zero_only
     def system_profile(self) -> None:
         """System Profiler Report."""
         if self.config.diagnostics.benchmark_profiler.system.enabled:
@@ -151,6 +156,7 @@ class AnemoiProfiler(AnemoiTrainer):
         return None
 
     @cached_property
+    @rank_zero_only
     def memory_profile(self) -> None:
         """Memory Profiler Report."""
         if self.config.diagnostics.benchmark_profiler.memory.enabled:
@@ -158,6 +164,7 @@ class AnemoiProfiler(AnemoiTrainer):
         return None
 
     @cached_property
+    @rank_zero_only
     def time_profile(self) -> None:
         """Time Profiler Report."""
         if self.config.diagnostics.benchmark_profiler.time.enabled:
@@ -168,8 +175,7 @@ class AnemoiProfiler(AnemoiTrainer):
     def model_summary(self) -> str:
         if self.config.diagnostics.benchmark_profiler.model_summary.enabled:
             model = self.model
-            example_input_array = self.example_input_array
-            return self.profiler.get_model_summary(model=model, example_input_array=example_input_array,  num_gpus_per_model=self.config.hardware.num_gpus_per_model)
+            return self.profiler.get_model_summary(model=model, example_input_array=self.example_input_array)
         return None
 
     @rank_zero_only
@@ -180,7 +186,6 @@ class AnemoiProfiler(AnemoiTrainer):
         elif self.config.diagnostics.log.mlflow.enabled:
             self.to_mlflow()
 
-    @rank_zero_only
     def report(self) -> str:
         """Print report to console."""
         LOGGER.info("Generating Profiler reports")
@@ -307,6 +312,15 @@ class AnemoiProfiler(AnemoiTrainer):
             ...,
             self.data_indices.data.input.full,
         ]
+        # If the input batch is sharded, replicate it to its full size
+        if self.config.dataloader.read_group_size > 1:
+            self.example_input_array = self.example_input_array.repeat(
+                1,
+                1,
+                1,
+                self.config.dataloader.read_group_size,
+                1,
+            )
         return datamodule
 
     @cached_property

--- a/training/src/anemoi/training/train/train.py
+++ b/training/src/anemoi/training/train/train.py
@@ -416,7 +416,7 @@ class AnemoiTrainer:
         )
 
         if self.config.diagnostics.print_memory_summary:
-            LOGGER.debug("memory summary: %s", torch.cuda.memory_summary())
+            LOGGER.info("memory summary: %s", torch.cuda.memory_summary())
 
         LOGGER.debug("---- DONE. ----")
 


### PR DESCRIPTION
Previously the profilers model summary didn't work if your model was sharded across multiple GPUs. By moving '@rank_zero_only' around, it works now.

One use of this is we can use the Model Summary to count the FLOPs done per model, which is useful for benchmarking. Below I use it to compare the arithmetic intensity of the transformer model at n320 vs o1280 input resolution.

![Screenshot 2025-01-24 at 09 37 06](https://github.com/user-attachments/assets/8e50a5a8-6c91-4264-aa3f-05f6824221b8)

I have also snuck in a small change to `diagnostics.print_memory_summary`. Previously it was a 'DEBUG' level log, so you likely wouldn't see it even when `diagnostics.print_memory_summary = true`. Now it is "INFO"