### PR TITLE
fix: SphericalAreaWeights

### DIFF
--- a/graphs/src/anemoi/graphs/generate/transforms.py
+++ b/graphs/src/anemoi/graphs/generate/transforms.py
@@ -32,6 +32,28 @@ def cartesian_to_latlon_rad(xyz: np.ndarray) -> np.ndarray:
     return np.array((lat, lon), dtype=np.float32).transpose()
 
 
+def latlon_rad_to_cartesian_np(locations: np.ndarray, radius: float = 1) -> np.ndarray:
+    """Convert planar coordinates to 3D coordinates in a sphere.
+
+    Parameters
+    ----------
+    locations : np.ndarray of shape (N, 2)
+        The 2D coordinates of the points, in radians.
+    radius : float, optional
+        The radius of the sphere containing los points. Defaults to the unit sphere.
+
+    Returns
+    -------
+    np.ndarray of shape (N, 3)
+        3D coordinates of the points in the sphere.
+    """
+    latr, lonr = locations[..., 0], locations[..., 1]
+    x = radius * np.cos(latr) * np.cos(lonr)
+    y = radius * np.cos(latr) * np.sin(lonr)
+    z = radius * np.sin(latr)
+    return np.stack((x, y, z), axis=-1)
+
+
 def latlon_rad_to_cartesian(locations: torch.Tensor, radius: float = 1) -> torch.Tensor:
     """Convert planar coordinates to 3D coordinates in a sphere.
 

--- a/graphs/src/anemoi/graphs/nodes/attributes/area_weights.py
+++ b/graphs/src/anemoi/graphs/nodes/attributes/area_weights.py
@@ -97,7 +97,7 @@ class PlanarAreaWeights(BaseNodeAttribute):
     """
 
     def get_latlon_coordinates(self, nodes: NodeStorage) -> torch.Tensor:
-        return nodes.x
+        return nodes.x.to(torch.float64)
 
     def _compute_mean_nearest_distance(self, points: np.ndarray) -> float:
         """Compute mean distance to nearest neighbor for each point.
@@ -259,6 +259,9 @@ class SphericalAreaWeights(BaseNodeAttribute):
         self.centre = centre
         self.fill_value = fill_value
 
+    def get_latlon_coordinates(self, nodes: NodeStorage) -> torch.Tensor:
+        return nodes.x.to(torch.float64)
+
     def get_raw_values(self, nodes: NodeStorage, **kwargs) -> np.ndarray:
         """Compute the area associated to each node.
 
@@ -276,7 +279,7 @@ class SphericalAreaWeights(BaseNodeAttribute):
         np.ndarray
             Attributes.
         """
-        points = latlon_rad_to_cartesian(nodes.x.cpu())
+        points = latlon_rad_to_cartesian(self.get_latlon_coordinates(nodes).cpu())
         sv = SphericalVoronoi(points, self.radius, self.centre)
         mask = np.array([bool(i) for i in sv.regions])
         sv.regions = [region for region in sv.regions if region]

--- a/graphs/src/anemoi/graphs/nodes/attributes/area_weights.py
+++ b/graphs/src/anemoi/graphs/nodes/attributes/area_weights.py
@@ -10,6 +10,8 @@
 from __future__ import annotations
 
 import logging
+from abc import ABC
+from abc import abstractmethod
 
 import numpy as np
 import torch
@@ -18,20 +20,20 @@ from scipy.spatial import SphericalVoronoi
 from scipy.spatial import Voronoi
 from torch_geometric.data.storage import NodeStorage
 
-from anemoi.graphs.generate.transforms import latlon_rad_to_cartesian
+from anemoi.graphs.generate.transforms import latlon_rad_to_cartesian_np
 from anemoi.graphs.nodes.attributes.base_attributes import BaseNodeAttribute
 
 LOGGER = logging.getLogger(__name__)
 
 
-class UniformWeights(BaseNodeAttribute):
-    """Implements a uniform weight for the nodes.
+class BaseAreaWeights(BaseNodeAttribute, ABC):
+    """Base class for area weights of the nodes."""
 
