### PR TITLE
fix: Move scaler to device in scale

### DIFF
--- a/training/src/anemoi/training/losses/base.py
+++ b/training/src/anemoi/training/losses/base.py
@@ -96,6 +96,8 @@ class BaseLoss(nn.Module, ABC):
         if len(self.scaler) == 0:
             return x[subset_indices]
 
+        self.scaler.to(x.device)
+
         scale_tensor = self.scaler
         if without_scalers is not None and len(without_scalers) > 0:
             if isinstance(without_scalers[0], str):
@@ -103,9 +105,9 @@ class BaseLoss(nn.Module, ABC):
             else:
                 scale_tensor = self.scaler.without_by_dim(without_scalers)
 
-        scaler = scale_tensor.get_scaler(x.ndim).to(x)
-
+        scaler = scale_tensor.get_scaler(x.ndim)
         scaler = scaler.expand_as(x)
+
         return x[subset_indices] * scaler[subset_indices]
 
     def reduce(self, out: torch.Tensor, squash: bool = True) -> torch.Tensor:

--- a/training/src/anemoi/training/losses/scaler_tensor.py
+++ b/training/src/anemoi/training/losses/scaler_tensor.py
@@ -74,7 +74,6 @@ class Shape:
         return self.func(dimension)
 
 
-# TODO(Harrison Cook): Consider moving this to subclass from a pytorch object and allow for device moving completely
 class ScaleTensor:
     """Dynamically resolved tensor scaling class.
 


### PR DESCRIPTION
## Description

The Loss Scaler was being moved from the cpu to the gpu every loss calculation.

When running with o96 on 1 GPU on ATOS the it/s changes from 3.10 -> 3.65.

## Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update

### Code Performance and Testing

-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I ran the [complete Pytest test](https://anemoi.readthedocs.io/projects/training/en/latest/dev/testing.html) suite locally, and they pass
-   [x] I have tested the changes on a single GPU
-   [x] I have tested the changes on multiple GPUs / multi-node setups
-   [x] I have run the Benchmark Profiler against the old version of the code


<!-- In case this affects the model sharding or other specific components please describe these here. -->
