### PR TITLE
fix: add reference in integration test workflow

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -8,7 +8,7 @@ jobs:
   integration_tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: ecmwf/reusable-workflows/nightly-pytest
+      - uses: ecmwf/reusable-workflows/nightly-pytest@main
         with:
           repository: ${{github.repository}}
           ref: ${{github.ref}}


### PR DESCRIPTION
## Description

The integration test workflow fails due to a missing reference in the 'uses' attribute pointing to the action in reusable workflows. This PR adds a reference to fix the syntax.

## Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update

## Code Compatibility

-   [x] I have performed a self-review of my code

