### PR TITLE
fix(training,schema): error when using ReweightedGraphNodeAttribute

### DIFF
--- a/training/src/anemoi/training/config/graph/stretched_grid.yaml
+++ b/training/src/anemoi/training/config/graph/stretched_grid.yaml
@@ -57,7 +57,7 @@ attributes:
       _target_: anemoi.graphs.nodes.attributes.SphericalAreaWeights
       norm: unit-max
       fill_value: 0
-    cutout:
+    cutout_mask:
       _target_: anemoi.graphs.nodes.attributes.CutOutMask
   edges:
     edge_length:

--- a/training/src/anemoi/training/config/stretched.yaml
+++ b/training/src/anemoi/training/config/stretched.yaml
@@ -26,12 +26,11 @@ dataloader:
     adjust: all
     min_distance_km: 0
 training:
-  loss_scaling:
-    spatial:
-      _target_: anemoi.training.data.scaling.ReweightedGraphAttribute
-      target_nodes: ${graph.data}
-      scaled_attribute: area_weight # it must be a node attribute of the output nodes
-      cutout_weight_frac_of_global: ???
+  node_loss_weights:
+    _target_: anemoi.training.data.scaling.ReweightedGraphAttribute
+    target_nodes: ${graph.data}
+    scaled_attribute: area_weight # it must be a node attribute of the output nodes
+    cutout_weight_frac_of_global: ???
 hardware:
   files:
     dataset: ???

--- a/training/src/anemoi/training/config/stretched.yaml
+++ b/training/src/anemoi/training/config/stretched.yaml
@@ -27,10 +27,11 @@ dataloader:
     min_distance_km: 0
 training:
   node_loss_weights:
-    _target_: anemoi.training.data.scaling.ReweightedGraphAttribute
+    _target_: anemoi.training.losses.nodeweights.ReweightedGraphNodeAttribute
     target_nodes: ${graph.data}
-    scaled_attribute: area_weight # it must be a node attribute of the output nodes
-    cutout_weight_frac_of_global: ???
+    node_attribute: area_weight
+    scaled_attribute: cutout_mask
+    weight_frac_of_global: ???
 hardware:
   files:
     dataset: ???

--- a/training/src/anemoi/training/schemas/training.py
+++ b/training/src/anemoi/training/schemas/training.py
@@ -190,7 +190,7 @@ class ReweightedGraphNodeAttributeSchema(BaseModel):
     "name of node weight attribute, key in the nodes object."
     scaled_attribute: str = Field(examples=["cutout_mask"])
     "name of node attribute defining the subset of nodes to be scaled, key in the nodes object."
-    weight_frac_of_total: float = Field(examples=[0.3])
+    weight_frac_of_total: float = Field(examples=[0.3], ge=0, le=1)
     "sum of weight of subset nodes as a fraction of sum of weight of all nodes after rescaling"
 
 

