### PR TITLE
fix(graphs): fix device mismatch error

### DIFF
--- a/graphs/src/anemoi/graphs/nodes/attributes/area_weights.py
+++ b/graphs/src/anemoi/graphs/nodes/attributes/area_weights.py
@@ -214,7 +214,7 @@ class MaskedPlanarAreaWeights(PlanarAreaWeights):
     def get_raw_values(self, nodes: NodeStorage, **kwargs) -> torch.Tensor:
         assert self.mask_node_attr_name in nodes, f"Node attribute '{self.mask_node_attr_name}' not found in nodes."
         attr_values = super().get_raw_values(nodes, **kwargs)
-        mask = nodes[self.mask_node_attr_name].squeeze()
+        mask = nodes[self.mask_node_attr_name].squeeze().to(self.device)
         return attr_values * mask
 
 


### PR DESCRIPTION
## Description
<!-- What issue or task does this change relate to? -->
This PR resolves an issue with mismatches between different devices that was raised during integration tests using the GPU.

## What problem does this change solve?
<!-- Describe if it's a bugfix, new feature, doc update, or breaking change -->
Error trace raised by the integration tests.
```
    def get_raw_values(self, nodes: NodeStorage, **kwargs) -> torch.Tensor:
        assert self.mask_node_attr_name in nodes, f"Node attribute '{self.mask_node_attr_name}' not found in nodes."
        attr_values = super().get_raw_values(nodes, **kwargs)
        mask = nodes[self.mask_node_attr_name].squeeze()
>       return attr_values * mask
E       RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!
```
## What issue or task does this change relate to?
<!-- link to Issue Number -->
No issue created

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***