-    Methods
-    -------
-    compute(self, graph, nodes_name)
-        Compute the area attributes for each node.
-    """
+    def get_latlon_coordinates(self, nodes: NodeStorage) -> torch.Tensor:
+        return nodes.x.to(torch.float64)
+
+    @abstractmethod
+    def compute_area_weights(self, latlons: np.ndarray) -> np.ndarray: ...
 
     def get_raw_values(self, nodes: NodeStorage, **kwargs) -> torch.Tensor:
         """Compute the weights.
@@ -46,9 +48,37 @@ class UniformWeights(BaseNodeAttribute):
         Returns
         -------
         torch.Tensor
+            Area weights for the nodes.
+        """
+        latlons = self.get_latlon_coordinates(nodes).cpu().numpy()
+        area_weights = self.compute_area_weights(latlons)
+        return torch.from_numpy(area_weights)
+
+
+class UniformWeights(BaseAreaWeights):
+    """Implements a uniform weight for the nodes.
+
+    Methods
+    -------
+    compute(self, graph, nodes_name)
+        Compute the area attributes for each node.
+    """
+
+    def compute_area_weights(self, latlons: np.ndarray) -> np.ndarray:
+        """Compute area weights.
+
+        Parameters
+        ----------
+        latlons : np.ndarray
+            2D array of shape (N, 2) with latitude and longitude coordinates of the
+            nodes of the graph.
+
+        Returns
+        -------
+        np.ndarray
             Ones.
         """
-        return torch.ones((nodes.num_nodes,))
+        return np.ones(latlons.shape[0])
 
 
 class AreaWeights(BaseNodeAttribute):
@@ -80,7 +110,7 @@ class AreaWeights(BaseNodeAttribute):
         return SphericalAreaWeights(**kwargs)
 
 
-class PlanarAreaWeights(BaseNodeAttribute):
+class PlanarAreaWeights(BaseAreaWeights):
     """Planar area weights
 
     It computes the area in a 2D plane asociated to each node.
@@ -95,9 +125,6 @@ class PlanarAreaWeights(BaseNodeAttribute):
     compute(self, graph, nodes_name)
         Compute the area attributes for each node.
     """
-
-    def get_latlon_coordinates(self, nodes: NodeStorage) -> torch.Tensor:
-        return nodes.x.to(torch.float64)
 
     def _compute_mean_nearest_distance(self, points: np.ndarray) -> float:
         """Compute mean distance to nearest neighbor for each point.
@@ -159,25 +186,37 @@ class PlanarAreaWeights(BaseNodeAttribute):
 
         return np.concatenate([expanded_hull, np.vstack(boundary_points)])
 
-    def get_raw_values(self, nodes: NodeStorage, **kwargs) -> torch.Tensor:
-        points = self.get_latlon_coordinates(nodes).cpu().numpy()
-        resolution = self._compute_mean_nearest_distance(points)
-        boundary_points = self._get_boundary_ring(points, resolution)
+    def compute_area_weights(self, latlons: np.ndarray) -> np.ndarray:
+        """Compute area weights.
+
+        Parameters
+        ----------
+        latlons : np.ndarray
+            2D array of shape (N, 2) with latitude and longitude coordinates of the
+            nodes of the graph.
+
+        Returns
+        -------
+        np.ndarray
+            Planar area weights.
+        """
+        resolution = self._compute_mean_nearest_distance(latlons)
+        boundary_points = self._get_boundary_ring(latlons, resolution)
 
         # Compute convex hull over all points (boundary ring included)
-        extended_points = np.vstack([points, boundary_points])
+        extended_points = np.vstack([latlons, boundary_points])
         v = Voronoi(extended_points, qhull_options="QJ Pp")
 
         # Compute the area of each node's region, excluding those in the boundary ring
         areas = []
-        for idx in range(len(points)):
+        for idx in range(len(latlons)):
             p_idx = v.point_region[idx]
             r = v.regions[p_idx]
             poly_coords = v.vertices[r]
             area = ConvexHull(poly_coords).volume
             areas.append(area)
 
