### PR TITLE
fix(graphs): load weights works for torch v2.6 and beyond

### DIFF
--- a/graphs/src/anemoi/graphs/describe.py
+++ b/graphs/src/anemoi/graphs/describe.py
@@ -24,7 +24,7 @@ class GraphDescriptor:
 
     def __init__(self, path: Union[str, Path], **kwargs):
         self.path = path
-        self.graph = torch.load(self.path)
+        self.graph = torch.load(self.path, weights_only=False)
 
     @property
     def total_size(self):

--- a/graphs/src/anemoi/graphs/inspect.py
+++ b/graphs/src/anemoi/graphs/inspect.py
@@ -49,7 +49,7 @@ class GraphInspector:
         **kwargs,
     ):
         self.path = path
-        self.graph = torch.load(self.path)
+        self.graph = torch.load(self.path, weights_only=False)
         self.output_path = output_path
         self.show_attribute_distributions = show_attribute_distributions
         self.show_nodes = show_nodes


### PR DESCRIPTION
## Description

torch 2.6 changed the default behavior for torch.load from `weights_only=False` to `weights_only=True`. As a result `anemoi-graphs describe` and `anemoi-graphs inspect` doesnt work in torch v2.6 and beyond.

the following small change fixes this.
```python
-  torch.load()
+ torch.load(weights_only=False)
```

## Type of Change

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update

## Code Compatibility

-   [X] I have performed a self-review of my code

