### PR TITLE
fix: Adapt ensemble configs to work with loss refactor. 

### DIFF
--- a/training/src/anemoi/training/config/debug_ens.yaml
+++ b/training/src/anemoi/training/config/debug_ens.yaml
@@ -6,10 +6,10 @@ defaults:
 - hardware: example
 - graph: encoder_decoder_only
 - model: transformer_ens
-- training: default
+- training: ensemble
 - _self_
 
-config_validation: True
+config_validation: False
 
 ### This file is for local experimentation.
 ##  When you commit your changes, assign the new features and keywords
@@ -23,8 +23,8 @@ diagnostics:
     callbacks: []
 hardware:
   files:
-    truncation: ${data.resolution}-O32-linear.mat.npz
-    truncation_inv: O32-${data.resolution}-linear.mat.npz
+    truncation: ${data.resolution}-o32-linear.mat.npz
+    truncation_inv: o32-${data.resolution}-linear.mat.npz
     graph: graph_anemoi_new_${data.resolution}.pt
     dataset: aifs-ea-an-oper-0001-mars-${data.resolution}-1979-2022-6h-v6.zarr
   accelerator: auto
@@ -45,30 +45,5 @@ data:
   resolution: o96
 
 training:
-  model_task: anemoi.training.train.forecaster.GraphEnsForecaster
-  strategy:
-    _target_: anemoi.training.distributed.strategy.DDPEnsGroupStrategy
-    num_gpus_per_ensemble: ${hardware.num_gpus_per_ensemble}
-    num_gpus_per_model: ${hardware.num_gpus_per_model}
   ensemble_size_per_device: 2
   max_epochs: 1
-
-  # loss function for the model
-  training_loss:
-    # loss class to initialise, can be anything subclassing torch.nn.Module
-    _target_: anemoi.training.losses.AlmostFairKernelCRPS
-    # other kwargs
-    scalars: ['variable']
-    ignore_nans: False
-    alpha: 1.0
-
-  validation_metrics:
-    # loss class to initialise, can be anything subclassing torch.nn.Module
-    - _target_: anemoi.training.losses.AlmostFairKernelCRPS
-      scalars: []
-      ignore_nans: False
-      alpha: 0.95
-    - _target_: anemoi.training.losses.AlmostFairKernelCRPS
-      scalars: []
-      ignore_nans: False
-      alpha: 1.0

--- a/training/src/anemoi/training/config/debug_ens.yaml
+++ b/training/src/anemoi/training/config/debug_ens.yaml
@@ -9,7 +9,7 @@ defaults:
 - training: ensemble
 - _self_
 
-config_validation: False
+config_validation: True
 
 ### This file is for local experimentation.
 ##  When you commit your changes, assign the new features and keywords

