### PR TITLE
add test for lam training with existing graph

### DIFF
--- a/training/tests/integration/config/test_lam.yaml
+++ b/training/tests/integration/config/test_lam.yaml
@@ -18,6 +18,8 @@ hardware:
   files:
     dataset: anemoi-integration-tests/regional-use-cases/cerra-rr-an-oper-0001-mars-5p5km-2017-2017-6h-v3-testing.zarr
     forcing_dataset: anemoi-integration-tests/regional-use-cases/aifs-ea-an-oper-0001-mars-o96-2017-2017-6h-v8-testing.zarr
+    # We only use the graph file in test_training_cycle_lam_with_existing_graph, not in test_training_cycle_lam
+    graph: anemoi-integration-tests/regional-use-cases/lam-graph.pt
 
 # need this modification since some variables set in the default zarr config are not part of the dataset
 data:

--- a/training/tests/integration/conftest.py
+++ b/training/tests/integration/conftest.py
@@ -17,6 +17,7 @@ from hydra import initialize
 from omegaconf import OmegaConf
 
 from anemoi.utils.testing import get_test_archive
+from anemoi.utils.testing import get_test_data
 
 
 @pytest.fixture(autouse=True)
@@ -140,6 +141,19 @@ def lam_config_with_data(testing_modifications_with_temp_dir: OmegaConf) -> Omeg
     cfg = OmegaConf.merge(template, testing_modifications_with_temp_dir, use_case_modifications)
     OmegaConf.resolve(cfg)
     return cfg
+
+
+@pytest.fixture
+def lam_config_with_data_and_graph(lam_config_with_data: OmegaConf) -> OmegaConf:
+    existing_graph_config = OmegaConf.load(Path.cwd() / "training/src/anemoi/training/config/graph/existing.yaml")
+    lam_config_with_data.graph = existing_graph_config
+
+    url_graph = lam_config_with_data.hardware.files["graph"]
+    tmp_path_graph = get_test_data(url_graph)
+    lam_config_with_data.hardware.paths.graph = Path(tmp_path_graph).parent
+    lam_config_with_data.hardware.files.graph = Path(tmp_path_graph).name
+
+    return lam_config_with_data
 
 
 @pytest.fixture

--- a/training/tests/integration/test_training_cycle.py
+++ b/training/tests/integration/test_training_cycle.py
@@ -50,6 +50,12 @@ def test_training_cycle_lam(lam_config_with_data: DictConfig) -> None:
     AnemoiTrainer(lam_config_with_data).train()
 
 
+@skip_if_offline
+@pytest.mark.longtests
+def test_training_cycle_lam_with_existing_graph(lam_config_with_data_and_graph: DictConfig) -> None:
+    AnemoiTrainer(lam_config_with_data_and_graph).train()
+
+
 def test_config_validation_lam(lam_config: DictConfig) -> None:
     BaseSchema(**lam_config)
 


### PR DESCRIPTION
## Description
This adds an integration tests in training to run a test cycle with a lam grid and an existing graph.

## What problem does this change solve?
We test if training works when loading a graph from disk. This is a feature used often for lam/stretched grid use cases.

## What issue or task does this change relate to?
Integration tests for training

##  Additional notes ##
We are looking into a better testing configuration for the graphs used in lam/stretched grids separately. This is just to test the functionality of loading a graph during training.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***
