### PR TITLE
fix: Adapt predict_step in model interface to pass on arguments for model classes

### DIFF
--- a/models/src/anemoi/models/interface/__init__.py
+++ b/models/src/anemoi/models/interface/__init__.py
@@ -126,6 +126,11 @@ class AnemoiModelInterface(torch.nn.Module):
             # batch, timesteps, horizonal space, variables
             x = batch[:, 0 : self.multi_step, None, ...]  # add dummy ensemble dimension as 3rd index
 
-            y_hat = self(x, model_comm_group)
+            if "fcstep" in kwargs:  # AnemoiEnsModelEncProcDec
+                y_hat = self(x, kwargs["fcstep"], model_comm_group=model_comm_group)
+            elif "target_forcing" in kwargs:  # AnemoiModelEncProcDecInterpolator
+                y_hat = self(x, kwargs["target_forcing"], model_comm_group=model_comm_group)
+            else:
+                y_hat = self(x, model_comm_group=model_comm_group)
 
         return self.post_processors(y_hat, in_place=False)


### PR DESCRIPTION
## Issue

When running anemoi-inference the `predict_step` function of the model interface is called, which in turn calls the forward function of the model. The forward function of `AnemoiEnsModelEncProcDec` however takes more arguments which needs to be passed from `anemoi-inference`. 

## Solution:
Passing on the relevant keywords coming from `anemoi-inference`.

## Alternative Solution
Interface classes: https://github.com/ecmwf/anemoi-core/pull/277

## Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] Documentation update

## Code Compatibility

-   [x] I have trained a deterministic and kcrps model and preformed inference

### Documentation

-   [ ] I have updated the documentation and docstrings to reflect the changes

### Notes
The arguments also need to be passed by `anemoi-inference` for that I've added a small PR https://github.com/ecmwf/anemoi-inference/pull/212