--- a/training/src/anemoi/training/config/training/ensemble.yaml
+++ b/training/src/anemoi/training/config/training/ensemble.yaml
@@ -1,0 +1,128 @@
+---
+defaults:
+  - scalers: global
+
+# resume or fork a training from a checkpoint last.ckpt or specified in hardware.files.warm_start
+run_id: null
+fork_run_id: null
+transfer_learning: False # activate to perform transfer learning
+load_weights_only: False # only load model weights, do not restore optimiser states etc.
+
+# run in deterministic mode ; slows down
+deterministic: False
+
+# miscellaneous
+precision: 16-mixed
+
+# multistep input
+# 1 = single step scheme, X(t-1) used to predict X(t)
+# k > 1: multistep scheme, uses [X(t-k), X(t-k+1), ... X(t-1)] to predict X(t)
+# Deepmind use k = 2 in their model
+multistep_input: 2
+
+# gradient accumulation across K batches, K >= 1 (if K == 1 then no accumulation)
+# the effective batch size becomes num-devices * batch_size * k
+accum_grad_batches: 1
+
+num_sanity_val_steps: 6
+
+# clipp gradients, 0 : don't clip, default algorithm: norm, alternative: value
+gradient_clip:
+  val: 32.
+  algorithm: value
+
+# stochastic weight averaging
+# https://pytorch.org/blog/stochastic-weight-averaging-in-pytorch/
+swa:
+  enabled: False
+  lr: 1.e-4
+
+# Optimizer settings
+optimizer:
+  zero: False # use ZeroRedundancyOptimizer ; saves memory for larger models
+  kwargs:
+    betas: [0.9, 0.95]
+
+# select model
+model_task: anemoi.training.train.forecaster.GraphEnsForecaster
+
+# number of ensemble members per device
+ensemble_size_per_device: 4
+
+# select strategy
+strategy:
+  _target_: anemoi.training.distributed.strategy.DDPEnsGroupStrategy
+  num_gpus_per_ensemble: ${hardware.num_gpus_per_ensemble}
+  num_gpus_per_model: ${hardware.num_gpus_per_model}
+  read_group_size: ${dataloader.read_group_size}
+
+
+# loss functions
+
+# dynamic rescaling of the loss gradient
+# see https://arxiv.org/pdf/2306.06079.pdf, section 4.3.2
+# don't enable this by default until it's been tested and proven beneficial
+loss_gradient_scaling: False
+
+# loss function for the model
+training_loss:
+  # loss class to initialise, can be anything subclassing torch.nn.Module
+  _target_: anemoi.training.losses.AlmostFairKernelCRPS
+  # Scalers to include in loss calculation
+  # A selection of available scalers are listed in training/scalers.
+  # '*' is a valid entry to use all `scalers` given, if a scaler is to be excluded
+  # add `!scaler_name`, i.e. ['*', '!scaler_1'], and `scaler_1` will not be added.
+  scalers: ['pressure_level', 'general_variable', 'nan_mask_weights', 'node_weights']
+  # other kwargs
+  ignore_nans: False
+  alpha: 1.0
+
+# Validation metrics calculation,
+# This may be a list, in which case all metrics will be calculated
+# and logged according to their name.
+# These metrics are calculated in the output model space, and thus
+# have undergone postprocessing.
+validation_metrics:
+  # loss class to initialise, can be anything subclassing torch.nn.Module
+  fkcrps:
+    _target_: anemoi.training.losses.AlmostFairKernelCRPS
+    scalers: []
+    ignore_nans: False
+    alpha: 1.0
+
+# Variable groups definition for scaling by variable level.
+# The variable level scaling methods are defined under training/scalers
+# A default group is required and is appended as prefix to the metric of all variables not assigned to a group.
+variable_groups:
+  default: sfc
+  pl: [q, t, u, v, w, z]
+
+metrics:
+- z_500
+- t_850
+- u_850
+- v_850
+
+# length of the "rollout" window (see Keisler's paper)
+rollout:
+  start: 1
+  # increase rollout every n epochs
+  epoch_increment: 0
+  # maximum rollout to use
+  max: 1
+
+# Set max_epochs or max_steps. Training stops at the first limit reached.
+max_epochs: null
+max_steps: 150000
+
+lr:
+  warmup: 1000 # number of warmup iterations
+  rate: 0.625e-4 #local_lr
+  iterations: ${training.max_steps} # NOTE: When max_epochs < max_steps, scheduler will run for max_steps
+  min: 3e-7 #Not scaled by #GPU
+
+# Changes in per-gpu batch_size should come with a rescaling of the local_lr
+# in order to keep a constant global_lr
+# global_lr = local_lr * num_gpus_per_node * num_nodes / gpus_per_model
+
+submodules_to_freeze: []


### PR DESCRIPTION
## Description

The default configs for the ensemble training were not working with the new loss refactor. This PR creates a `config/training/ensemble.yaml` that sets default values for training with ensemble members.

A new `ensemble.yaml` file was required because the `default.yaml` would set `mse` as a `training.validation_metrics`, which can be extended by other metrics but cannot be fully overwritten (mse would always be part of the validation_metrics). The MSE metric, however, is not compatible with the `GraphEnsForecaster` model. 

## Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)

## Code Compatibility

-   [x] I have performed a self-review of my code

### Code Performance and Testing

-   [x] I have tested the changes on a single GPU
-   [x] I have tested the changes on multiple GPUs / multi-node setups
-   [x] I have tested inference on a trained model

### Dependencies

-   [x] I have not introduced new dependencies in the inference portion of the pipeline
