### PR TITLE
fix:  bug in variables ordering in NormalizedReluBounding

### DIFF
--- a/models/src/anemoi/models/layers/bounding.py
+++ b/models/src/anemoi/models/layers/bounding.py
@@ -13,7 +13,6 @@ from abc import ABC
 from abc import abstractmethod
 from typing import Optional
 
-import numpy as np
 import torch
 from torch import nn
 

--- a/models/src/anemoi/models/layers/bounding.py
+++ b/models/src/anemoi/models/layers/bounding.py
@@ -14,6 +14,7 @@ from abc import abstractmethod
 from typing import Optional
 
 import torch
+import numpy as np
 from torch import nn
 
 from anemoi.models.data_indices.tensor import InputTensorIndex
@@ -137,7 +138,7 @@ class NormalizedReluBounding(BaseBounding):
 
         # Compute normalized min values
         self.data_index = [name_to_index[var] for var in variables]
-        norm_min_val = torch.zeros(len(variables))
+        self.norm_min_val = torch.zeros(len(variables))
         for ii, variable in enumerate(variables):
             stat_index = self.name_to_index_stats[variable]
             if self.normalizer[ii] == "mean-std":
@@ -156,7 +157,7 @@ class NormalizedReluBounding(BaseBounding):
                 self.norm_min_val[ii] = min_val[ii] / std
 
         # Reorder normalized min values based on data_index
-        self.norm_min_val = norm_min_val[torch.argsort(torch.tensor(self.data_index))]
+        self.norm_min_val = self.norm_min_val[np.argsort(np.array(self.data_index))]
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Applies the ReLU activation with the normalized minimum values to the input tensor.

--- a/models/src/anemoi/models/layers/bounding.py
+++ b/models/src/anemoi/models/layers/bounding.py
@@ -13,8 +13,8 @@ from abc import ABC
 from abc import abstractmethod
 from typing import Optional
 
-import torch
 import numpy as np
+import torch
 from torch import nn
 
 from anemoi.models.data_indices.tensor import InputTensorIndex

--- a/models/src/anemoi/models/layers/bounding.py
+++ b/models/src/anemoi/models/layers/bounding.py
@@ -135,7 +135,9 @@ class NormalizedReluBounding(BaseBounding):
                 "The length of the min_val list must match the number of variables in NormalizedReluBounding."
             )
 
-        self.norm_min_val = torch.zeros(len(variables))
+        # Compute normalized min values
+        self.data_index = [name_to_index[var] for var in variables]
+        norm_min_val = torch.zeros(len(variables))
         for ii, variable in enumerate(variables):
             stat_index = self.name_to_index_stats[variable]
             if self.normalizer[ii] == "mean-std":
@@ -152,6 +154,9 @@ class NormalizedReluBounding(BaseBounding):
             elif self.normalizer[ii] == "std":
                 std = self.statistics["stdev"][stat_index]
                 self.norm_min_val[ii] = min_val[ii] / std
+
+        # Reorder normalized min values based on data_index
+        self.norm_min_val = norm_min_val[torch.argsort(torch.tensor(self.data_index))]
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Applies the ReLU activation with the normalized minimum values to the input tensor.

--- a/models/src/anemoi/models/layers/bounding.py
+++ b/models/src/anemoi/models/layers/bounding.py
@@ -156,9 +156,6 @@ class NormalizedReluBounding(BaseBounding):
                 std = self.statistics["stdev"][stat_index]
                 self.norm_min_val[ii] = min_val[ii] / std
 
-        # Reorder normalized min values based on data_index
-        self.norm_min_val = self.norm_min_val[np.argsort(np.array(self.data_index))]
-
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Applies the ReLU activation with the normalized minimum values to the input tensor.
 

--- a/models/tests/layers/test_bounding.py
+++ b/models/tests/layers/test_bounding.py
@@ -67,7 +67,6 @@ def test_normalized_relu_bounding(config, name_to_index, name_to_index_stats, in
         name_to_index_stats=name_to_index_stats,
     )
     output = bounding(input_tensor.clone())
-    # breakpoint()
     expected_output = torch.tensor([[2.0, 2.0, 3.0], [4.0, 0.1111, 6.0], [2.0, 0.5, 0.5]])
     assert torch.allclose(output, expected_output, atol=1e-4)
 


### PR DESCRIPTION
A bug affects `anemoi.models.layers.bounding.NormalizedReluBounding` if the order of the variable douring the call in config does not match the order of the variables in the torch array. This a problem emerged only when multiple variables were bounded at the same time with this procedure.

This is fixed by making sure that `self.norm_min_val` follows the same order as `self.data_index`.