### PR TITLE
feat(graphs): Add target-centric EdgeBuilders 

### DIFF
--- a/graphs/docs/graphs/edges/cutoff.rst
+++ b/graphs/docs/graphs/edges/cutoff.rst
@@ -52,3 +52,17 @@ YAML configuration:
    will be the lowest value without isolated nodes. This optimal value
    depends on the node distribution, so it is recommended to tune it for
    each case.
+
+There is also a ReversedCutOffEdges variant that will connect each
+target node to its all source nodes within the cutoff radius, but the
+resulting edge direction is still from the source nodes to the target
+nodes.
+
+.. code:: yaml
+
+   edges:
+     -  source_name: source
+        target_name: target
+        edge_builders:
+        - _target_: anemoi.graphs.edges.ReversedCutOffEdges
+          cutoff_factor: 0.6

--- a/graphs/docs/graphs/edges/cutoff.rst
+++ b/graphs/docs/graphs/edges/cutoff.rst
@@ -54,7 +54,7 @@ YAML configuration:
    each case.
 
 There is also a ReversedCutOffEdges variant that will connect each
-target node to its all source nodes within the cutoff radius, but the
+target node to all source nodes within the cutoff radius, but the
 resulting edge direction is still from the source nodes to the target
 nodes.
 

--- a/graphs/docs/graphs/edges/knn.rst
+++ b/graphs/docs/graphs/edges/knn.rst
@@ -25,3 +25,16 @@ YAML configuration:
 
    The ``KNNEdges`` method is recommended for the decoder edges, to
    connect all target nodes with the surrounding source nodes.
+
+There is also a reversed KNN edges variant that will connect each target
+node to its k nearest source nodes, but the resulting edge direction is
+still from the source nodes to the target nodes.
+
+.. code:: yaml
+
+   edges:
+     -  source_name: source
+        target_name: target
+        edge_builders:
+        - _target_: anemoi.graphs.edges.ReversedKNNEdges
+          num_nearest_neighbours: 3 :contentReference[oaicite:5]{index=5}

--- a/graphs/src/anemoi/graphs/edges/__init__.py
+++ b/graphs/src/anemoi/graphs/edges/__init__.py
@@ -8,15 +8,19 @@
 # nor does it submit to any jurisdiction.
 
 from .builders.cutoff import CutOffEdges
+from .builders.cutoff import ReversedCutOffEdges
 from .builders.icon import ICONTopologicalDecoderEdges
 from .builders.icon import ICONTopologicalEncoderEdges
 from .builders.icon import ICONTopologicalProcessorEdges
 from .builders.knn import KNNEdges
