### PR TITLE
docs: fix documentation to refer to anemoi datasets instead of zarr datasets

### DIFF
--- a/graphs/docs/graphs/node_attributes/boolean_operations.rst
+++ b/graphs/docs/graphs/node_attributes/boolean_operations.rst
@@ -6,7 +6,7 @@
 of boolean opearations to support these operations when defining node
 attributes. Below, an attribute `mask` is computed as the intersection
 of two other masks, that are generated as the non-missing values in 2
-different variables in a Zarr dataset.
+different variables in a anemoi dataset.
 
 .. literalinclude:: ../yaml/attributes_boolean_operation.yaml
    :language: yaml

--- a/graphs/docs/graphs/node_attributes/zarr_attribute.rst
+++ b/graphs/docs/graphs/node_attributes/zarr_attribute.rst
@@ -1,6 +1,6 @@
-###################
- From Zarr dataset
-###################
+#####################
+ From anemoi dataset
+#####################
 
 Zarr datasets are the standard format to define data nodes in
 :ref:`anemoi-graphs <anemoi-graphs:index-page>`. The user can define

--- a/graphs/docs/graphs/node_coordinates/zarr_dataset.rst
+++ b/graphs/docs/graphs/node_coordinates/zarr_dataset.rst
@@ -1,15 +1,15 @@
 .. _zarr-file:
 
-###################
- From Zarr dataset
-###################
+#####################
+ From anemoi dataset
+#####################
 
-This class builds a set of nodes from a Zarr dataset. The nodes are
+This class builds a set of nodes from a anemoi dataset. The nodes are
 defined by the coordinates of the dataset. The ZarrDataset class
 supports operations compatible with :ref:`anemoi-datasets
 <anemoi-datasets:index-page>`.
 
-To define the `node coordinates` based on a Zarr dataset, you can use
+To define the `node coordinates` based on a anemoi dataset, you can use
 the following YAML configuration:
 
 .. code:: yaml
@@ -21,13 +21,13 @@ the following YAML configuration:
          dataset: /path/to/dataset.zarr
        attributes: ...
 
-where `dataset` is the path to the Zarr dataset.
+where `dataset` is the path to the anemoi dataset.
 
 The ``ZarrDatasetNodes`` class supports operations over multiple
 datasets. For example, the `cutout` operation supports combining a
 regional dataset and a global dataset to enable both limited area and
 stretched grids. To define the `node coordinates` that combine multiple
-Zarr datasets, you can use the following YAML configuration:
+anemoi datasets, you can use the following YAML configuration:
 
 .. code:: yaml
 

--- a/graphs/docs/index.rst
+++ b/graphs/docs/index.rst
@@ -41,8 +41,8 @@ recipe file, which can be used to build graphs for the input, hidden and
 output layers. For each layer, the package allows you to:
 
 -  :ref:`Define graph nodes <graphs-node_coordinates>` based on
-   coordinates defined in a dataset (Zarr and NPZ) or via algorithmic
-   approaches such as the triangular refined icosahedron.
+   coordinates defined in a dataset (anemoi dataset and NPZ) or via
+   algorithmic approaches such as the triangular refined icosahedron.
 
 -  :ref:`Define edges <graphs-edges>` (connections between nodes) based
    on methods such as the cut-off radius or K nearest-neighbours.

--- a/graphs/docs/overview.rst
+++ b/graphs/docs/overview.rst
@@ -34,7 +34,7 @@ categories:
 data nodes
    A set of nodes representing one or multiple datasets. The `data
    nodes` may correspond to the input/output of our data-driven model.
-   They can be defined from Zarr datasets and this method supports all
+   They can be defined from anemoi datasets and this method supports all
    :ref:`anemoi-datasets <anemoi-datasets:index-page>` operations such
    as `cutout` or `thinning`.
 
@@ -42,7 +42,7 @@ hidden nodes
    The `hidden nodes` capture intermediate representations of the model,
    which are used to learn the dynamics of the system considered
    (atmosphere, ocean, etc, ...). These nodes can be generated from
-   existing locations (Zarr datasets or NPZ files) or algorithmically
+   existing locations (Anemoi datasets or NPZ files) or algorithmically
    from iterative refinements of polygons over the globe.
 
 Another important term that can refer to both data and hidden nodes is

--- a/graphs/src/anemoi/graphs/nodes/attributes.py
+++ b/graphs/src/anemoi/graphs/nodes/attributes.py
@@ -229,14 +229,14 @@ class BooleanBaseNodeAttribute(BaseNodeAttribute, ABC):
 
 
 class NonmissingZarrVariable(BooleanBaseNodeAttribute):
-    """Mask of valid (not missing) values of a Zarr dataset variable.
+    """Mask of valid (not missing) values of a Anemoi dataset variable.
 
-    It reads a variable from a Zarr dataset and returns a boolean mask of nonmissing values in the first timestep.
+    It reads a variable from a Anemoi dataset and returns a boolean mask of nonmissing values in the first timestep.
 
     Attributes
     ----------
     variable : str
-        Variable to read from the Zarr dataset.
+        Variable to read from the Anemoi dataset.
 
     Methods
     -------

--- a/graphs/src/anemoi/graphs/nodes/builders/from_file.py
+++ b/graphs/src/anemoi/graphs/nodes/builders/from_file.py
@@ -26,7 +26,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 class ZarrDatasetNodes(BaseNodeBuilder):
-    """Nodes from Zarr dataset.
+    """Nodes from an anemoi dataset.
 
     Attributes
     ----------

