### PR TITLE
fix: fix --longtests not available

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -3,6 +3,10 @@ on:
   schedule:
     - cron: "0 23 * * *"  # every day at 22pm on default(main) branch
   workflow_dispatch:
+  push:
+    branches:
+      # - main
+      - ci/fix-longrun-marker
 
 jobs:
   integration_tests:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -3,10 +3,6 @@ on:
   schedule:
     - cron: "0 23 * * *"  # every day at 22pm on default(main) branch
   workflow_dispatch:
-  push:
-    branches:
-      # - main
-      - ci/fix-longrun-marker
 
 jobs:
   integration_tests:

--- a/training/docs/dev/testing.rst
+++ b/training/docs/dev/testing.rst
@@ -138,6 +138,16 @@ top-level directory of anemoi-core run:
 
    pytest training/tests/integration --longtests
 
+For long-running integration tests, we use the `--longtests` flag to
+ensure that they are run only when necessary. This means that you should
+add the correspondong marker to these tests:
+
+.. code:: python
+
+   @pytest.mark.longtests
+   def test_long():
+         pass
+
 **********************************************
  Integration tests and member state use cases
 **********************************************

--- a/training/pytest.ini
+++ b/training/pytest.ini
@@ -3,5 +3,8 @@ markers =
     data_dependent: marks tests depending on data (deselect with '-m "not data_dependent"')
     auth: marks tests that require authentication (deselect with '-m "not auth"')
     gpu: marks tests that require a GPU (deselect with '-m "not gpu"')
+    longtest: mark test as long-running (skipped unless --longtests is used)
+
+addopts = --longtest
 
 tmp_path_retention_policy = none

--- a/training/pytest.ini
+++ b/training/pytest.ini
@@ -3,8 +3,7 @@ markers =
     data_dependent: marks tests depending on data (deselect with '-m "not data_dependent"')
     auth: marks tests that require authentication (deselect with '-m "not auth"')
     gpu: marks tests that require a GPU (deselect with '-m "not gpu"')
-    longtest: mark test as long-running (skipped unless --longtests is used)
+    longtests: mark test as long-running (skipped unless --longtests is used)
 
-addopts = --longtest
 
 tmp_path_retention_policy = none

--- a/training/tests/conftest.py
+++ b/training/tests/conftest.py
@@ -13,23 +13,23 @@ import pytest
 
 def pytest_addoption(parser: pytest.Parser) -> None:
     parser.addoption(
-        "--longtest",
+        "--longtests",
         action="store_true",
-        dest="longtest",
+        dest="longtests",
         default=False,
-        help="enable longrundecorated tests",
+        help="enable longtests decorated tests",
     )
 
 
 def pytest_configure(config: pytest.Config) -> None:
-    """Register the 'longtest' marker to avoid warnings."""
-    config.addinivalue_line("markers", "longtest: mark tests as long-running")
+    """Register the 'longtests' marker to avoid warnings."""
+    config.addinivalue_line("markers", "longtests: mark tests as long-running")
 
 
 def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
     """Automatically skip @pytest.mark.longrun tests unless --longtests is used."""
-    if not config.getoption("--longtest"):
+    if not config.getoption("--longtests"):
         skip_marker = pytest.mark.skip(reason="Skipping long test, use --longtests to enable")
         for item in items:
-            if "longtest" in item.keywords:
+            if item.get_closest_marker("longtests"):
                 item.add_marker(skip_marker)

