### PR TITLE
fix(graphs): throw error instead of raising warning when graph exists. 

### DIFF
--- a/graphs/src/anemoi/graphs/create.py
+++ b/graphs/src/anemoi/graphs/create.py
@@ -162,7 +162,7 @@ class GraphCreator:
             torch.save(graph, save_path)
             LOGGER.info(f"Graph saved at {save_path}.")
         else:
-            LOGGER.info("Graph already exists. Use overwrite=True to overwrite.")
+            raise ValueError(f"Graph already exists at {save_path}. Use overwrite=True to overwrite.")
 
     def create(self, save_path: Path | None = None, overwrite: bool = False) -> HeteroData:
         """Create the graph and save it to the output path.


### PR DESCRIPTION
## Description

The warning currently thrown by `anemoi-graphs create` when a graph already exists is too subtle. If you don’t scroll up in a successful-looking output, you will miss that the graph creation failed. Here’s an **example output from a failed graph creation** from  my terminal: 

![Screenshot from 2025-06-24 08-34-22](https://github.com/user-attachments/assets/0bb36d6e-d488-4689-b527-a73ba1a46ddb)

I began working on a new PR because I thought there was a bug elsewhere,  because I didn’t notice the warning.

To make failure more noisy, I’ve changed the behavior to raise an explicit error instead of a warning:

![Screenshot from 2025-06-24 08-58-28](https://github.com/user-attachments/assets/96ab03fa-161a-4bfe-bc9f-75976b690778)


 ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***
