### PR TITLE
ci: add notify team step to hpc workflow

### DIFF
--- a/.github/workflows/integration-tests-hpc.yml
+++ b/.github/workflows/integration-tests-hpc.yml
@@ -41,7 +41,7 @@ jobs:
             source .venv/bin/activate
             pip install --upgrade pip
             pip install -e ./training[all,tests] -e ./models[all,tests] -e ./graphs[all,tests]
-            python3 -m pytest training/tests/integration --longtests
+            python3 -m pytest -v training/tests/integration --longtests
             deactivate
             rm -rf $REPO_NAME
           sbatch_options: |

--- a/.github/workflows/integration-tests-hpc.yml
+++ b/.github/workflows/integration-tests-hpc.yml
@@ -52,3 +52,22 @@ jobs:
             #SBATCH --gres=gpu:1
             #SBATCH --mem=16G
           troika_user: ${{ secrets.HPC_CI_INTEGRATION_USER }}
+
+  notify-team:
+    needs: integration-tests
+    if: failure() && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add failure comment
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          issue-number: 294
+          body: |
+            ## 🚨 Nightly Job Failed
+
+            **Repository:** ${{ github.repository }}
+            **Workflow:** ${{ github.workflow }}
+            **Run URL:** [View logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+            **Time:** ${{ github.event.schedule }}
+
+            cc: @ecmwf/anemoisecurity


### PR DESCRIPTION
## Description
This PR changes the ci workflow for integration tests on the hpc.
 - It adds a notify-team step, as for the integration test workflow on github runners, to notify the AnemoiSecurity group if tests fail -- currently only the person who set up the cron job gets a notification.
 - It makes the pytest output more verbose.