--- a/training/tests/conftest.py
+++ b/training/tests/conftest.py
@@ -1,0 +1,35 @@
+# (C) Copyright 2025 Anemoi contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+
+import pytest
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption(
+        "--longtest",
+        action="store_true",
+        dest="longtest",
+        default=False,
+        help="enable longrundecorated tests",
+    )
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Register the 'longtest' marker to avoid warnings."""
+    config.addinivalue_line("markers", "longtest: mark tests as long-running")
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    """Automatically skip @pytest.mark.longrun tests unless --longtests is used."""
+    if not config.getoption("--longtest"):
+        skip_marker = pytest.mark.skip(reason="Skipping long test, use --longtests to enable")
+        for item in items:
+            if "longtest" in item.keywords:
+                item.add_marker(skip_marker)

--- a/training/tests/conftest.py
+++ b/training/tests/conftest.py
@@ -17,7 +17,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         action="store_true",
         dest="longtests",
         default=False,
-        help="enable longtests decorated tests",
+        help="enable tests marked as longtests",
     )
 
 
@@ -27,7 +27,7 @@ def pytest_configure(config: pytest.Config) -> None:
 
 
 def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
-    """Automatically skip @pytest.mark.longrun tests unless --longtests is used."""
+    """Automatically skip @pytest.mark.longtests tests unless --longtests is used."""
     if not config.getoption("--longtests"):
         skip_marker = pytest.mark.skip(reason="Skipping long test, use --longtests to enable")
         for item in items:

--- a/training/tests/integration/conftest.py
+++ b/training/tests/integration/conftest.py
@@ -41,13 +41,3 @@ def testing_modifications_with_temp_dir(tmp_path: Path) -> OmegaConf:
     temp_dir = str(tmp_path)
     testing_modifications.hardware.paths.output = temp_dir
     return testing_modifications
-
-
-def pytest_addoption(parser: pytest.Parser) -> None:
-    parser.addoption(
-        "--longtests",
-        action="store_true",
-        dest="longtests",
-        default=False,
-        help="enable longrundecorated tests",
-    )

--- a/training/tests/integration/test_training_cycle.py
+++ b/training/tests/integration/test_training_cycle.py
@@ -22,7 +22,7 @@ os.environ["ANEMOI_BASE_SEED"] = "42"  # need to set base seed if running on git
 LOGGER = logging.getLogger(__name__)
 
 
-@pytest.mark.longtest
+@pytest.mark.longtests
 def test_training_cycle_architecture_configs(architecture_config: DictConfig) -> None:
     AnemoiTrainer(architecture_config).train()
     shutil.rmtree(architecture_config.hardware.paths.output)

--- a/training/tests/integration/test_training_cycle.py
+++ b/training/tests/integration/test_training_cycle.py
@@ -18,12 +18,11 @@ from anemoi.training.train.train import AnemoiTrainer
 
 os.environ["ANEMOI_BASE_SEED"] = "42"  # need to set base seed if running on github runners
 
-longtests = pytest.mark.skipif("not config.getoption('longtests')", reason="need --longtests option to run")
 
 LOGGER = logging.getLogger(__name__)
 
 
-@longtests
+@pytest.mark.longtest
 def test_training_cycle_architecture_configs(architecture_config: DictConfig) -> None:
     AnemoiTrainer(architecture_config).train()
     shutil.rmtree(architecture_config.hardware.paths.output)


### PR DESCRIPTION
## Description

Previously, the --longtests option for the pytest suite was only available in the integration test folder. Now, it is available on the top-level test as well.

The marker has changed to @pytest.mark.longtests.

## Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update

## Issue Number

<!-- Link the Issue number this change addresses, ideally in one of the "magic format" such as Closes #XYZ -->

<!-- Alternatively, explain the motivation behind the changes and the context in which they are being made. -->

## Code Compatibility

-   [x] I have performed a self-review of my code

### Code Performance and Testing

-   [x] I ran the [complete Pytest test](https://anemoi.readthedocs.io/projects/training/en/latest/dev/testing.html) suite locally, and they pass



## Additional Notes

<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->


<!-- readthedocs-preview anemoi-training start -->
----
📚 Documentation preview 📚: https://anemoi-training--200.org.readthedocs.build/en/200/

<!-- readthedocs-preview anemoi-training end -->

<!-- readthedocs-preview anemoi-graphs start -->
----
📚 Documentation preview 📚: https://anemoi-graphs--200.org.readthedocs.build/en/200/

<!-- readthedocs-preview anemoi-graphs end -->

<!-- readthedocs-preview anemoi-models start -->
----
📚 Documentation preview 📚: https://anemoi-models--200.org.readthedocs.build/en/200/

<!-- readthedocs-preview anemoi-models end -->