### PR TITLE
feat(mlflow): Make direct endpoint calls robust

### DIFF
--- a/training/pyproject.toml
+++ b/training/pyproject.toml
@@ -49,6 +49,7 @@ dependencies = [
   "hydra-core>=1.3",
   "matplotlib>=3.7.1",
   "mlflow>=2.11.1",
+  "multiurl>=0.3.3",
   "numpy<2",                         # Pinned until we can confirm it works with anemoi graphs
   "pydantic>=2.9",
   "pynvml>=11.5",

--- a/training/pyproject.toml
+++ b/training/pyproject.toml
@@ -43,14 +43,13 @@ dependencies = [
   "anemoi-datasets>=0.5.13",
   "anemoi-graphs>=0.4.1",
   "anemoi-models>=0.4.1",
-  "anemoi-utils[provenance]>=0.4.4",
+  "anemoi-utils[provenance]>=0.4.13",
   "datashader>=0.16.3",
   "einops>=0.6.1",
   "hydra-core>=1.3",
   "matplotlib>=3.7.1",
   "mlflow>=2.11.1",
-  "multiurl>=0.3.3",
-  "numpy<2",                         # Pinned until we can confirm it works with anemoi graphs
+  "numpy<2",                          # Pinned until we can confirm it works with anemoi graphs
   "pydantic>=2.9",
   "pynvml>=11.5",
   "pyshtools>=4.10.4",

--- a/training/src/anemoi/training/diagnostics/mlflow/auth.py
+++ b/training/src/anemoi/training/diagnostics/mlflow/auth.py
@@ -20,11 +20,11 @@ from getpass import getpass
 from typing import TYPE_CHECKING
 
 import requests
-from multiurl.http import robust
 from requests.exceptions import HTTPError
 
 from anemoi.utils.config import load_config
 from anemoi.utils.config import save_config
+from anemoi.utils.remote import robust
 from anemoi.utils.timer import Timer
 
 REFRESH_EXPIRE_DAYS = 29
@@ -226,7 +226,7 @@ class TokenAuth:
         }
 
         try:
-            response = robust(requests.post, retry_after=60, maximum_tries=30)(
+            response = robust(requests.post)(
                 f"{self.url}/{path}",
                 headers=headers,
                 json=payload,

--- a/training/src/anemoi/training/diagnostics/mlflow/utils.py
+++ b/training/src/anemoi/training/diagnostics/mlflow/utils.py
@@ -13,6 +13,7 @@ import os
 from typing import Any
 
 import requests
+from multiurl.http import robust
 
 
 def health_check(tracking_uri: str) -> None:
@@ -29,7 +30,11 @@ def health_check(tracking_uri: str) -> None:
     token = os.getenv("MLFLOW_TRACKING_TOKEN")
 
     headers = {"Authorization": f"Bearer {token}"}
-    response = requests.get(f"{tracking_uri}/health", headers=headers, timeout=60)
+    response = robust(requests.get, retry_after=30, maximum_tries=10)(
+        f"{tracking_uri}/health",
+        headers=headers,
+        timeout=60,
+    )
 
     if response.text == "OK":
         return

--- a/training/src/anemoi/training/diagnostics/mlflow/utils.py
+++ b/training/src/anemoi/training/diagnostics/mlflow/utils.py
@@ -13,7 +13,8 @@ import os
 from typing import Any
 
 import requests
-from multiurl.http import robust
+
+from anemoi.utils.remote import robust
 
 
 def health_check(tracking_uri: str) -> None:


### PR DESCRIPTION
## Description

There are two parts in training that talk to the mlflow endpoint direct: the authentication layer, and the health check that verifies if the authentication succeeded and we can reach the server.

These send requests to the mlflow endpoint directly, and if it fails the code will crash.

This PR adds a retry mechanic, where it will retry those requests if the failure is caused by a recoverable HTTP response (bad gateway, service unavailable, etc). This will make training less prone to crashes from intermittent network issues.

## Type of Change

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update

## Code Compatibility

-   [x] I have performed a self-review of my code

### Code Performance and Testing

-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] I ran the [complete Pytest test](https://anemoi.readthedocs.io/projects/training/en/latest/dev/testing.html) suite locally, and they pass
-   [ ] I have tested the changes on a single GPU
-   [ ] I have tested the changes on multiple GPUs / multi-node setups
-   [ ] I have run the Benchmark Profiler against the old version of the code
-   [ ] If the new feature introduces modifications at the config level, I have made sure to update Pydantic Schemas and default configs accordingly

### Dependencies

-   [x] I have ensured that the code is still pip-installable after the changes and runs
-   [x] I have tested that new dependencies themselves are pip-installable.
-   [x] I have not introduced new dependencies in the inference portion of the pipeline

There is a new indirect dependency on `multiurl` (anemoi.utils robust calls that under the hood) , but this is an ECMWF package and is very lightweight with only the following dependencies: "requests", "tqdm", "pytz", "python-dateutil". All of these are already in the dependency tree.