--- a/models/docs/modules/data_indices.rst
+++ b/models/docs/modules/data_indices.rst
@@ -59,7 +59,7 @@ remapper-preprocessor.
 
 There are two main Index-levels:
 
--  Data: The data at "Zarr"-level provided by Anemoi-Datasets
+-  Data: The data at "anemoi-datasets"-level provided by Anemoi-Datasets
 -  Model: The "squeezed" tensors with irrelevant parts missing.
 
 Additionally, there are two internal model levels (After preprocessor

--- a/training/src/anemoi/training/data/dataset.py
+++ b/training/src/anemoi/training/data/dataset.py
@@ -51,7 +51,7 @@ class NativeGridDataset(IterableDataset):
         Parameters
         ----------
         data_reader : Callable
-            user function that opens and returns the zarr array data
+            user function that opens and returns the anemoi-datasets array data
         grid_indices : Type[BaseGridIndices]
             indices of the grid to keep. Defaults to None, which keeps all spatial indices.
         rollout : int, optional
@@ -246,7 +246,7 @@ class NativeGridDataset(IterableDataset):
     def __iter__(self) -> torch.Tensor:
         """Return an iterator over the dataset.
 
-        The datasets are retrieved by Anemoi Datasets from zarr files. This iterator yields
+        The datasets are retrieved by anemoi.datasets from anemoi datasets. This iterator yields
         chunked batches for DDP and sharded training.
 
         Currently it receives data with an ensemble dimension, which is discarded for

--- a/training/src/anemoi/training/schemas/graphs/node_attributes_schemas.py
+++ b/training/src/anemoi/training/schemas/graphs/node_attributes_schemas.py
@@ -47,9 +47,12 @@ class CutOutMaskSchema(BaseModel):
 
 class NonmissingZarrVariableSchema(BaseModel):
     target_: Literal["anemoi.graphs.nodes.attributes.NonmissingZarrVariable"] = Field(..., alias="_target_")
-    "Implementation of a mask from the nonmissing values of a Zarr variable from anemoi.graphs.nodes.attributes."
+    (
+        "Implementation of a mask from the nonmissing values of a anemoi-datasets variable "
+        "from anemoi.graphs.nodes.attributes."
+    )
     variable: str
-    "The Zarr variable to use."
+    "The anemoi-datasets variable to use."
 
 
 class BooleanOperationSchema(BaseModel):

--- a/training/src/anemoi/training/schemas/graphs/node_schemas.py
+++ b/training/src/anemoi/training/schemas/graphs/node_schemas.py
@@ -27,7 +27,7 @@ LOGGER = logging.getLogger(__name__)
 
 class ZarrNodeSchema(BaseModel):
     target_: Literal["anemoi.graphs.nodes.ZarrDatasetNodes"] = Field(..., alias="_target_")
-    "Nodes from Zarr dataset class implementation from anemoi.graphs.nodes."
+    "Nodes from Anemoi dataset class implementation from anemoi.graphs.nodes."
     dataset: Union[str, dict]  # TODO(Helen): Discuss schema with Baudouin
     "The dataset containing the nodes."
 


### PR DESCRIPTION
## Description

Refering to Zarr outside of the anemoi-datasets package breaks the encapsulation principle.

## Type of Change

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] Documentation update

## Issue Number

<!-- Link the Issue number this change addresses, ideally in one of the "magic format" such as Closes #XYZ -->

<!-- Alternatively, explain the motivation behind the changes and the context in which they are being made. -->

## Code Compatibility

-   [ ] I have performed a self-review of my code

### Code Performance and Testing

-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I ran the [complete Pytest test](https://anemoi.readthedocs.io/projects/training/en/latest/dev/testing.html) suite locally, and they pass
-   [ ] I have tested the changes on a single GPU
-   [ ] I have tested the changes on multiple GPUs / multi-node setups
-   [ ] I have run the Benchmark Profiler against the old version of the code
-   [ ] If the new feature introduces modifications at the config level, I have made sure to update Pydantic Schemas and default configs accordingly


<!-- In case this affects the model sharding or other specific components please describe these here. -->

### Dependencies

-   [ ] I have ensured that the code is still pip-installable after the changes and runs
-   [ ] I have tested that new dependencies themselves are pip-installable.
-   [ ] I have not introduced new dependencies in the inference portion of the pipeline

<!-- List any new dependencies that are required for this change and the justification to add them. -->

### Documentation

-   [ ] My code follows the style guidelines of this project
-   [ ] I have updated the documentation and docstrings to reflect the changes
-   [ ] I have added comments to my code, particularly in hard-to-understand areas

<!-- Describe any major updates to the documentation -->

## Additional Notes

<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->


<!-- readthedocs-preview anemoi-training start -->
----
📚 Documentation preview 📚: https://anemoi-training--154.org.readthedocs.build/en/154/

<!-- readthedocs-preview anemoi-training end -->

<!-- readthedocs-preview anemoi-graphs start -->
----
📚 Documentation preview 📚: https://anemoi-graphs--154.org.readthedocs.build/en/154/

<!-- readthedocs-preview anemoi-graphs end -->

<!-- readthedocs-preview anemoi-models start -->
----
📚 Documentation preview 📚: https://anemoi-models--154.org.readthedocs.build/en/154/

<!-- readthedocs-preview anemoi-models end -->