### PR TITLE
ci: only run notify-team step on cron jobs in integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -20,7 +20,7 @@ jobs:
 
   notify-team:
     needs: integration_tests
-    if: failure()
+    if: failure() && github.event_name == 'schedule'
     runs-on: ubuntu-latest
     steps:
       - name: Add failure comment


### PR DESCRIPTION
## Description
Only run the notify-team step on cron jobs in the integration tests workflow. For manually triggered tests on branches the AnemoiSecurity group doesn't need to be notified. The default notification (to the person who triggered the workflow) is enough.