### PR TITLE
test: add training cycle test without config validation

### DIFF
--- a/training/tests/integration/test_training_cycle.py
+++ b/training/tests/integration/test_training_cycle.py
@@ -36,6 +36,14 @@ def test_config_validation_architecture_configs(architecture_config: DictConfig)
 
 @skip_if_offline
 @pytest.mark.longtests
+def test_training_cycle_without_config_validation(gnn_config_with_data: DictConfig) -> None:
+    gnn_config_with_data.config_validation = False
+    gnn_config_with_data.hardware.files.graph = "dummpy.pt"  # Mandatory input when running without config validation
+    AnemoiTrainer(gnn_config_with_data).train()
+
+
+@skip_if_offline
+@pytest.mark.longtests
 def test_training_cycle_stretched(stretched_config_with_data: DictConfig) -> None:
     AnemoiTrainer(stretched_config_with_data).train()
 


### PR DESCRIPTION
## Description
Add a training cycle test to test if training with the basic global config works when running without config validation.

## What problem does this change solve?
All other integration tests in training use config validation. This is just to test one use case without config validation as we still provide this option.

## What issue or task does this change relate to?
Integration tests in training

##  Additional notes ##

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***