--- a/training/src/anemoi/training/schemas/training.py
+++ b/training/src/anemoi/training/schemas/training.py
@@ -173,7 +173,7 @@ LossSchemas = Union[BaseLossSchema, HuberLossSchema, WeightedMSELossLimitedAreaS
 
 
 class GraphNodeAttributeSchema(BaseModel):
-    target_: "anemoi.training.losses.nodeweights.GraphNodeAttribute" = Field(..., alias="_target_")
+    target_: Literal["anemoi.training.losses.nodeweights.GraphNodeAttribute"] = Field(..., alias="_target_")
     "Node loss weights object from anemoi.training.losses."
     target_nodes: str = Field(examples=["data"])
     "name of target nodes, key in HeteroData graph object."
@@ -182,7 +182,7 @@ class GraphNodeAttributeSchema(BaseModel):
 
 
 class ReweightedGraphNodeAttributeSchema(BaseModel):
-    target_: "anemoi.training.losses.nodeweights.ReweightedGraphNodeAttribute" = Field(..., alias="_target_")
+    target_: Literal["anemoi.training.losses.nodeweights.ReweightedGraphNodeAttribute"] = Field(..., alias="_target_")
     "Node loss weights object from anemoi.training.losses."
     target_nodes: str = Field(examples=["data"])
     "name of target nodes, key in HeteroData graph object."

--- a/training/src/anemoi/training/schemas/training.py
+++ b/training/src/anemoi/training/schemas/training.py
@@ -173,7 +173,7 @@ LossSchemas = Union[BaseLossSchema, HuberLossSchema, WeightedMSELossLimitedAreaS
 
 
 class GraphNodeAttributeSchema(BaseModel):
-    target_: anemoi.training.losses.nodeweights.GraphNodeAttribute = Field(..., alias="_target_")
+    target_: "anemoi.training.losses.nodeweights.GraphNodeAttribute" = Field(..., alias="_target_")
     "Node loss weights object from anemoi.training.losses."
     target_nodes: str = Field(examples=["data"])
     "name of target nodes, key in HeteroData graph object."
@@ -182,7 +182,7 @@ class GraphNodeAttributeSchema(BaseModel):
 
 
 class ReweightedGraphNodeAttributeSchema(BaseModel):
-    target_: anemoi.training.losses.nodeweights.ReweightedGraphNodeAttribute = Field(..., alias="_target_")
+    target_: "anemoi.training.losses.nodeweights.ReweightedGraphNodeAttribute" = Field(..., alias="_target_")
     "Node loss weights object from anemoi.training.losses."
     target_nodes: str = Field(examples=["data"])
     "name of target nodes, key in HeteroData graph object."

--- a/training/src/anemoi/training/schemas/training.py
+++ b/training/src/anemoi/training/schemas/training.py
@@ -172,18 +172,29 @@ class CombinedLossSchema(BaseLossSchema):
 LossSchemas = Union[BaseLossSchema, HuberLossSchema, WeightedMSELossLimitedAreaSchema, CombinedLossSchema]
 
 
-class NodeLossWeightsTargets(str, Enum):
-    graph_node_attribute = "anemoi.training.losses.nodeweights.GraphNodeAttribute"
-    reweighted_graph_node_attributes = "anemoi.training.losses.ReweightedGraphNodeAttribute"
-
-
-class NodeLossWeightsSchema(BaseModel):
-    target_: NodeLossWeightsTargets = Field(..., alias="_target_")
+class GraphNodeAttributeSchema(BaseModel):
+    target_: anemoi.training.losses.nodeweights.GraphNodeAttribute = Field(..., alias="_target_")
     "Node loss weights object from anemoi.training.losses."
     target_nodes: str = Field(examples=["data"])
     "name of target nodes, key in HeteroData graph object."
     node_attribute: str = Field(examples=["area_weight"])
     "name of node weight attribute, key in HeteroData graph object."
+
+
+class ReweightedGraphNodeAttributeSchema(BaseModel):
+    target_: anemoi.training.losses.nodeweights.ReweightedGraphNodeAttribute = Field(..., alias="_target_")
+    "Node loss weights object from anemoi.training.losses."
+    target_nodes: str = Field(examples=["data"])
+    "name of target nodes, key in HeteroData graph object."
+    node_attribute: str = Field(examples=["area_weight"])
+    "name of node weight attribute, key in the nodes object."
+    scaled_attribute: str = Field(examples=["cutout_mask"])
+    "name of node attribute defining the subset of nodes to be scaled, key in the nodes object."
+    weight_frac_of_total: float = Field(examples=[0.3])
+    "sum of weight of subset nodes as a fraction of sum of weight of all nodes after rescaling"
+
+
+NodeLossWeightsSchema = Union[GraphNodeAttributeSchema, ReweightedGraphNodeAttributeSchema]
 
 
 class ScaleValidationMetrics(BaseModel):


### PR DESCRIPTION
## Description

This is a fix to an error raised by pydantic when using `ReweightedGraphNodeAttribute` with the `no_validation: False`.

The node attribute "cutout" is renamed to "cutout_mask" (same as for config/graph/limited_area.yaml)

## Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update

## Issue Number

<!-- Link the Issue number this change addresses, ideally in one of the "magic format" such as Closes #XYZ -->

<!-- Alternatively, explain the motivation behind the changes and the context in which they are being made. -->

## Code Compatibility

-   [x] I have performed a self-review of my code

### Code Performance and Testing

-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] I ran the [complete Pytest test](https://anemoi.readthedocs.io/projects/training/en/latest/dev/testing.html) suite locally, and they pass
-   [ ] I have tested the changes on a single GPU
-   [ ] I have tested the changes on multiple GPUs / multi-node setups
-   [ ] I have run the Benchmark Profiler against the old version of the code
-   [ ] If the new feature introduces modifications at the config level, I have made sure to update Pydantic Schemas and default configs accordingly


<!-- In case this affects the model sharding or other specific components please describe these here. -->

### Dependencies

-   [ ] I have ensured that the code is still pip-installable after the changes and runs
-   [ ] I have tested that new dependencies themselves are pip-installable.
-   [ ] I have not introduced new dependencies in the inference portion of the pipeline

<!-- List any new dependencies that are required for this change and the justification to add them. -->

### Documentation

-   [x] My code follows the style guidelines of this project
-   [x] I have updated the documentation and docstrings to reflect the changes
-   [x] I have added comments to my code, particularly in hard-to-understand areas

<!-- Describe any major updates to the documentation -->

## Additional Notes

<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->
