### PR TITLE
fix(training): no logging variable metadata to mlflow

### DIFF
--- a/training/src/anemoi/training/diagnostics/mlflow/utils.py
+++ b/training/src/anemoi/training/diagnostics/mlflow/utils.py
@@ -150,6 +150,7 @@ def clean_config_params(params: dict[str, Any]) -> dict[str, Any]:
         "config.dataset.sourcesmetadata.dataset.variables_metadata",
         "metadata.dataset.sources",
         "metadata.dataset.specific",
+        "metadata.dataset.variables_metadata",
     ]
 
     keys_to_remove = [key for key in params if any(key.startswith(prefix) for prefix in prefixes_to_remove)]


### PR DESCRIPTION
## Description

Reduce the number of parameters logged to increase MLflow spread.
Recently, the metadata of the variables has been increased in size and information. Not all this information needs to be logged to mllfow, where it reduces the speed.

## Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update

## Issue Number


## Code Compatibility

-   [x] I have performed a self-review of my code

### Code Performance and Testing

-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I ran the [complete Pytest test](https://anemoi.readthedocs.io/projects/training/en/latest/dev/testing.html) suite locally, and they pass
-   [ ] I have tested the changes on a single GPU
-   [ ] I have tested the changes on multiple GPUs / multi-node setups
-   [ ] I have run the Benchmark Profiler against the old version of the code
-   [ ] If the new feature introduces modifications at the config level, I have made sure to update Pydantic Schemas and default configs accordingly


### Dependencies

-   [ ] I have ensured that the code is still pip-installable after the changes and runs
-   [ ] I have tested that new dependencies themselves are pip-installable.
-   [ ] I have not introduced new dependencies in the inference portion of the pipeline


### Documentation

-   [ ] My code follows the style guidelines of this project
-   [ ] I have updated the documentation and docstrings to reflect the changes
-   [ ] I have added comments to my code, particularly in hard-to-understand areas



## Additional Notes


