### PR TITLE
ci: Synchronised releases

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -2,13 +2,13 @@
   "release-type": "python",
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
-  "separate-pull-requests": true,
+  "separate-pull-requests": false,
   "always-update": true,
   "changelog-type": "default",
   "include-component-in-tag": true,
   "include-v-in-tag": false,
   "draft-pull-request": true,
-  "pull-request-title-pattern": "chore${scope}: Release${component} ${version}",
+  "group-pull-request-title-pattern": "chore: Release ${branch}",
   "pull-request-header": ":robot: Automated Release PR\n\nThis PR was created by `release-please` to prepare the next release. Once merged:\n\n1. A new version tag will be created\n2. A GitHub release will be published\n3. The changelog will be updated\n\nChanges to be included in the next release:",
   "pull-request-footer": "> [!IMPORTANT]\n> Please do not change the PR title, manifest file, or any other automatically generated content in this PR unless you understand the implications. Changes here can break the release process.\n> \n> :warning: Merging this PR will:\n> - Create a new release\n> - Trigger deployment pipelines\n> - Update package versions\n\n **Before merging:**\n - Ensure all tests pass\n - Review the changelog carefully\n - Get required approvals\n\n [Release-please documentation](https://github.com/googleapis/release-please)",
   "packages": {
@@ -25,5 +25,10 @@
         "component": "models"
     }
   },
+  "plugins": [
+    {
+      "type": "sentence-case"
+    }
+  ],
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"
 }


### PR DESCRIPTION
We currently release each core package separately. At the repo level the tests ensure compatibility of the state of main, but in the case of breaking changes a person has to decide which core packages to release together so that pypi releases remain compatible.

It has happened a few times now where we released models without realising it broke the pypi version of training.

This PR turns on synchronised releases: instead of 3 PRs, there will now be 1 PR to trigger a release of all packages that have been changed. Each core package will still have its own independent version number, and it should(tm) not create a release for a package if it has not changed since the last release. 

The result will be that every pypi release mirrors the state of main at the time of release, thus ensuring compatibility between all core packages. 
