### PR TITLE
chore(training): Update ruff lint settings

### DIFF
--- a/training/pyproject.toml
+++ b/training/pyproject.toml
@@ -112,13 +112,14 @@ target-version = "py39"
 line-length = 120
 src = [ "src" ]
 exclude = [ "docs/" ]
-
 preview = true
-lint.flake8-import-conventions.extend-aliases."pytorch_lightning" = "pl"
-lint.pydocstyle.convention = "numpy"
+
+[tool.ruff.lint]
+flake8-import-conventions.extend-aliases."pytorch_lightning" = "pl"
+pydocstyle.convention = "numpy"
 # Preserve types, even if a file imports `from __future__ import annotations`.
 # Necessary for supporting PEP 604 and pydantic with python 3.9
-lint.pyupgrade.keep-runtime-typing = true
+pyupgrade.keep-runtime-typing = true
 select = [
   "A", # flake8 builtins
   # "ANN", # flake8-annotations

--- a/training/pyproject.toml
+++ b/training/pyproject.toml
@@ -188,7 +188,6 @@ lint.ignore = [
   "S101",
   "TD003",
   "UP007",
-  "UP007",
 ]
 lint.flake8-import-conventions.extend-aliases."pytorch_lightning" = "pl"
 lint.pydocstyle.convention = "numpy"

--- a/training/pyproject.toml
+++ b/training/pyproject.toml
@@ -112,8 +112,8 @@ target-version = "py39"
 line-length = 120
 src = [ "src" ]
 exclude = [ "docs/" ]
-preview = true
 
+preview = true
 lint.select = [
   "A", # flake8 builtins
   # "ANN", # flake8-annotations
@@ -172,6 +172,7 @@ lint.select = [
   "W",   # pycodestyle warning
   "YTT", # flake8-2020
 ]
+
 lint.ignore = [
   "B018",
   "B028",
@@ -187,9 +188,10 @@ lint.ignore = [
   "S101",
   "TD003",
   "UP007",
+  "UP007",
 ]
-lint.flake8-import-conventions = "pl"
-lint.pydocstyle = "numpy"
+lint.flake8-import-conventions.extend-aliases."pytorch_lightning" = "pl"
+lint.pydocstyle.convention = "numpy"
 # Preserve types, even if a file imports `from __future__ import annotations`.
 # Necessary for supporting PEP 604 and pydantic with python 3.9
-lint.pyupgrade = true
+lint.pyupgrade.keep-runtime-typing = true

--- a/training/pyproject.toml
+++ b/training/pyproject.toml
@@ -114,13 +114,7 @@ src = [ "src" ]
 exclude = [ "docs/" ]
 preview = true
 
-[tool.ruff.lint]
-flake8-import-conventions.extend-aliases."pytorch_lightning" = "pl"
-pydocstyle.convention = "numpy"
-# Preserve types, even if a file imports `from __future__ import annotations`.
-# Necessary for supporting PEP 604 and pydantic with python 3.9
-pyupgrade.keep-runtime-typing = true
-select = [
+lint.select = [
   "A", # flake8 builtins
   # "ANN", # flake8-annotations
   "ANN001", # Type annotation
@@ -178,9 +172,7 @@ select = [
   "W",   # pycodestyle warning
   "YTT", # flake8-2020
 ]
-
-ignore = [
-  "UP007",
+lint.ignore = [
   "B018",
   "B028",
   "D100",
@@ -194,4 +186,10 @@ ignore = [
   "PT018",
   "S101",
   "TD003",
+  "UP007",
 ]
+lint.flake8-import-conventions = "pl"
+lint.pydocstyle = "numpy"
+# Preserve types, even if a file imports `from __future__ import annotations`.
+# Necessary for supporting PEP 604 and pydantic with python 3.9
+lint.pyupgrade = true


### PR DESCRIPTION
## Description

The top level ruff lint options in the training pyproject are deprecated:

```
warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `training/pyproject.toml`:
  - 'ignore' -> 'lint.ignore'
  - 'select' -> 'lint.select'
```

This updates the settings according to the above warning.