### PR TITLE
fix: config validator checks for conflict with bounding and graphtran…

### DIFF
--- a/training/src/anemoi/training/schemas/base_schema.py
+++ b/training/src/anemoi/training/schemas/base_schema.py
@@ -89,6 +89,21 @@ class BaseSchema(BaseModel):
             raise PydanticCustomError("logger_path_missing", msg)  # noqa: EM101
         return self
 
+    @model_validator(mode="after")
+    def check_bounding_not_used_with_data_extractor_zero(self) -> BaseSchema:
+        """Check that bounding is not used with zero data extractor."""
+        if (
+            self.model.decoder.target_ == "anemoi.models.layers.mapper.GraphTransformerBackwardMapper"
+            and self.model.decoder.initialise_data_extractor_zero
+            and self.model.bounding is not None
+        ):
+            error = "bounding_conflict_with_data_extractor_zero"
+            msg = "Boundings cannot be used with zero data extractor."
+            raise PydanticCustomError(
+                error,
+                msg,
+            )
+
     def model_dump(self, by_alias: bool = False) -> dict:
         dumped_model = super().model_dump(by_alias=by_alias)
         return DictConfig(dumped_model)


### PR DESCRIPTION

## Description
This PR introduces a new validator in the config to check whether the config.model.decoder.initialise_data_extractor_zero = True is not used with any bounding. 

Closes #346 

## What problem does this change solve?
This is mainly a concern for the GraphTransformer in the decoder, see issue #346.

## What issue or task does this change relate to?
<!-- link to Issue Number -->

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***