+from .builders.knn import ReversedKNNEdges
 from .builders.multi_scale import MultiScaleEdges
 
 __all__ = [
     "KNNEdges",
     "CutOffEdges",
+    "ReversedKNNEdges",
+    "ReversedCutOffEdges",
     "MultiScaleEdges",
     "ICONTopologicalProcessorEdges",
     "ICONTopologicalEncoderEdges",

--- a/graphs/src/anemoi/graphs/edges/builders/cutoff.py
+++ b/graphs/src/anemoi/graphs/edges/builders/cutoff.py
@@ -192,3 +192,36 @@ class CutOffEdges(BaseEdgeBuilder, NodeMaskingMixin):
             edge_index = self._compute_edge_index_sklearn(source_nodes, target_nodes)
 
         return edge_index
+
+
+class ReversedCutOffEdges(CutOffEdges):
+    """
+    For each target node, this builder connects all source nodes within the cutoff_factor.
+
+    Attributes
+    ----------
+    source_name : str
+        The name of the source nodes.
+    target_name : str
+        The name of the target nodes.
+    cutoff_factor : float
+        Factor to multiply the grid reference distance to get the cut-off radius.
+    source_mask_attr_name : str | None
+        The name of the source mask attribute to filter edge connections.
+    target_mask_attr_name : str | None
+        The name of the target mask attribute to filter edge connections.
+    max_num_neighbours : int
+        The maximum number of nearest neighbours to consider when building edges.
+
+    Methods
+    -------
+    register_edges(graph)
+        Register the edges in the graph.
+    register_attributes(graph, config)
+        Register attributes in the edges of the graph.
+    update_graph(graph, attrs_config)
+        Update the graph with the edges.
+    """
+
+    def compute_edge_index(self, source_nodes: NodeStorage, target_nodes: NodeStorage) -> torch.Tensor:
+        return super().compute_edge_index(target_nodes, source_nodes)

--- a/graphs/src/anemoi/graphs/edges/builders/knn.py
+++ b/graphs/src/anemoi/graphs/edges/builders/knn.py
@@ -122,3 +122,34 @@ class KNNEdges(BaseEdgeBuilder, NodeMaskingMixin):
             edge_index = self._compute_edge_index_sklearn(source_nodes, target_nodes)
 
         return edge_index
+
+
+class ReversedKNNEdges(KNNEdges):
+    """
+    For each target node, this builder connects its K nearest neighbors among the source nodes.
+
+    Attributes
+    ----------
+    source_name : str
+        The name of the source nodes.
+    target_name : str
+        The name of the target nodes.
+    num_nearest_neighbours : int
+        Number of nearest neighbours.
+    source_mask_attr_name : str | None
+        The name of the source mask attribute to filter edge connections.
+    target_mask_attr_name : str | None
+        The name of the target mask attribute to filter edge connections.
+
+    Methods
+    -------
+    register_edges(graph)
+        Register the edges in the graph.
+    register_attributes(graph, config)
+        Register attributes in the edges of the graph.
+    update_graph(graph, attrs_config)
+        Update the graph with the edges.
+    """
+
+    def compute_edge_index(self, source_nodes: NodeStorage, target_nodes: NodeStorage) -> torch.Tensor:
+        return super().compute_edge_index(target_nodes, source_nodes)

--- a/graphs/tests/conftest.py
+++ b/graphs/tests/conftest.py
@@ -71,8 +71,8 @@ def graph_with_nodes() -> HeteroData:
 @pytest.fixture
 def graph_with_two_node_sets() -> HeteroData:
     """Graph with 12 nodes over the globe, stored in \"test_nodes\"."""
-    lats = [0, 1]
-    lons = [0, 1]
+    lats = [0, 0.25]
+    lons = [0, 0.25]
     coords1 = np.array([[lat, lon] for lat in lats for lon in lons])
     coords2 = np.array([[lat / 1000, lon / 1000] for lat in lats for lon in lons])
     graph = HeteroData()

--- a/graphs/tests/conftest.py
+++ b/graphs/tests/conftest.py
@@ -69,6 +69,21 @@ def graph_with_nodes() -> HeteroData:
 
 
 @pytest.fixture
+def graph_with_two_node_sets() -> HeteroData:
+    """Graph with 12 nodes over the globe, stored in \"test_nodes\"."""
+    lats = [0, 1]
+    lons = [0, 1]
+    coords1 = np.array([[lat, lon] for lat in lats for lon in lons])
+    coords2 = np.array([[lat / 1000, lon / 1000] for lat in lats for lon in lons])
+    graph = HeteroData()
+    graph["test_nodes1"].x = 2 * torch.pi * torch.tensor(coords1)
+    graph["test_nodes2"].x = 2 * torch.pi * torch.tensor(coords2)
+    graph["test_nodes1"]["_grid_reference_distance"] = 1
+    graph["test_nodes2"]["_grid_reference_distance"] = 1
+    return graph
+
+
+@pytest.fixture
 def graph_with_isolated_nodes() -> HeteroData:
     graph = HeteroData()
     graph["test_nodes"].x = torch.tensor([[1], [2], [3], [4], [5], [6]])

--- a/graphs/tests/edges/test_cutoff.py
+++ b/graphs/tests/edges/test_cutoff.py
@@ -39,8 +39,8 @@ def test_reversed_cutoff(graph_with_two_node_sets):
     graph = graph_with_two_node_sets
     reverse_graph = graph_with_two_node_sets.clone()
 
-    builder = CutOffEdges("test_nodes1", "test_nodes2", 0.1)
-    reverse_builder = ReversedCutOffEdges("test_nodes1", "test_nodes2", 0.1)
+    builder = CutOffEdges("test_nodes1", "test_nodes2", 0.01)
+    reverse_builder = ReversedCutOffEdges("test_nodes1", "test_nodes2", 0.01)
 
     graph = builder.update_graph(graph_with_two_node_sets)
     reverse_graph = reverse_builder.update_graph(reverse_graph)
@@ -49,9 +49,9 @@ def test_reversed_cutoff(graph_with_two_node_sets):
     reverse_edge_index = reverse_graph[("test_nodes1", "to", "test_nodes2")].edge_index
 
     # The graph is arranged so that all four nodes in “test_nodes2” lie very close to one node in “test_nodes1.”
-    # Consequently, running KNN from “test_nodes1”→“test_nodes2” will connect all four to that single “test_nodes1” node,
-    # whereas reversing the direction links them all to a single “test_nodes2” node instead.
+    # Consequently, all nodes will be connected to the same node
+
     print(edge_index)
     print(reverse_edge_index)
-    assert len(edge_index[0].unique()) == 4
-    assert len(reverse_edge_index[0].unique()) == 1
+    assert len(edge_index[0].unique()) == 1
+    assert len(reverse_edge_index[0].unique()) == 4

--- a/graphs/tests/edges/test_cutoff.py
+++ b/graphs/tests/edges/test_cutoff.py
@@ -50,8 +50,5 @@ def test_reversed_cutoff(graph_with_two_node_sets):
 
     # The graph is arranged so that all four nodes in “test_nodes2” lie very close to one node in “test_nodes1.”
     # Consequently, all nodes will be connected to the same node
-
-    print(edge_index)
-    print(reverse_edge_index)
     assert len(edge_index[0].unique()) == 1
     assert len(reverse_edge_index[0].unique()) == 4

--- a/graphs/tests/edges/test_knn.py
+++ b/graphs/tests/edges/test_knn.py
@@ -52,5 +52,3 @@ def test_reversed_knn(graph_with_two_node_sets):
     # whereas reversing the direction links them all to a single “test_nodes2” node instead.
     len(edge_index[0].unique()) == 4
     len(reverse_edge_index[0].unique()) == 1
-
-    assert edge_index[0]

--- a/graphs/tests/edges/test_knn.py
+++ b/graphs/tests/edges/test_knn.py
@@ -10,6 +10,7 @@
 import pytest
 
 from anemoi.graphs.edges import KNNEdges
+from anemoi.graphs.edges import ReversedKNNEdges
 
 
 def test_init():
@@ -29,3 +30,27 @@ def test_knn(graph_with_nodes):
     builder = KNNEdges("test_nodes", "test_nodes", 3)
     graph = builder.update_graph(graph_with_nodes)
     assert ("test_nodes", "to", "test_nodes") in graph.edge_types
+
+
+def test_reversed_knn(graph_with_two_node_sets):
+    """Test that ReversedKNNEdges actually registers an edge type in the graph."""
+
+    graph = graph_with_two_node_sets
+    reverse_graph = graph_with_two_node_sets.clone()
+
+    builder = KNNEdges("test_nodes1", "test_nodes2", 1)
+    reverse_builder = ReversedKNNEdges("test_nodes1", "test_nodes2", 1)
+
+    graph = builder.update_graph(graph_with_two_node_sets)
+    reverse_graph = reverse_builder.update_graph(reverse_graph)
+
+    edge_index = graph[("test_nodes1", "to", "test_nodes2")].edge_index
+    reverse_edge_index = reverse_graph[("test_nodes1", "to", "test_nodes2")].edge_index
+
+    # The graph is arranged so that all four nodes in “test_nodes2” lie very close to one node in “test_nodes1.”
+    # Consequently, running KNN from “test_nodes1”→“test_nodes2” will connect all four to that single “test_nodes1” node,
+    # whereas reversing the direction links them all to a single “test_nodes2” node instead.
+    len(edge_index[0].unique()) == 4
+    len(reverse_edge_index[0].unique()) == 1
+
+    assert edge_index[0]


### PR DESCRIPTION
## Description
This PR introduces support for constructing KNN and CutOffRadius edge indices using a target-centric search while preserving the edge direction from source → target. In addition to the existing KNNEdges and CutOffRadiusEdges (which search per‐source), it adds two new edge‐builder classes:

`ReversedKNNEdges`: For each target node, find its k nearest source nodes, then create edges from each of those sources into the target.

`ReversedCutOffRadiusEdges`: For each target node, find all source nodes within a given radius, then create edges from each of those sources into the target.

Both new classes have unit tests and documentation.

## What problem does this change solve?
This is a new feature that allows to build KNN and CutOffRadius edge indices based on the target nodes but still with the edge direction going from source -> target

## What issue or task does this change relate to?
Initially, we developed this feature to support research on blurred skip connections, but later discovered that a different approach would be needed for that research. Since the functionality is implemented, tested, and documented, it would be a shame to binning it. :) 


<!-- readthedocs-preview anemoi-training start -->
----
📚 Documentation preview 📚: https://anemoi-training--354.org.readthedocs.build/en/354/

<!-- readthedocs-preview anemoi-training end -->

<!-- readthedocs-preview anemoi-graphs start -->
----
📚 Documentation preview 📚: https://anemoi-graphs--354.org.readthedocs.build/en/354/

<!-- readthedocs-preview anemoi-graphs end -->

<!-- readthedocs-preview anemoi-models start -->
----
📚 Documentation preview 📚: https://anemoi-models--354.org.readthedocs.build/en/354/

<!-- readthedocs-preview anemoi-models end -->