### PR TITLE
fix(graphs): move libraries to optional dependencies

### DIFF
--- a/graphs/pyproject.toml
+++ b/graphs/pyproject.toml
@@ -40,10 +40,7 @@ classifiers = [
 
 dynamic = [ "version" ]
 dependencies = [
-  "anemoi-datasets>=0.5.21",
   "anemoi-utils>=0.4.11",
-  "h3>=3.7.7,<4",
-  "healpy>=1.17",
   "hydra-core>=1.3",
   "matplotlib>=3.6",
   "netcdf4>1.7",
@@ -53,11 +50,17 @@ dependencies = [
   "scikit-learn>=1.5",
   "torch>=2.2",
   "torch-geometric>=2.3.1",
-  "trimesh>=4.1",
   "typeguard>=4",
 ]
 
-optional-dependencies.all = [  ]
+optional-dependencies.extra = [
+  "anemoi-datasets>=0.5.21",
+  "h3>=3.7.7,<4",
+  "healpy>=1.17", 
+  "trimesh>=4.1",
+]
+
+optional-dependencies.all = [ "anemoi-graphs[extra]" ]
 optional-dependencies.dev = [ "anemoi-graphs[docs,tests]" ]
 
 optional-dependencies.docs = [

--- a/graphs/src/anemoi/graphs/nodes/attributes/masks.py
+++ b/graphs/src/anemoi/graphs/nodes/attributes/masks.py
@@ -15,7 +15,6 @@ import numpy as np
 import torch
 from torch_geometric.data.storage import NodeStorage
 
-from anemoi.datasets import open_dataset
 from anemoi.graphs.nodes.attributes.base_attributes import BooleanBaseNodeAttribute
 
 LOGGER = logging.getLogger(__name__)
@@ -42,6 +41,8 @@ class NonmissingAnemoiDatasetVariable(BooleanBaseNodeAttribute):
         self.variable = variable
 
     def get_raw_values(self, nodes: NodeStorage, **kwargs) -> torch.Tensor:
+        from anemoi.datasets import open_dataset
+
         assert nodes["node_type"] in [
             "ZarrDatasetNodes",
             "AnemoiDatasetNodes",
@@ -54,6 +55,8 @@ class CutOutMask(BooleanBaseNodeAttribute):
     """Cut out mask."""
 
     def get_raw_values(self, nodes: NodeStorage, **kwargs) -> torch.Tensor:
+        from anemoi.datasets import open_dataset
+
         assert "_dataset" in nodes and isinstance(
             nodes["_dataset"], dict
         ), "The '_dataset' attribute must be a dictionary."

--- a/graphs/src/anemoi/graphs/nodes/builders/from_file.py
+++ b/graphs/src/anemoi/graphs/nodes/builders/from_file.py
@@ -18,7 +18,6 @@ from omegaconf import DictConfig
 from omegaconf import OmegaConf
 from torch_geometric.data import HeteroData
 
-from anemoi.datasets import open_dataset
 from anemoi.graphs.generate.masks import KNNAreaMaskBuilder
 from anemoi.graphs.nodes.builders.base import BaseNodeBuilder
 
@@ -59,6 +58,8 @@ class AnemoiDatasetNodes(BaseNodeBuilder):
         torch.Tensor of shape (num_nodes, 2)
             A 2D tensor with the coordinates, in radians.
         """
+        from anemoi.datasets import open_dataset
+
         dataset = open_dataset(self.dataset)
         return self.reshape_coords(dataset.latitudes, dataset.longitudes)
 

--- a/graphs/src/anemoi/graphs/nodes/builders/from_refined_icosahedron.py
+++ b/graphs/src/anemoi/graphs/nodes/builders/from_refined_icosahedron.py
@@ -18,10 +18,7 @@ import numpy as np
 import torch
 from torch_geometric.data import HeteroData
 
-from anemoi.graphs.generate.hex_icosahedron import create_hex_nodes
 from anemoi.graphs.generate.masks import KNNAreaMaskBuilder
-from anemoi.graphs.generate.tri_icosahedron import create_stretched_tri_nodes
-from anemoi.graphs.generate.tri_icosahedron import create_tri_nodes
 from anemoi.graphs.nodes.builders.base import BaseNodeBuilder
 
 LOGGER = logging.getLogger(__name__)
@@ -107,6 +104,8 @@ class TriNodes(IcosahedralNodes):
     multi_scale_edge_cls: str = "anemoi.graphs.generate.multi_scale_edges.TriNodesEdgeBuilder"
 
     def create_nodes(self) -> tuple[nx.Graph, np.ndarray, list[int]]:
+        from anemoi.graphs.generate.tri_icosahedron import create_tri_nodes
+        
         return create_tri_nodes(resolution=max(self.resolutions))
 
 
@@ -119,6 +118,8 @@ class HexNodes(IcosahedralNodes):
     multi_scale_edge_cls: str = "anemoi.graphs.generate.multi_scale_edges.HexNodesEdgeBuilder"
 
     def create_nodes(self) -> tuple[nx.Graph, np.ndarray, list[int]]:
+        from anemoi.graphs.generate.hex_icosahedron import create_hex_nodes
+
         return create_hex_nodes(resolution=max(self.resolutions))
 
 
@@ -136,6 +137,8 @@ class LimitedAreaTriNodes(LimitedAreaIcosahedralNodes):
     multi_scale_edge_cls: str = "anemoi.graphs.generate.multi_scale_edges.TriNodesEdgeBuilder"
 
     def create_nodes(self) -> tuple[nx.Graph, np.ndarray, list[int]]:
+        from anemoi.graphs.generate.tri_icosahedron import create_tri_nodes
+        
         return create_tri_nodes(resolution=max(self.resolutions), area_mask_builder=self.area_mask_builder)
 
 
@@ -153,6 +156,8 @@ class LimitedAreaHexNodes(LimitedAreaIcosahedralNodes):
     multi_scale_edge_cls: str = "anemoi.graphs.generate.multi_scale_edges.HexNodesEdgeBuilder"
 
     def create_nodes(self) -> tuple[nx.Graph, np.ndarray, list[int]]:
+        from anemoi.graphs.generate.hex_icosahedron import create_hex_nodes
+
         return create_hex_nodes(resolution=max(self.resolutions), area_mask_builder=self.area_mask_builder)
 
 
@@ -196,6 +201,8 @@ class StretchedTriNodes(StretchedIcosahedronNodes):
     multi_scale_edge_cls: str = "anemoi.graphs.generate.multi_scale_edges.StretchedTriNodesEdgeBuilder"
 
     def create_nodes(self) -> tuple[nx.Graph, np.ndarray, list[int]]:
+        from anemoi.graphs.generate.tri_icosahedron import create_stretched_tri_nodes
+        
         return create_stretched_tri_nodes(
             base_resolution=self.global_resolution,
             lam_resolution=max(self.resolutions),


### PR DESCRIPTION
## Description
<!-- What issue or task does this change relate to? -->
This PR moves some dependencies to optional.

## What problem does this change solve?
<!-- Describe if it's a bugfix, new feature, doc update, or breaking change -->
Some users are experiencing issues when installing `h3` via `pip install anemoi-graphs`. This is an optional library that is only used with `HexNodes`. We are moving this and other libraries to the optional dependencies __extra__ category.

## What issue or task does this change relate to?
<!-- link to Issue Number -->
#331 

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those, please refer to https://anemoi.readthedocs.io/en/latest/***
