### PR TITLE
make activation checkpointing configurable

### DIFF
--- a/training/src/anemoi/training/config/model/gnn.yaml
+++ b/training/src/anemoi/training/config/model/gnn.yaml
@@ -23,7 +23,7 @@ processor:
   trainable_size: ${model.trainable_parameters.hidden2hidden}
   sub_graph_edge_attributes: ${model.attributes.edges}
   num_layers: 16
-  num_chunks: 2
+  num_chunks: 4
   mlp_extra_layers: 0
   cpu_offload: ${model.cpu_offload}
 

--- a/training/src/anemoi/training/config/model/graphtransformer.yaml
+++ b/training/src/anemoi/training/config/model/graphtransformer.yaml
@@ -23,7 +23,7 @@ processor:
   trainable_size: ${model.trainable_parameters.hidden2hidden}
   sub_graph_edge_attributes: ${model.attributes.edges}
   num_layers: 16
-  num_chunks: 2
+  num_chunks: 8
   mlp_hidden_ratio: 4 # GraphTransformer or Transformer only
   num_heads: 16 # GraphTransformer or Transformer only
   cpu_offload: ${model.cpu_offload}

--- a/training/src/anemoi/training/config/model/transformer.yaml
+++ b/training/src/anemoi/training/config/model/transformer.yaml
@@ -20,7 +20,7 @@ processor:
   _target_: anemoi.models.layers.processor.TransformerProcessor
   activation: ${model.activation}
   num_layers: 16
-  num_chunks: 2
+  num_chunks: 8
   mlp_hidden_ratio: 4 # GraphTransformer or Transformer only
   num_heads: 16 # GraphTransformer or Transformer only
   window_size: 512

--- a/training/src/anemoi/training/config/training/default.yaml
+++ b/training/src/anemoi/training/config/training/default.yaml
@@ -4,6 +4,12 @@ fork_run_id: null
 transfer_learning: False # activate to perform transfer learning
 load_weights_only: False # only load model weights, do not restore optimiser states etc.
 
+# use activation checkpointing to reduce memory usage
+activation_checkpointing:
+  encoder: False
+  decoder: False
+  processor: False
+
 # run in deterministic mode ; slows down
 deterministic: False
 

--- a/training/src/anemoi/training/schemas/training.py
+++ b/training/src/anemoi/training/schemas/training.py
@@ -80,6 +80,17 @@ class LR(BaseModel):
     "Number of warm up iteration. Default to 1000."
 
 
+class ActivationCheckpointing(BaseModel):
+    """Activation checkpointing configuration."""
+
+    encoder: bool = Field(example=False)
+    "Enable activation checkpointing for the encoder."
+    decoder: bool = Field(example=False)
+    "Enable activation checkpointing for the decoder."
+    processor: bool = Field(example=False)
+    "Enable activation checkpointing for the processor."
+
+
 class LossScalingSchema(BaseModel):
     default: int = 1
     "Default scaling value applied to the variables loss. Default to 1."
@@ -225,6 +236,8 @@ class TrainingSchema(BaseModel):
     "List of submodules to freeze during transfer learning."
     deterministic: bool = Field(default=False)
     "This flag sets the torch.backends.cudnn.deterministic flag. Might be slower, but ensures reproducibility."
+    activation_checkpointing: ActivationCheckpointing = Field(default_factory=ActivationCheckpointing)
+    "Activation checkpointing configuration."
     precision: str = Field(default="16-mixed")
     "Precision"
     multistep_input: PositiveInt = Field(example=2)

--- a/training/src/anemoi/training/train/train.py
+++ b/training/src/anemoi/training/train/train.py
@@ -189,6 +189,16 @@ class AnemoiTrainer:
                 freeze_submodule_by_name(model, submodule_name)
                 LOGGER.info("%s frozen successfully.", submodule_name.upper())
 
+        if self.config.training.activation_checkpointing.encoder:
+            LOGGER.info("Encoder activation checkpointing enabled.")
+            model.model.model.encoder_act_checkpointing = True
+        if self.config.training.activation_checkpointing.decoder:
+            LOGGER.info("Decoder activation checkpointing enabled.")
+            model.model.model.decoder_act_checkpointing = True
+        if self.config.training.activation_checkpointing.processor:
+            LOGGER.info("Processor activation checkpointing enabled.")
+            model.model.model.processor_act_checkpointing = True
+
         return model
 
     @rank_zero_only


### PR DESCRIPTION
Effort to make activation checkpointing configurable. With more GPU memory, small models will be able to run without full checkpointing and therefore we can increase throughput. 

Also sets the processor default chunking values to more sane defaults.
