### PR TITLE
fix(models): remove repeated lines

### DIFF
--- a/models/src/anemoi/models/models/encoder_processor_decoder.py
+++ b/models/src/anemoi/models/models/encoder_processor_decoder.py
@@ -60,12 +60,6 @@ class AnemoiModelEncProcDec(nn.Module):
         self._graph_data = graph_data
         self._graph_name_data = model_config.graph.data
         self._graph_name_hidden = model_config.graph.hidden
-
-        self.multi_step = model_config.training.multistep_input
-        self.num_channels = model_config.model.num_channels
-
-        self.node_attributes = NamedNodesAttributes(model_config.model.trainable_parameters.hidden, self._graph_data)
-
         self._calculate_shapes_and_indices(data_indices)
         self._assert_matching_indices(data_indices)
         self.data_indices = data_indices


### PR DESCRIPTION
## Description
<!-- What issue or task does this change relate to? -->
Three lines are repeated in the `__init__()` method of the `AnemoiModelEncProcDec` class.

## What problem does this change solve?
<!-- Describe if it's a bugfix, new feature, doc update, or breaking change -->

## What issue or task does this change relate to?
<!-- link to Issue Number -->

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***
