### PR TITLE
ci: Propose release-please implementation

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,30 @@
+# This workflow will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+name: Upload Python Packages to PyPI
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy-training:
+    if: contains(github.ref, 'training')
+    uses: ecmwf-actions/reusable-workflows/.github/workflows/cd-pypi.yml@v2
+    with:
+      working-directory: ./training
+    secrets: inherit
+
+  deploy-models:
+    if: contains(github.ref, 'models')
+    uses: ecmwf-actions/reusable-workflows/.github/workflows/cd-pypi.yml@v2
+    with:
+      working-directory: ./models
+    secrets: inherit
+
+  deploy-graphs:
+    if: contains(github.ref, 'graphs')
+    uses: ecmwf-actions/reusable-workflows/.github/workflows/cd-pypi.yml@v2
+    with:
+      working-directory: ./graphs
+    secrets: inherit

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,28 @@
+# This workflow uses an action to run Release Please to create a release PR.
+# It is governed by the config and manifest in the root of the repo.
+# For more information see: https://github.com/googleapis/release-please
+name: Run Release Please
+on:
+  push:
+    branches:
+      - main
+      - hotfix/*
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          # this assumes that you have created a personal access token
+          # (PAT) and configured it as a GitHub action secret named
+          # `MY_RELEASE_PLEASE_TOKEN` (this secret name is not important).
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          # optional. customize path to .release-please-config.json
+          config-file: .release-please-config.json
+          # Currently releases are done from main
+          target-branch: ${{ github.ref_name }}

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -7,7 +7,7 @@
   "changelog-type": "github",
   "include-component-in-tag": true,
   "include-v-in-tag": false,
-  "draft": true,
+  "draft-pull-request": true,
   "pull-request-title-pattern": "chore${scope}: Preparing Next Release for ${component} ${version}",
   "pull-request-header": ":robot: Automated Release PR\n\nThis PR was created by `release-please` to prepare the next release. Once merged:\n\n1. A new version tag will be created\n2. A GitHub release will be published\n3. The changelog will be updated\n\nChanges to be included in the next release:",
   "pull-request-footer": "> [!IMPORTANT]\n> :warning: Merging this PR will:\n> - Create a new release\n> - Trigger deployment pipelines\n> - Update package versions\n\n **Before merging:**\n - Ensure all tests pass\n - Review the changelog carefully\n - Get required approvals\n\n [Release-please documentation](https://github.com/googleapis/release-please)",

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -1,0 +1,26 @@
+{
+  "release-type": "python",
+  "bump-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": true,
+  "separate-pull-requests": true,
+  "always-update": true,
+  "changelog-type": "github",
+  "include-component-in-tag": true,
+  "include-v-in-tag": false,
+  "draft": true,
+  "pull-request-title-pattern": "chore${scope}: Preparing Next Release for ${component} ${version}",
+  "pull-request-header": ":robot: Automated Release PR\n\nThis PR was created by `release-please` to prepare the next release. Once merged:\n\n1. A new version tag will be created\n2. A GitHub release will be published\n3. The changelog will be updated\n\nChanges to be included in the next release:",
+  "pull-request-footer": "> [!IMPORTANT]\n> :warning: Merging this PR will:\n> - Create a new release\n> - Trigger deployment pipelines\n> - Update package versions\n\n **Before merging:**\n - Ensure all tests pass\n - Review the changelog carefully\n - Get required approvals\n\n [Release-please documentation](https://github.com/googleapis/release-please)",
+  "packages": {
+    "training/": {
+        "package-name": "anemoi-training"
+    },
+    "graphs/": {
+        "package-name": "anemoi-graphs"
+    },
+    "models/": {
+        "package-name": "anemoi-models"
+    }
+  },
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"
+}

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,5 @@
+{
+    "training": "",
+    "graphs": "",
+    "models": ""
+}

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-    "training": "",
-    "graphs": "",
-    "models": ""
+    "training": "0.3.2",
+    "graphs": "0.4.2",
+    "models": "0.4.1"
 }


### PR DESCRIPTION
This is a first proposal for a release please implementation and Python publish workflow that works with mono-repos