### PR TITLE
Models fix/74 imputer inference mode

### DIFF
--- a/models/src/anemoi/models/preprocessing/imputer.py
+++ b/models/src/anemoi/models/preprocessing/imputer.py
@@ -124,7 +124,11 @@ class BaseImputer(BasePreprocessor, ABC):
         if not in_place:
             x = x.clone()
 
-        # Initialize nan mask once
+        # Reset NaN locations outside of training for validation and inference.
+        if not self.training:
+            self.nan_locations = None
+
+        # Initialise mask if not cached.
         if self.nan_locations is None:
 
             # Get NaN locations

--- a/models/tests/preprocessing/test_preprocessor_imputer.py
+++ b/models/tests/preprocessing/test_preprocessor_imputer.py
@@ -130,14 +130,17 @@ def default_constant_data():
     return base, expected
 
 
+fixture_combinations = (
+    ("default_constant_imputer", "default_constant_data"),
+    ("non_default_constant_imputer", "non_default_constant_data"),
+    ("default_input_imputer", "default_input_data"),
+    ("non_default_input_imputer", "non_default_input_data"),
+)
+
+
 @pytest.mark.parametrize(
     ("imputer_fixture", "data_fixture"),
-    [
-        ("default_constant_imputer", "default_constant_data"),
-        ("non_default_constant_imputer", "non_default_constant_data"),
-        ("default_input_imputer", "default_input_data"),
-        ("non_default_input_imputer", "non_default_input_data"),
-    ],
+    fixture_combinations,
 )
 def test_imputer_not_inplace(imputer_fixture, data_fixture, request) -> None:
     """Check that the imputer does not modify the input tensor when in_place=False."""
@@ -150,12 +153,7 @@ def test_imputer_not_inplace(imputer_fixture, data_fixture, request) -> None:
 
 @pytest.mark.parametrize(
     ("imputer_fixture", "data_fixture"),
-    [
-        ("default_constant_imputer", "default_constant_data"),
-        ("non_default_constant_imputer", "non_default_constant_data"),
-        ("default_input_imputer", "default_input_data"),
-        ("non_default_input_imputer", "non_default_input_data"),
-    ],
+    fixture_combinations,
 )
 def test_imputer_inplace(imputer_fixture, data_fixture, request) -> None:
     """Check that the imputer modifies the input tensor when in_place=True."""
@@ -169,12 +167,7 @@ def test_imputer_inplace(imputer_fixture, data_fixture, request) -> None:
 
 @pytest.mark.parametrize(
     ("imputer_fixture", "data_fixture"),
-    [
-        ("default_constant_imputer", "default_constant_data"),
-        ("non_default_constant_imputer", "non_default_constant_data"),
-        ("default_input_imputer", "default_input_data"),
-        ("non_default_input_imputer", "non_default_input_data"),
-    ],
+    fixture_combinations,
 )
 def test_transform_with_nan(imputer_fixture, data_fixture, request):
     """Check that the imputer correctly transforms a tensor with NaNs."""
@@ -186,12 +179,7 @@ def test_transform_with_nan(imputer_fixture, data_fixture, request):
 
 @pytest.mark.parametrize(
     ("imputer_fixture", "data_fixture"),
-    [
-        ("default_constant_imputer", "default_constant_data"),
-        ("non_default_constant_imputer", "non_default_constant_data"),
-        ("default_input_imputer", "default_input_data"),
-        ("non_default_input_imputer", "non_default_input_data"),
-    ],
+    fixture_combinations,
 )
 def test_transform_with_nan_small(imputer_fixture, data_fixture, request):
     """Check that the imputer correctly transforms a tensor with NaNs."""
@@ -211,12 +199,7 @@ def test_transform_with_nan_small(imputer_fixture, data_fixture, request):
 
 @pytest.mark.parametrize(
     ("imputer_fixture", "data_fixture"),
-    [
-        ("default_constant_imputer", "default_constant_data"),
-        ("non_default_constant_imputer", "non_default_constant_data"),
-        ("default_input_imputer", "default_input_data"),
-        ("non_default_input_imputer", "non_default_input_data"),
-    ],
+    fixture_combinations,
 )
 def test_transform_with_nan_inference(imputer_fixture, data_fixture, request):
     """Check that the imputer correctly transforms a tensor with NaNs in inference."""
@@ -244,12 +227,7 @@ def test_transform_with_nan_inference(imputer_fixture, data_fixture, request):
 
 @pytest.mark.parametrize(
     ("imputer_fixture", "data_fixture"),
-    [
-        ("default_constant_imputer", "default_constant_data"),
-        ("non_default_constant_imputer", "non_default_constant_data"),
-        ("default_input_imputer", "default_input_data"),
-        ("non_default_input_imputer", "non_default_input_data"),
-    ],
+    fixture_combinations,
 )
 def test_transform_noop(imputer_fixture, data_fixture, request):
     """Check that the imputer does not modify a tensor without NaNs."""
@@ -262,12 +240,7 @@ def test_transform_noop(imputer_fixture, data_fixture, request):
 
 @pytest.mark.parametrize(
     ("imputer_fixture", "data_fixture"),
-    [
-        ("default_constant_imputer", "default_constant_data"),
-        ("non_default_constant_imputer", "non_default_constant_data"),
-        ("default_input_imputer", "default_input_data"),
-        ("non_default_input_imputer", "non_default_input_data"),
-    ],
+    fixture_combinations,
 )
 def test_inverse_transform(imputer_fixture, data_fixture, request):
     """Check that the imputer correctly inverts the transformation."""
