### PR TITLE
ci: update develop to main in push_to_private action

### DIFF
--- a/.github/workflows/push-to-private.yml
+++ b/.github/workflows/push-to-private.yml
@@ -3,7 +3,7 @@ name: Push to private repository
 on:
   push:
     branches:
-      - develop
+      - main
 
 jobs:
   push_changes:
@@ -30,4 +30,4 @@ jobs:
     - name: Push changes to private repository
       run: |
         git remote add private git@github.com:${{ github.repository }}-private.git
-        git push --set-upstream private develop
+        git push --set-upstream private main


### PR DESCRIPTION
## Description

Ci fix: update the push_to_private github action to activate on pushes to main (instead of develop)

## Type of Change

Due to the switch from develop to main, this github action needs to be updated.