### PR TITLE
test: fix relative paths for downstream ci

### DIFF
--- a/training/tests/integration/conftest.py
+++ b/training/tests/integration/conftest.py
@@ -8,6 +8,7 @@
 # nor does it submit to any jurisdiction.
 
 
+import os
 from pathlib import Path
 
 import pytest
@@ -15,6 +16,14 @@ from hydra import compose
 from hydra import initialize
 from omegaconf import OmegaConf
 
+@pytest.fixture(autouse=True)
+def set_working_directory():
+    """Automatically set the working directory to the repo root."""
+    repo_root = Path(__file__).resolve().parent
+    while not (repo_root / ".git").exists() and repo_root != repo_root.parent:
+        repo_root = repo_root.parent
+
+    os.chdir(repo_root) 
 
 @pytest.fixture(
     params=[

--- a/training/tests/integration/conftest.py
+++ b/training/tests/integration/conftest.py
@@ -18,7 +18,7 @@ from omegaconf import OmegaConf
 
 
 @pytest.fixture(autouse=True)
-def set_working_directory():
+def set_working_directory() -> None:
     """Automatically set the working directory to the repo root."""
     repo_root = Path(__file__).resolve().parent
     while not (repo_root / ".git").exists() and repo_root != repo_root.parent:

--- a/training/tests/integration/conftest.py
+++ b/training/tests/integration/conftest.py
@@ -16,6 +16,7 @@ from hydra import compose
 from hydra import initialize
 from omegaconf import OmegaConf
 
+
 @pytest.fixture(autouse=True)
 def set_working_directory():
     """Automatically set the working directory to the repo root."""
@@ -23,7 +24,8 @@ def set_working_directory():
     while not (repo_root / ".git").exists() and repo_root != repo_root.parent:
         repo_root = repo_root.parent
 
-    os.chdir(repo_root) 
+    os.chdir(repo_root)
+
 
 @pytest.fixture(
     params=[


### PR DESCRIPTION
## Description

Adds a fixture to the integration test set-up that navigates to the repo's root dir at the beginning of each test.
This is needed because we use config files in anemoi-core/training//src/anemoi/training/config/ with relative paths for hydra, as well as config files from the integration test dir in anemoi-core.

This fixes the fast integration tests failing on the downstream-ci where tests are not run from the root dir of anemoi-core.

Error message from downstream-ci on anemoi-utils:
=========================== short test summary info ============================
 
ERROR tests/integration/test_training_cycle.py::test_config_validation_architecture_configs[architecture_config0] - FileNotFoundError: [Errno 2] No such file or directory: '/opt/actions-runner/work/_work/anemoi-utils/anemoi-utils/training/training/tests/integration/config/testing_modifications.yaml'
 
ERROR tests/integration/test_training_cycle.py::test_config_validation_architecture_configs[architecture_config1] - FileNotFoundError: [Errno 2] No such file or directory: '/opt/actions-runner/work/_work/anemoi-utils/anemoi-utils/training/training/tests/integration/config/testing_modifications.yaml'
 
============ 92 passed, 3 skipped, 104 warnings, 2 errors in 10.81s ============
 
Error: Process completed with exit code 1.

## Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update

## Code Compatibility

-   [x] I have performed a self-review of my code

### Code Performance and Testing

-   [x] I have run the integration tests from different directories to check if my fix is effective


### Documentation

-   [x] My code follows the style guidelines of this project
-   [x] I have updated the documentation and docstrings to reflect the changes
-   [x] I have added comments to my code, particularly in hard-to-understand areas