@@ -281,12 +254,7 @@ def test_inverse_transform(imputer_fixture, data_fixture, request):
 
 @pytest.mark.parametrize(
     ("imputer_fixture", "data_fixture"),
-    [
-        ("default_constant_imputer", "default_constant_data"),
-        ("non_default_constant_imputer", "non_default_constant_data"),
-        ("default_input_imputer", "default_input_data"),
-        ("non_default_input_imputer", "non_default_input_data"),
-    ],
+    fixture_combinations,
 )
 def test_mask_saving(imputer_fixture, data_fixture, request):
     """Check that the imputer saves the NaN mask correctly."""
@@ -299,12 +267,7 @@ def test_mask_saving(imputer_fixture, data_fixture, request):
 
 @pytest.mark.parametrize(
     ("imputer_fixture", "data_fixture"),
-    [
-        ("default_constant_imputer", "default_constant_data"),
-        ("non_default_constant_imputer", "non_default_constant_data"),
-        ("default_input_imputer", "default_input_data"),
-        ("non_default_input_imputer", "non_default_input_data"),
-    ],
+    fixture_combinations,
 )
 def test_loss_nan_mask(imputer_fixture, data_fixture, request):
     """Check that the imputer correctly transforms a tensor with NaNs."""
@@ -336,3 +299,45 @@ def test_reuse_imputer(imputer_fixture, data_fixture, request):
     assert torch.allclose(
         transformed2, expected, equal_nan=True
     ), "Imputer does not reuse mask correctly on subsequent runs."
+
+
+@pytest.mark.parametrize(
+    ("imputer_fixture", "data_fixture"),
+    fixture_combinations,
+)
+def test_inference_imputer(imputer_fixture, data_fixture, request):
+    """Check that the imputer resets its mask during inference."""
+    x, expected = request.getfixturevalue(data_fixture)
+    imputer = request.getfixturevalue(imputer_fixture)
+
+    # Check training flag
+    assert imputer.training, "Imputer is not set to training mode."
+
+    expected_mask = torch.isnan(x)
+    transformed = imputer.transform(x, in_place=False)
+    assert torch.allclose(transformed, expected, equal_nan=True), "Transform does not handle NaNs correctly."
+    restored = imputer.inverse_transform(transformed, in_place=False)
+    assert torch.allclose(restored, x, equal_nan=True), "Inverse transform does not restore NaNs correctly."
+    assert torch.equal(imputer.nan_locations, expected_mask), "Mask not saved correctly after first run."
+
+    imputer.eval()
+    with torch.no_grad():
+        x2 = x.roll(-1, dims=0)
+        expected2 = expected.roll(-1, dims=0)
+        expected_mask2 = torch.isnan(x2)
+
+        assert torch.equal(imputer.nan_locations, expected_mask), "Mask not saved correctly after first run."
+
+        # Check training flag
+        assert not imputer.training, "Imputer is not set to evaluation mode."
+
+        assert not torch.allclose(x, x2, equal_nan=True), "Failed to modify the input data."
+        assert not torch.allclose(expected, expected2, equal_nan=True), "Failed to modify the expected data."
+        assert not torch.allclose(expected_mask, expected_mask2, equal_nan=True), "Failed to modify the nan mask."
+
+        transformed = imputer.transform(x2, in_place=False)
+        assert torch.allclose(transformed, expected2, equal_nan=True), "Transform does not handle NaNs correctly."
+        restored = imputer.inverse_transform(transformed, in_place=False)
+        assert torch.allclose(restored, x2, equal_nan=True), "Inverse transform does not restore NaNs correctly."
+
+        assert torch.equal(imputer.nan_locations, expected_mask2), "Mask not saved correctly after evaluation run."


### PR DESCRIPTION
## Description

PR from @JesperDramsch from anemoi-model: https://github.com/ecmwf/anemoi-models/pull/75

This resets the `nan_locations` in the `BaseImputer` during non-training runs of the code.

Specifically, this enables changes in the dataset after training.


## Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update

## Issue Number

Closes https://github.com/ecmwf/anemoi-core/issues/34

## Code Compatibility

-   [x] I have performed a self-review of my code

### Code Performance and Testing

-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I ran the [complete Pytest test](https://anemoi.readthedocs.io/projects/training/en/latest/dev/testing.html) suite locally, and they pass
-   [x] I have tested the changes on a single GPU
-   [ ] I have tested the changes on multiple GPUs / multi-node setups
-   [ ] I have run the [Benchmark Profiler](https://anemoi.readthedocs.io/projects/training/en/latest/user-guide/benchmarking.html) against the old version of the code

### Dependencies

-   [x] I have ensured that the code is still pip-installable after the changes and runs
-   [ ] I have tested that new dependencies themselves are pip-installable.
-   [x] I have not introduced new dependencies in the inference portion of the pipeline

### Documentation

-   [x] My code follows the style guidelines of this project
-   [x] I have updated the documentation and docstrings to reflect the changes
-   [x] I have added comments to my code, particularly in hard-to-understand areas

## Additional Notes

None
