### PR TITLE
docs: cancel RTD builds on PRs without change

### DIFF
--- a/.github/workflows/readthedocs-pr-update.yml
+++ b/.github/workflows/readthedocs-pr-update.yml
@@ -8,6 +8,7 @@ on:
     # Execute this action only on PRs that touch
     # documentation files.
     paths:
+      - "**/.readthedocs.yaml"
       - "graphs/docs/**"
       - "models/docs/**"
       - "training/docs/**"
@@ -45,7 +46,6 @@ jobs:
           echo "training_changed=$(echo "$CHANGED_FILES" | grep -q '^training/' && echo 'true' || echo 'false')" >> $GITHUB_OUTPUT
           echo "graphs_changed=$(echo "$CHANGED_FILES" | grep -q '^graphs/' && echo 'true' || echo 'false')" >> $GITHUB_OUTPUT
           echo "models_changed=$(echo "$CHANGED_FILES" | grep -q '^models/' && echo 'true' || echo 'false')" >> $GITHUB_OUTPUT
-          # echo "integration_changed=$(echo "$CHANGED_FILES" | grep -q '^tests/' && echo 'true' || echo 'false')" >> $GITHUB_OUTPUT
 
       - name: Documentation for training package
         if: steps.changed-packages.outputs.training_changed == 'true'

--- a/graphs/.readthedocs.yaml
+++ b/graphs/.readthedocs.yaml
@@ -4,6 +4,17 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
+  jobs:
+    post_checkout:
+      # Cancel building pull requests when there aren't changed in the docs directory or YAML file.
+      #
+      # If there are no changes (git diff exits with 0) we force the command to return with 183.
+      # This is a special exit code on Read the Docs that will cancel the build immediately.
+      - |
+        if [ "$READTHEDOCS_VERSION_TYPE" = "external" ] && git diff --quiet origin/main -- graphs/docs/ graphs/.readthedocs.yaml;
+        then
+          exit 183;
+        fi
 
 sphinx:
   configuration: graphs/docs/conf.py

--- a/models/.readthedocs.yaml
+++ b/models/.readthedocs.yaml
@@ -4,6 +4,17 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
+  jobs:
+    post_checkout:
+      # Cancel building pull requests when there aren't changed in the docs directory or YAML file.
+      #
+      # If there are no changes (git diff exits with 0) we force the command to return with 183.
+      # This is a special exit code on Read the Docs that will cancel the build immediately.
+      - |
+        if [ "$READTHEDOCS_VERSION_TYPE" = "external" ] && git diff --quiet origin/main -- models/docs/ models/.readthedocs.yaml;
+        then
+          exit 183;
+        fi
 
 sphinx:
   configuration: models/docs/conf.py

--- a/training/.readthedocs.yaml
+++ b/training/.readthedocs.yaml
@@ -4,6 +4,17 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
+  jobs:
+    post_checkout:
+      # Cancel building pull requests when there aren't changed in the docs directory or YAML file.
+      #
+      # If there are no changes (git diff exits with 0) we force the command to return with 183.
+      # This is a special exit code on Read the Docs that will cancel the build immediately.
+      - |
+        if [ "$READTHEDOCS_VERSION_TYPE" = "external" ] && git diff --quiet origin/main -- training/docs/ training/.readthedocs.yaml;
+        then
+          exit 183;
+        fi
 
 sphinx:
   configuration: training/docs/conf.py


### PR DESCRIPTION
This limits the builds on RTD to avoid always building all documentations for PRs.