### PR TITLE
fix(graphs): undo masking when torch-cluster is installed

### DIFF
--- a/graphs/src/anemoi/graphs/edges/builders/knn.py
+++ b/graphs/src/anemoi/graphs/edges/builders/knn.py
@@ -11,22 +11,19 @@ from __future__ import annotations
 
 import logging
 import warnings
-from importlib.util import find_spec
 
 import numpy as np
 import torch
 from sklearn.neighbors import NearestNeighbors
 from torch_geometric.data.storage import NodeStorage
 
-from anemoi.graphs.edges.builders.base import BaseEdgeBuilder
-from anemoi.graphs.edges.builders.masking import NodeMaskingMixin
+from anemoi.graphs.edges.builders.base import BaseDistanceEdgeBuilders
 
 LOGGER = logging.getLogger(__name__)
 
-TORCH_CLUSTER_AVAILABLE = find_spec("torch_cluster") is not None
 
 
-class KNNEdges(BaseEdgeBuilder, NodeMaskingMixin):
+class KNNEdges(BaseDistanceEdgeBuilders):
     """Computes KNN based edges and adds them to the graph.
 
     Attributes
@@ -65,7 +62,14 @@ class KNNEdges(BaseEdgeBuilder, NodeMaskingMixin):
         assert num_nearest_neighbours > 0, "Number of nearest neighbours must be positive."
         self.num_nearest_neighbours = num_nearest_neighbours
 
-    def _compute_adj_matrix_pyg(self, source_coords: NodeStorage, target_coords: NodeStorage) -> torch.Tensor:
+        LOGGER.info(
+            "Using KNN-Edges (with %d nearest neighbours) between %s and %s.",
+            self.num_nearest_neighbours,
+            self.source_name,
+            self.target_name,
+        )
+
+    def _compute_adj_matrix_pyg(self, source_coords: NodeStorage, target_coords: NodeStorage) -> np.ndarray:
         from torch_cluster.knn import knn
         from scipy.sparse import coo_matrix
 
@@ -79,7 +83,7 @@ class KNNEdges(BaseEdgeBuilder, NodeMaskingMixin):
         )
         return adj_matrix
 
-    def _compute_adj_matrix_sklearn(self, source_coords: NodeStorage, target_coords: NodeStorage) -> torch.Tensor:
+    def _compute_adj_matrix_sklearn(self, source_coords: NodeStorage, target_coords: NodeStorage) -> np.ndarray:
         nearest_neighbour = NearestNeighbors(metric="euclidean", n_jobs=4)
         nearest_neighbour.fit(source_coords.cpu())
         adj_matrix = nearest_neighbour.kneighbors_graph(
@@ -88,44 +92,3 @@ class KNNEdges(BaseEdgeBuilder, NodeMaskingMixin):
         ).tocoo()
 
         return adj_matrix
-
-    def compute_edge_index(self, source_nodes: NodeStorage, target_nodes: NodeStorage) -> torch.Tensor:
-        """Compute the edge indices for the KNN method.
-
-        Parameters
-        ----------
-        source_nodes : NodeStorage
-            The source nodes.
-        target_nodes : NodeStorage
-            The target nodes.
-
-        Returns
-        -------
-        torch.Tensor of shape (2, num_edges)
-            Indices of source and target nodes connected by an edge.
-        """
-        assert self.num_nearest_neighbours is not None, "number of neighbors required for knn encoder"
-        LOGGER.info(
-            "Using KNN-Edges (with %d nearest neighbours) between %s and %s.",
-            self.num_nearest_neighbours,
-            self.source_name,
-            self.target_name,
-        )
-
-        source_coords, target_coords = self.get_cartesian_node_coordinates(source_nodes, target_nodes)
-
-        if TORCH_CLUSTER_AVAILABLE:
-            adj_matrix = self._compute_adj_matrix_pyg(source_coords, target_coords)
-        else:
-            warnings.warn(
-                "The 'torch-cluster' library is not installed. Installing 'torch-cluster' can significantly improve "
-                "performance for graph creation. You can install it using 'pip install torch-cluster'.",
-                UserWarning,
-            )
-            adj_matrix = self._compute_adj_matrix_sklearn(source_coords, target_coords)
-
-        # Post-process the adjacency matrix. Add masked nodes.
-        adj_matrix = self.undo_masking(adj_matrix, source_nodes, target_nodes)
-        edge_index = torch.from_numpy(np.stack([adj_matrix.col, adj_matrix.row], axis=0))
-
-        return edge_index


### PR DESCRIPTION
## Description
<!-- What issue or task does this change relate to? -->
The current workflow did not function as intended with `torch-cluster` when a source or target mask was specified. The `torch-cluster` library is used only when graph creation needs to be optimized. It is not listed as a dependency because it is difficult to install in the CI environment, and as a result, it is only lightly tested.

## What problem does this change solve?
<!-- Describe if it's a bugfix, new feature, doc update, or breaking change -->
This PR fixes the previously reported bug and introduces a new base class shared by both KNNEdges and CutOffEdges to handle masking.

## What issue or task does this change relate to?
<!-- link to Issue Number -->

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***
