### PR TITLE
feat!: Explicit weight initialization.

### DIFF
--- a/models/src/anemoi/models/layers/mapper.py
+++ b/models/src/anemoi/models/layers/mapper.py
@@ -402,7 +402,6 @@ class GraphTransformerBackwardMapper(BackwardMapperPostProcessMixin, GraphTransf
         src_grid_size: int,
         dst_grid_size: int,
         qk_norm: bool = False,
-        initialise_data_extractor_zero: bool = False,
         cpu_offload: bool = False,
         layer_kernels: DotDict = None,
     ) -> None:
@@ -434,8 +433,6 @@ class GraphTransformerBackwardMapper(BackwardMapperPostProcessMixin, GraphTransf
             Source grid size
         dst_grid_size : int
             Destination grid size
-        initialise_data_extractor_zero : bool, default False:
-            Whether to initialise the data extractor to zero
         qk_norm : bool, optional
             Whether to use query and key normalization, default False
         cpu_offload : bool, optional
@@ -465,12 +462,6 @@ class GraphTransformerBackwardMapper(BackwardMapperPostProcessMixin, GraphTransf
         self.node_data_extractor = nn.Sequential(
             nn.LayerNorm(self.hidden_dim), nn.Linear(self.hidden_dim, self.out_channels_dst)
         )
-        if initialise_data_extractor_zero:
-            for module in self.node_data_extractor.modules():
-                if isinstance(module, nn.Linear):
-                    nn.init.constant_(module.weight, 0.0)
-                    if module.bias is not None:
-                        nn.init.constant_(module.bias, 0.0)
 
     def pre_process(self, x, shard_shapes, model_comm_group=None):
         x_src, x_dst, shapes_src, shapes_dst = super().pre_process(x, shard_shapes, model_comm_group)

--- a/models/src/anemoi/models/schemas/decoder.py
+++ b/models/src/anemoi/models/schemas/decoder.py
@@ -32,8 +32,6 @@ class GraphTransformerDecoderSchema(TransformerModelComponent):
     "Edge attributes to consider in the decoder features. Default to [edge_length, edge_dirs]"
     qk_norm: bool = Field(example=False)
     "Normalize the query and key vectors. Default to False."
-    initialise_data_extractor_zero: bool = Field(example=False)
-    "Initialise the data extractor with zeros. Default to False."
 
 
 class TransformerDecoderSchema(TransformerModelComponent):

--- a/training/src/anemoi/training/config/model/gnn.yaml
+++ b/training/src/anemoi/training/config/model/gnn.yaml
@@ -53,6 +53,12 @@ trainable_parameters:
   hidden2data: 8
   hidden2hidden: 8
 
+# Weight initialization
+custom_weight_initialization: null
+  # Zero initialization for specific modules can be specified as a list of module paths
+  # zero:
+  #   - "decoder.node_data_extractor" # Do not use zero initialization of the last layer with boundings
+
 attributes:
   edges:
   - edge_length

--- a/training/src/anemoi/training/config/model/gnn_ens.yaml
+++ b/training/src/anemoi/training/config/model/gnn_ens.yaml
@@ -70,6 +70,12 @@ trainable_parameters:
   hidden2data: 8
   hidden2hidden: 8
 
+# Weight initialization
+custom_weight_initialization: null
+  # Zero initialization for specific modules can be specified as a list of module paths
+  # zero:
+  #   - "decoder.node_data_extractor" # Do not use zero initialization of the last layer with boundings
+
 
 output_mask:
   _target_: anemoi.training.utils.masks.NoOutputMask

--- a/training/src/anemoi/training/config/model/graphtransformer.yaml
+++ b/training/src/anemoi/training/config/model/graphtransformer.yaml
@@ -50,7 +50,6 @@ decoder:
   num_chunks: 1
   mlp_hidden_ratio: 4 # GraphTransformer or Transformer only
   num_heads: 16 # GraphTransformer or Transformer only
-  initialise_data_extractor_zero: False
   qk_norm: False
   cpu_offload: ${model.cpu_offload}
   layer_kernels: ${model.layer_kernels}
@@ -64,6 +63,12 @@ trainable_parameters:
   data2hidden: 8
   hidden2data: 8
   hidden2hidden: 8 # GNN and GraphTransformer Processor only
+
+# Weight initialization
+custom_weight_initialization: null
+  # Zero initialization for specific modules can be specified as a list of module paths
+  # zero:
+  #   - "decoder.node_data_extractor" # Do not use zero initialization of the last layer with boundings
 
 
 attributes:

--- a/training/src/anemoi/training/config/model/graphtransformer_ens.yaml
+++ b/training/src/anemoi/training/config/model/graphtransformer_ens.yaml
@@ -78,7 +78,6 @@ decoder:
   num_chunks: 1
   mlp_hidden_ratio: 4 # GraphTransformer or Transformer only
   num_heads: 16 # GraphTransformer or Transformer only
-  initialise_data_extractor_zero: True
   qk_norm: False
   cpu_offload: ${model.cpu_offload}
   layer_kernels: ${model.layer_kernels}
@@ -89,6 +88,12 @@ trainable_parameters:
   data2hidden: 8
   hidden2data: 8
   hidden2hidden: 8 # GNN and GraphTransformer Processor only
+
+# Weight initialization
+custom_weight_initialization: null
+  # Zero initialization for specific modules can be specified as a list of module paths
+  # zero:
+  #   - "decoder.node_data_extractor" # Do not use zero initialization of the last layer with boundings
 
 attributes:
   edges:

--- a/training/src/anemoi/training/config/model/transformer.yaml
+++ b/training/src/anemoi/training/config/model/transformer.yaml
@@ -53,7 +53,6 @@ decoder:
   num_chunks: 1
   mlp_hidden_ratio: 4 # GraphTransformer or Transformer only
   num_heads: 16 # GraphTransformer or Transformer only
-  initialise_data_extractor_zero: False
   qk_norm: False
   cpu_offload: ${model.cpu_offload}
   layer_kernels: ${model.layer_kernels}
@@ -66,6 +65,12 @@ trainable_parameters:
   hidden: 8
   data2hidden: 8
   hidden2data: 8
+
+# Weight initialization
+custom_weight_initialization: null
+  # Zero initialization for specific modules can be specified as a list of module paths
+  # zero:
+  #   - "decoder.node_data_extractor" # Do not use zero initialization of the last layer with boundings
 
 attributes:
   edges:

--- a/training/src/anemoi/training/config/model/transformer_ens.yaml
+++ b/training/src/anemoi/training/config/model/transformer_ens.yaml
@@ -77,7 +77,6 @@ decoder:
   num_chunks: 1
   mlp_hidden_ratio: 4 # GraphTransformer or Transformer only
   num_heads: 16 # GraphTransformer or Transformer only
-  initialise_data_extractor_zero: True
   qk_norm: False
   cpu_offload: ${model.cpu_offload}
   layer_kernels: ${model.layer_kernels}
@@ -90,6 +89,12 @@ trainable_parameters:
   hidden: 8
   data2hidden: 8
   hidden2data: 8
+
+# Weight initialization
+custom_weight_initialization: null
+  # Zero initialization for specific modules can be specified as a list of module paths
+  # zero:
+  #   - "decoder.node_data_extractor" # Do not use zero initialization of the last layer with boundings
 
 
 attributes:

--- a/training/src/anemoi/training/config/model/transformer_transformermapper.yaml
+++ b/training/src/anemoi/training/config/model/transformer_transformermapper.yaml
@@ -77,6 +77,12 @@ trainable_parameters:
   data2hidden: 8
   hidden2data: 8
 
+# Weight initialization
+custom_weight_initialization: null
+  # Zero initialization for specific modules can be specified as a list of module paths
+  # zero:
+  #   - "decoder.node_data_extractor" # Do not use zero initialization of the last layer with boundings
+
 attributes:
   edges:
   - edge_length


### PR DESCRIPTION
## Description
The weight initialization is often hidden in the submodules, or torch defaults are assumed. To make this more explicit and be able to easily try other weight initialization, an `_init_weights()` function is added to the highest torch.nn.Module level.

```
class Model(nn.Module):
    def __init__(self, ...):
        ...
        self.apply(self._init_weights)

    def _init_weights(self, m):
        """Initialize weights for modules."""
        if isinstance(m, nn.Linear):
            nn.init.trunc_normal_(m.weight, std=0.02)
            if m.bias is not None:
                nn.init.constant_(m.bias, 0)
       ...
```

Examples for potential training improvement:
 - ViTs typically use truncated normal initialization e.g. https://github.com/microsoft/Swin-Transformer
- GraphAttention typically uses xavier uniform initialization (https://arxiv.org/abs/1710.10903)

## What issue or task does this change relate to?
https://github.com/ecmwf/anemoi-core/issues/346 


##  TODOs

- [x] test weight initialization for AnemoiModelEncProcDec
- [ ] test weight initialization for AnemoiEnsModelEncProcDec
- [ ] test weight initialization for AnemoiModelEncProcDecInterpolator
- [ ] test weight initialization for AnemoiModelEncProcDecHierarchical
- [ ] add tests
- [ ] try good default values  
- [ ] include`custom_weight_initializations` beyond zero initialization
