### PR TITLE
fix: Fix inference with kcrps 

### DIFF
--- a/models/src/anemoi/models/interface/__init__.py
+++ b/models/src/anemoi/models/interface/__init__.py
@@ -129,3 +129,93 @@ class AnemoiModelInterface(torch.nn.Module):
             y_hat = self(x, model_comm_group)
 
         return self.post_processors(y_hat, in_place=False)
+
+
+class AnemoiEnsModelInterface(AnemoiModelInterface):
+    """An interface for Anemoi ensemble models.
+
+    This class is a wrapper around the Anemoi ensemble model that includes pre-processing and post-processing steps.
+    It inherits from the AnemoiModelInterface class.
+
+    Attributes
+    ----------
+    config : DotDict
+        Configuration settings for the model.
+    id : str
+        A unique identifier for the model instance.
+    multi_step : bool
+        Whether the model uses multi-step input.
+    graph_data : HeteroData
+        Graph data for the model.
+    statistics : dict
+        Statistics for the data.
+    metadata : dict
+        Metadata for the model.
+    supporting_arrays : dict
+        Numpy arraysto store in the checkpoint.
+    data_indices : dict
+        Indices for the data.
+    pre_processors : Processors
+        Pre-processing steps to apply to the data before passing it to the model.
+    post_processors : Processors
+        Post-processing steps to apply to the model's output.
+    model : AnemoiModelEncProcDec
+        The underlying Anemoi model.
+    """
+
+    def __init__(
+        self,
+        *,
+        config: DotDict,
+        graph_data: HeteroData,
+        statistics: dict,
+        data_indices: dict,
+        metadata: dict,
+        supporting_arrays: dict = None,
+        truncation_data: dict,
+    ) -> None:
+        super().__init__(
+            config=config,
+            graph_data=graph_data,
+            statistics=statistics,
+            data_indices=data_indices,
+            metadata=metadata,
+            supporting_arrays=supporting_arrays,
+            truncation_data=truncation_data,
+        )
+
+    def predict_step(
+        self, batch: torch.Tensor, fcstep: int = 1, model_comm_group: Optional[ProcessGroup] = None, **kwargs
+    ) -> torch.Tensor:
+        """Prediction step for the model.
+
+        Parameters
+        ----------
+        batch : torch.Tensor
+            Input batched data.
+        fcstep : int
+            Forecast step.
+        model_comm_group : Optional[ProcessGroup]
+            Model communication group.
+        **kwargs : dict
+            Additional keyword arguments.
+
+        Returns
+        -------
+        torch.Tensor
+            Predicted data.
+        """
+        batch = self.pre_processors(batch, in_place=False)
+
+        with torch.no_grad():
+
+            assert (
+                len(batch.shape) == 4
+            ), f"The input tensor has an incorrect shape: expected a 4-dimensional tensor, got {batch.shape}!"
+            # Dimensions are
+            # batch, timesteps, horizonal space, variables
+            x = batch[:, 0 : self.multi_step, None, ...]  # add dummy ensemble dimension as 3rd index
+
+            y_hat = self(x, fcstep, model_comm_group=model_comm_group)
+
+        return self.post_processors(y_hat, in_place=False)

--- a/training/src/anemoi/training/config/model/gnn.yaml
+++ b/training/src/anemoi/training/config/model/gnn.yaml
@@ -3,6 +3,7 @@ num_channels: 512
 cpu_offload: False
 output_mask: null
 
+interface: anemoi.models.interface.AnemoiModelInterface
 model:
   _target_: anemoi.models.models.encoder_processor_decoder.AnemoiModelEncProcDec
 

--- a/training/src/anemoi/training/config/model/gnn_ens.yaml
+++ b/training/src/anemoi/training/config/model/gnn_ens.yaml
@@ -2,6 +2,7 @@ activation: GELU
 num_channels: 512
 output_mask: null
 