-        return torch.from_numpy(np.array(areas))
+        return np.array(areas)
 
 
 class MaskedPlanarAreaWeights(PlanarAreaWeights):
@@ -218,7 +257,7 @@ class MaskedPlanarAreaWeights(PlanarAreaWeights):
         return attr_values * mask
 
 
-class SphericalAreaWeights(BaseNodeAttribute):
+class SphericalAreaWeights(BaseAreaWeights):
     """Spherical area weights
 
     It computes the area of a unit radius sphere asociated to each node.
@@ -259,27 +298,23 @@ class SphericalAreaWeights(BaseNodeAttribute):
         self.centre = centre
         self.fill_value = fill_value
 
-    def get_latlon_coordinates(self, nodes: NodeStorage) -> torch.Tensor:
-        return nodes.x.to(torch.float64)
-
-    def get_raw_values(self, nodes: NodeStorage, **kwargs) -> np.ndarray:
+    def compute_area_weights(self, latlons: np.ndarray) -> np.ndarray:
         """Compute the area associated to each node.
 
         It uses Voronoi diagrams to compute the area of each node.
 
         Parameters
         ----------
-        nodes : NodeStorage
-            Nodes of the graph.
-        kwargs : dict
-            Additional keyword arguments.
+        latlons : np.ndarray
+            2D array of shape (N, 2) with latitude and longitude coordinates of the
+            nodes of the graph.
 
         Returns
         -------
         np.ndarray
-            Attributes.
+            Spherical area weights.
         """
-        points = latlon_rad_to_cartesian(self.get_latlon_coordinates(nodes).cpu())
+        points = latlon_rad_to_cartesian_np(latlons)
         sv = SphericalVoronoi(points, self.radius, self.centre)
         mask = np.array([bool(i) for i in sv.regions])
         sv.regions = [region for region in sv.regions if region]
@@ -300,4 +335,4 @@ class SphericalAreaWeights(BaseNodeAttribute):
             len(result),
             result.sum(),
         )
-        return torch.from_numpy(result)
+        return result

--- a/graphs/src/anemoi/graphs/nodes/builders/base.py
+++ b/graphs/src/anemoi/graphs/nodes/builders/base.py
@@ -57,7 +57,7 @@ class BaseNodeBuilder(ABC):
         HeteroData
             The graph with the registered nodes.
         """
-        graph[self.name].x = self.get_coordinates()
+        graph[self.name].x = self.get_coordinates().to(torch.float32)
         graph[self.name].node_type = type(self).__name__
 
         if graph[self.name].num_nodes >= 2:
@@ -144,7 +144,5 @@ class BaseNodeBuilder(ABC):
         graph = self.register_attributes(graph, attrs_config or {})
         t1 = time.time()
         LOGGER.debug("Time to register node coordinates (%s): %.2f s", self.__class__.__name__, t1 - t0)
-
-        graph[self.name].x = graph[self.name].x.to(torch.float32)
 
         return graph

--- a/graphs/src/anemoi/graphs/nodes/builders/base.py
+++ b/graphs/src/anemoi/graphs/nodes/builders/base.py
@@ -57,7 +57,7 @@ class BaseNodeBuilder(ABC):
         HeteroData
             The graph with the registered nodes.
         """
-        graph[self.name].x = self.get_coordinates().to(torch.float32)
+        graph[self.name].x = self.get_coordinates()
         graph[self.name].node_type = type(self).__name__
 
         if graph[self.name].num_nodes >= 2:
@@ -144,5 +144,7 @@ class BaseNodeBuilder(ABC):
         graph = self.register_attributes(graph, attrs_config or {})
         t1 = time.time()
         LOGGER.debug("Time to register node coordinates (%s): %.2f s", self.__class__.__name__, t1 - t0)
+
+        graph[self.name].x = graph[self.name].x.to(torch.float32)
 
         return graph


### PR DESCRIPTION
## Description
Fixes #362 

## What problem does this change solve?
SphericalAreaWeights needs float64 precision input to work as intended for high resolution graphs

## What issue or task does this change relate to?
#362 

##  Additional notes ##


***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***
