### PR TITLE
fix: Checkpoint path check for multiple tasks/GPUs training

### DIFF
--- a/training/src/anemoi/training/train/train.py
+++ b/training/src/anemoi/training/train/train.py
@@ -425,6 +425,8 @@ class AnemoiTrainer:
 
     def _get_dry_run_id(self) -> None:
         """Check if the run ID is dry, e.g. without a checkpoint."""
+        # The Path casting is needed because in some multiple-gpu case
+        # ranks > 0 checkpoint paths are Python strings.
         if Path(self.config.hardware.paths.checkpoints).is_dir():
             self.dry_run_id = False
         else:

--- a/training/src/anemoi/training/train/train.py
+++ b/training/src/anemoi/training/train/train.py
@@ -425,7 +425,7 @@ class AnemoiTrainer:
 
     def _get_dry_run_id(self) -> None:
         """Check if the run ID is dry, e.g. without a checkpoint."""
-        # The Path casting is needed because in some multiple-gpu case
+        # The Path casting is needed because in some multiple-gpu use cases
         # ranks > 0 checkpoint paths are Python strings.
         if Path(self.config.hardware.paths.checkpoints).is_dir():
             self.dry_run_id = False

--- a/training/src/anemoi/training/train/train.py
+++ b/training/src/anemoi/training/train/train.py
@@ -419,15 +419,13 @@ class AnemoiTrainer:
             self.lineage_run = self.parent_run_server2server or self.config.training.fork_run_id
             # Only rank non zero in the forked run will go here
             self.config.hardware.paths.checkpoints = Path(self.config.hardware.paths.checkpoints, self.lineage_run)
-        else:  # To have type consistency between all ranks
-            self.config.hardware.paths.checkpoints = Path(self.config.hardware.paths.checkpoints)
 
         LOGGER.info("Checkpoints path: %s", self.config.hardware.paths.checkpoints)
         LOGGER.info("Plots path: %s", self.config.hardware.paths.plots)
 
     def _get_dry_run_id(self) -> None:
         """Check if the run ID is dry, e.g. without a checkpoint."""
-        if self.config.hardware.paths.checkpoints.is_dir():
+        if Path(self.config.hardware.paths.checkpoints).is_dir():
             self.dry_run_id = False
         else:
             LOGGER.info("Starting from a dry run ID.")

--- a/training/src/anemoi/training/train/train.py
+++ b/training/src/anemoi/training/train/train.py
@@ -419,6 +419,8 @@ class AnemoiTrainer:
             self.lineage_run = self.parent_run_server2server or self.config.training.fork_run_id
             # Only rank non zero in the forked run will go here
             self.config.hardware.paths.checkpoints = Path(self.config.hardware.paths.checkpoints, self.lineage_run)
+        else:  # To have type consistency between all ranks
+            self.config.hardware.paths.checkpoints = Path(self.config.hardware.paths.checkpoints)
 
         LOGGER.info("Checkpoints path: %s", self.config.hardware.paths.checkpoints)
         LOGGER.info("Plots path: %s", self.config.hardware.paths.plots)


### PR DESCRIPTION
## Description

Fix bug introduced in https://github.com/ecmwf/anemoi-core/pull/164 when running a training with multiple GPUs/tasks. This a quick fix and a more long term and robust solution might be investigated: https://github.com/ecmwf/anemoi-core/issues/240. 

## Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update

## Issue Number


## Code Compatibility

-   [x] I have performed a self-review of my code

### Code Performance and Testing

-   [x] I have added tests that prove my fix is effective or that my feature works
-   [ ] I ran the [complete Pytest test](https://anemoi.readthedocs.io/projects/training/en/latest/dev/testing.html) suite locally, and they pass
-   [ ] I have tested the changes on a single GPU
-   [ ] I have tested the changes on multiple GPUs / multi-node setups
-   [ ] I have run the Benchmark Profiler against the old version of the code
-   [ ] If the new feature introduces modifications at the config level, I have made sure to update Pydantic Schemas and default configs accordingly


<!-- In case this affects the model sharding or other specific components please describe these here. -->

### Dependencies

-   [ ] I have ensured that the code is still pip-installable after the changes and runs
-   [ ] I have tested that new dependencies themselves are pip-installable.
-   [ ] I have not introduced new dependencies in the inference portion of the pipeline

<!-- List any new dependencies that are required for this change and the justification to add them. -->

### Documentation

-   [ ] My code follows the style guidelines of this project
-   [ ] I have updated the documentation and docstrings to reflect the changes
-   [ ] I have added comments to my code, particularly in hard-to-understand areas

<!-- Describe any major updates to the documentation -->

## Additional Notes

<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->