+interface: anemoi.models.interface.AnemoiEnsModelInterface
 model:
   _target_: anemoi.models.models.ens_encoder_processor_decoder.AnemoiEnsModelEncProcDec
 

--- a/training/src/anemoi/training/config/model/graphtransformer.yaml
+++ b/training/src/anemoi/training/config/model/graphtransformer.yaml
@@ -3,6 +3,7 @@ num_channels: 1024
 cpu_offload: False
 output_mask: null
 
+interface: anemoi.models.interface.AnemoiModelInterface
 model:
   _target_: anemoi.models.models.encoder_processor_decoder.AnemoiModelEncProcDec
 

--- a/training/src/anemoi/training/config/model/graphtransformer_ens.yaml
+++ b/training/src/anemoi/training/config/model/graphtransformer_ens.yaml
@@ -3,6 +3,7 @@ num_channels: 1024
 output_mask: null
 cpu_offload: False
 
+interface: anemoi.models.interface.AnemoiEnsModelInterface
 model:
   _target_: anemoi.models.models.ens_encoder_processor_decoder.AnemoiEnsModelEncProcDec
 

--- a/training/src/anemoi/training/config/model/transformer.yaml
+++ b/training/src/anemoi/training/config/model/transformer.yaml
@@ -3,6 +3,8 @@ num_channels: 1024
 cpu_offload: False
 output_mask: null
 
+interface: anemoi.models.interface.AnemoiModelInterface
+
 model:
   _target_: anemoi.models.models.encoder_processor_decoder.AnemoiModelEncProcDec
 

--- a/training/src/anemoi/training/config/model/transformer_ens.yaml
+++ b/training/src/anemoi/training/config/model/transformer_ens.yaml
@@ -3,6 +3,8 @@ num_channels: 1024
 output_mask: null
 cpu_offload: False
 
+interface: anemoi.models.interface.AnemoiEnsModelInterface
+
 model:
   _target_: anemoi.models.models.ens_encoder_processor_decoder.AnemoiEnsModelEncProcDec
 

--- a/training/src/anemoi/training/train/forecaster/forecaster.py
+++ b/training/src/anemoi/training/train/forecaster/forecaster.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 import pytorch_lightning as pl
 import torch
+from hydra.utils import get_class
 from hydra.utils import instantiate
 from omegaconf import DictConfig
 from omegaconf import ListConfig
@@ -25,7 +26,6 @@ from timm.scheduler import CosineLRScheduler
 from torch.distributed.optim import ZeroRedundancyOptimizer
 from torch.utils.checkpoint import checkpoint
 
-from anemoi.models.interface import AnemoiModelInterface
 from anemoi.training.losses.utils import grad_scaler
 from anemoi.training.losses.weightedloss import BaseWeightedLoss
 from anemoi.training.schemas.base_schema import BaseSchema
@@ -90,7 +90,8 @@ class GraphForecaster(pl.LightningModule):
         else:
             self.output_mask = NoOutputMask()
 
-        self.model = AnemoiModelInterface(
+        model_interface = get_class(config.model.interface)
+        self.model = model_interface(
             statistics=statistics,
             data_indices=data_indices,
             metadata=metadata,


### PR DESCRIPTION
## Issue

When running anemoi-inference the `predict_step` function of the model interface is called, which in turn calls the forward function of the model. The forward function of `AnemoiEnsModelEncProcDec` however takes more arguments which needs to be passed from `anemoi-inference`. 

## Solution:
Introduction of a new `AnemoiEnsModelInterface`, which passes the arguments correctly.
For that, I've introduced a `model.interface` keyword in the model configs. This is a breaking change since the keyword is required. 

## Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update

## Code Compatibility

-   [ ] I have trained a deterministic and kcrps model and preformed inference

### Documentation

-   [ ] I have updated the documentation and docstrings to reflect the changes

### Notes
The arguments also need to be passed by `anemoi-inference` for that I've added a small PR https://github.com/ecmwf/anemoi-inference/pull/212
