### PR TITLE
fix(training): kcrps losses handling NaNs for validation

### DIFF
--- a/training/src/anemoi/training/losses/kcrps.py
+++ b/training/src/anemoi/training/losses/kcrps.py
@@ -57,7 +57,7 @@ class KernelCRPS(BaseLoss):
             The point-wise kernel CRPS, shape (batch_size, 1, latlon).
         """
         ens_size = preds.shape[-1]
-        mae = torch.mean(torch.abs(targets[..., None] - preds), dim=-1)
+        mae = self.avg_function(torch.abs(targets[..., None] - preds), dim=-1)
 
         assert ens_size > 1, "Ensemble size must be greater than 1."
 
@@ -65,7 +65,7 @@ class KernelCRPS(BaseLoss):
 
         ens_var = torch.zeros(size=preds.shape[:-1], device=preds.device)
         for i in range(ens_size):  # loop version to reduce memory usage
-            ens_var += torch.sum(torch.abs(preds[..., i].unsqueeze(-1) - preds[..., i + 1 :]), dim=-1)
+            ens_var += self.sum_function(torch.abs(preds[..., i].unsqueeze(-1) - preds[..., i + 1 :]), dim=-1)
         ens_var = coef * ens_var
 
         return mae + ens_var
@@ -167,7 +167,7 @@ class AlmostFairKernelCRPS(BaseLoss):
         assert ens_size > 1, "Ensemble size must be greater than 1."
 
         coef = 1.0 / (2.0 * ens_size * (ens_size - 1))
-        return coef * torch.sum(mem_err + mem_err_transpose - (1 - epsilon) * var, dim=(-1, -2))
+        return coef * self.sum_function(mem_err + mem_err_transpose - (1 - epsilon) * var, dim=(-1, -2))
 
     def forward(
         self,


### PR DESCRIPTION
## Description

All our losses have the option `ignore_nans` as we want to ignore NaN fields if the losses are used as validation metrics. 
This option is still missing for the kcrps losses. 

Instead of using `torch.sum` and `torch.mean` use the sum and avg functions of the loss class to allow or not allow NaNs depending on what has been selected in the config file.

## Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update

## Issue Number

## Code Compatibility

-   [x] I have performed a self-review of my code

### Code Performance and Testing

-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I ran the [complete Pytest test](https://anemoi.readthedocs.io/projects/training/en/latest/dev/testing.html) suite locally, and they pass
-   [ ] I have tested the changes on a single GPU
-   [ ] I have tested the changes on multiple GPUs / multi-node setups
-   [ ] I have run the Benchmark Profiler against the old version of the code
-   [ ] If the new feature introduces modifications at the config level, I have made sure to update Pydantic Schemas and default configs accordingly

### Dependencies

-   [ ] I have ensured that the code is still pip-installable after the changes and runs
-   [ ] I have tested that new dependencies themselves are pip-installable.
-   [ ] I have not introduced new dependencies in the inference portion of the pipeline


### Documentation

-   [ ] My code follows the style guidelines of this project
-   [ ] I have updated the documentation and docstrings to reflect the changes
-   [ ] I have added comments to my code, particularly in hard-to-understand areas


## Additional Notes


