### PR TITLE
fix: Combined Loss

### DIFF
--- a/training/docs/modules/losses.rst
+++ b/training/docs/modules/losses.rst
@@ -140,10 +140,10 @@ losses above.
 .. code:: yaml
 
    training_loss:
-      __target__: anemoi.training.losses.combined.CombinedLoss
+      _target_: anemoi.training.losses.combined.CombinedLoss
       losses:
-         - __target__: anemoi.training.losses.mse.WeightedMSELoss
-         - __target__: anemoi.training.losses.mae.WeightedMAELoss
+         - _target_: anemoi.training.losses.mse.WeightedMSELoss
+         - _target_: anemoi.training.losses.mae.WeightedMAELoss
       scalars: ['variable']
       loss_weights: [1.0,0.5]
 

--- a/training/src/anemoi/training/losses/combined.py
+++ b/training/src/anemoi/training/losses/combined.py
@@ -75,8 +75,20 @@ class CombinedLoss(BaseWeightedLoss):
             losses:
                 - _target_: anemoi.training.losses.mse.WeightedMSELoss
                 - _target_: anemoi.training.losses.mae.WeightedMAELoss
-            scalars: ['variable']
-            loss_weights: [1.0,0.5]
+            scalars: ['*']
+            loss_weights: [1.0, 0.6]
+        ```
+
+        ```
+        training_loss:
+            _target_: anemoi.training.losses.combined.CombinedLoss
+            losses:
+                - _target_: anemoi.training.losses.mse.WeightedMSELoss
+                  scalars: ['ocean']
+                - _target_: anemoi.training.losses.mae.WeightedMAELoss
+                  scalars: ['atmosphere']
+            scalars: ['*']
+            loss_weights: [1.0, 1.0]
         ```
         """
         self.losses: list[BaseWeightedLoss] = []

--- a/training/src/anemoi/training/losses/combined.py
+++ b/training/src/anemoi/training/losses/combined.py
@@ -52,7 +52,7 @@ class CombinedLoss(torch.nn.Module):
         Examples
         --------
         >>> CombinedLoss(
-                {"__target__": "anemoi.training.losses.mse.WeightedMSELoss"},
+                {"_target_": "anemoi.training.losses.mse.WeightedMSELoss"},
                 loss_weights=(1.0,),
                 node_weights=node_weights
             )
@@ -66,10 +66,10 @@ class CombinedLoss(torch.nn.Module):
 
         ```
         training_loss:
-            __target__: anemoi.training.losses.combined.CombinedLoss
+            _target_: anemoi.training.losses.combined.CombinedLoss
             losses:
-                - __target__: anemoi.training.losses.mse.WeightedMSELoss
-                - __target__: anemoi.training.losses.mae.WeightedMAELoss
+                - _target_: anemoi.training.losses.mse.WeightedMSELoss
+                - _target_: anemoi.training.losses.mae.WeightedMAELoss
             scalars: ['variable']
             loss_weights: [1.0,0.5]
         ```

--- a/training/src/anemoi/training/train/forecaster.py
+++ b/training/src/anemoi/training/train/forecaster.py
@@ -224,10 +224,11 @@ class GraphForecaster(pl.LightningModule):
         scalars_to_include = loss_config.pop("scalars", [])
 
         # Instantiate the loss function with the loss_init_config
+        kwargs["_recursive_"] = kwargs.get("_recursive_", False)
         loss_function = instantiate(loss_config, **kwargs)
 
         if not isinstance(loss_function, BaseWeightedLoss):
-            error_msg = f"Loss must be a subclass of 'BaseWeightedLoss', not {type(loss_function)}"
+            error_msg = f"Loss must be a subclass of `BaseWeightedLoss`, not {type(loss_function)}"
             raise TypeError(error_msg)
 
         for key in scalars_to_include:


### PR DESCRIPTION
# Fix Combined Loss
The combined loss was never working (whoops)

This fixes it such that CombinedLoss looks like any other loss, with no interface changes to the forecaster.
Will allow for multiple loss functions to be used together
- Weighted on a single prediction
- Attending to only parts of a prediction

```yaml
        training_loss:
            _target_: anemoi.training.losses.combined.CombinedLoss
            losses:
                - _target_: anemoi.training.losses.mse.WeightedMSELoss
                  scalars: ['ocean']
                - _target_: anemoi.training.losses.mae.WeightedMAELoss
                  scalars: ['atmosphere']
            scalars: ['*']
            loss_weights: [1.0, 1.0]
```