### PR TITLE
feat: Log variable scaling in mlflow

### DIFF
--- a/training/src/anemoi/training/losses/utils.py
+++ b/training/src/anemoi/training/losses/utils.py
@@ -8,18 +8,23 @@
 # nor does it submit to any jurisdiction.
 
 
-import logging
+from __future__ import annotations
 
-from anemoi.models.data_indices.collection import IndexCollection
-from anemoi.training.losses.base import BaseLoss
+import logging
+from typing import TYPE_CHECKING
+
 from anemoi.training.utils.enums import TensorDim
+
+if TYPE_CHECKING:
+    from anemoi.models.data_indices.collection import IndexCollection
+    from anemoi.training.losses.base import BaseLoss
 
 LOGGER = logging.getLogger(__name__)
 
 
-def print_variable_scaling(loss: BaseLoss, data_indices: IndexCollection) -> None:
+def print_variable_scaling(loss: BaseLoss, data_indices: IndexCollection) -> dict[str, float]:
     """
-    Log the final variable scaling for each variable in the model.
+    Log the final variable scaling for each variable in the model and return the scaling values.
 
     Parameters
     ----------
@@ -27,9 +32,20 @@ def print_variable_scaling(loss: BaseLoss, data_indices: IndexCollection) -> Non
         Loss function to get the variable scaling from.
     data_indices : IndexCollection
         Index collection to get the variable names from.
+
+    Returns
+    -------
+    Dict[str, float]
+        Dictionary mapping variable names to their scaling values.
     """
     variable_scaling = loss.scaler.subset_by_dim(TensorDim.VARIABLE.value).get_scaler(len(TensorDim)).squeeze()
     log_text = "Final Variable Scaling: "
+    scaling_values = {}
+
     for idx, name in enumerate(data_indices.internal_model.output.name_to_index.keys()):
-        log_text += f"{name}: {variable_scaling[idx]:.4g}, "
+        value = float(variable_scaling[idx])
+        log_text += f"{name}: {value:.4g}, "
+        scaling_values[name] = value
+
     LOGGER.debug(log_text)
+    return scaling_values


### PR DESCRIPTION
## Description

The variable scaling of the loss function is not trivial anymore since many scalers can be multiplied. To keep track of that, the final variable scaling is logged to mlfow hyperparameters (see image) 

![image](https://github.com/user-attachments/assets/1450c624-9038-441c-9923-5c61bd770120)

## Type of Change

-   [x] New feature (non-breaking change which adds functionality)


## Code Compatibility

-   [x] I have performed a self-review of my code

### Code Performance and Testing

-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I ran the [complete Pytest test](https://anemoi.readthedocs.io/projects/training/en/latest/dev/testing.html) suite locally, and they pass
-   [x] I have tested the changes on a single GPU
-   [x] I have tested the changes on multiple GPUs / multi-node setups
-   [ ] I have run the Benchmark Profiler against the old version of the code


### Documentation

-   [x] My code follows the style guidelines of this project
-   [ ] I have added comments to my code, particularly in hard-to-understand areas
