### PR TITLE
test: update markers for consistency

### DIFF
--- a/.github/workflows/integration-tests-hpc.yml
+++ b/.github/workflows/integration-tests-hpc.yml
@@ -41,6 +41,7 @@ jobs:
             source .venv/bin/activate
             pip install --upgrade pip
             pip install -e ./training[all,tests] -e ./models[all,tests] -e ./graphs[all,tests]
+            export SLOW_TESTS=1
             python3 -m pytest -v training/tests/integration --longtests
             deactivate
             rm -rf $REPO_NAME

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,5 +1,9 @@
 name: nightly-ci-integration-tests
 on:
+  # Need to revert this before merging to main, just for purposes of testing
+  # the workflow.
+  pull_request:
+    types: [opened, synchronize, reopened]
   schedule:
     - cron: "0 23 * * *"  # every day at 22pm on default(main) branch
   workflow_dispatch:
@@ -8,14 +12,14 @@ jobs:
   integration_tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: ecmwf/reusable-workflows/nightly-pytest@main
+      - uses: ecmwf/reusable-workflows/nightly-pytest@feat/add-env-vars-to-nightly-python-action
         with:
           repository: ${{github.repository}}
           ref: ${{github.ref}}
           python-version: '3.10'
           install-package: "-e ./training[all,tests] -e ./graphs[all,tests] -e ./models[all,tests]"
           test-directory: "training/tests/integration"
-          pytest-options: "--longtests"
+          env-vars: "SLOW_TESTS=1"
           manual: ${{github.event_name == 'workflow_dispatch' && 'true' || 'false'}}
 
   notify-team:

--- a/training/docs/contributing.rst
+++ b/training/docs/contributing.rst
@@ -244,7 +244,7 @@ available, then from the top-level directory of anemoi-core run:
 
 .. code:: bash
 
-   pytest training/tests/integration --longtests
+   SLOW_TESTS=1 pytest training/tests/integration
 
 *********************************************
  Configuration handling in integration tests

--- a/training/tests/conftest.py
+++ b/training/tests/conftest.py
@@ -22,30 +22,6 @@ from anemoi.training.data.datamodule import AnemoiDatasetsDataModule
 pytest_plugins = "anemoi.utils.testing"
 
 
-def pytest_addoption(parser: pytest.Parser) -> None:
-    parser.addoption(
-        "--longtests",
-        action="store_true",
-        dest="longtests",
-        default=False,
-        help="enable tests marked as longtests",
-    )
-
-
-def pytest_configure(config: pytest.Config) -> None:
-    """Register the 'longtests' marker to avoid warnings."""
-    config.addinivalue_line("markers", "longtests: mark tests as long-running")
-
-
-def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
-    """Automatically skip @pytest.mark.longtests tests unless --longtests is used."""
-    if not config.getoption("--longtests"):
-        skip_marker = pytest.mark.skip(reason="Skipping long test, use --longtests to enable")
-        for item in items:
-            if item.get_closest_marker("longtests"):
-                item.add_marker(skip_marker)
-
-
 @pytest.fixture
 def config(request: SubRequest) -> DictConfig:
     overrides = request.param

--- a/training/tests/integration/aicon/test_cicd_aicon_04_icon-dream_medium.py
+++ b/training/tests/integration/aicon/test_cicd_aicon_04_icon-dream_medium.py
@@ -29,6 +29,7 @@ from typeguard import typechecked
 import anemoi.training
 from anemoi.training.schemas.base_schema import BaseSchema
 from anemoi.training.train.train import AnemoiTrainer
+from anemoi.utils.testing import skip_slow_tests
 
 os.environ["ANEMOI_BASE_SEED"] = "42"
 os.environ["ANEMOI_CONFIG_PATH"] = str(pathlib.Path(anemoi.training.__file__).parent / "config")
@@ -99,7 +100,7 @@ def test_config_validation_aicon(aicon_config_with_tmp_dir: DictConfig) -> None:
     BaseSchema(**aicon_config_with_tmp_dir)
 
 
-@pytest.mark.longtests
+@skip_slow_tests
 @typechecked
 def test_aicon_metadata(aicon_config_with_grid: DictConfig) -> None:
     """Test for presence of metadata required for inference.
@@ -134,7 +135,7 @@ def test_aicon_metadata(aicon_config_with_grid: DictConfig) -> None:
     assert trainer.model.model.model.decoder.proc.num_chunks == aicon_config_with_grid.model.decoder.num_chunks
 
 
-@pytest.mark.longtests
+@skip_slow_tests
 @typechecked
 def test_aicon_training(trained_aicon: tuple) -> None:
     trainer, initial_sum, final_sum = trained_aicon

--- a/training/tests/integration/test_training_cycle.py
+++ b/training/tests/integration/test_training_cycle.py
@@ -24,20 +24,20 @@ os.environ["ANEMOI_BASE_SEED"] = "42"  # need to set base seed if running on git
 LOGGER = logging.getLogger(__name__)
 
 
-@skip_if_offline
-@skip_slow_tests
-def test_training_cycle_architecture_configs(
-    architecture_config: tuple[DictConfig, str],
-    get_test_archive: callable,
-) -> None:
-    cfg, url = architecture_config
-    get_test_archive(url)
-    AnemoiTrainer(cfg).train()
+# @skip_if_offline
+# @skip_slow_tests
+# def test_training_cycle_architecture_configs(
+#     architecture_config: tuple[DictConfig, str],
+#     get_test_archive: callable,
+# ) -> None:
+#     cfg, url = architecture_config
+#     get_test_archive(url)
+#     AnemoiTrainer(cfg).train()
 
 
-def test_config_validation_architecture_configs(architecture_config: tuple[DictConfig, str]) -> None:
-    cfg, _ = architecture_config
-    BaseSchema(**cfg)
+# def test_config_validation_architecture_configs(architecture_config: tuple[DictConfig, str]) -> None:
+#     cfg, _ = architecture_config
+#     BaseSchema(**cfg)
 
 
 @skip_if_offline
@@ -54,89 +54,89 @@ def test_training_cycle_without_config_validation(
     AnemoiTrainer(cfg).train()
 
 
-@skip_if_offline
-@skip_slow_tests
-def test_training_cycle_stretched(stretched_config: tuple[DictConfig, list[str]], get_test_archive: callable) -> None:
-    cfg, urls = stretched_config
-    for url in urls:
-        get_test_archive(url)
-    AnemoiTrainer(cfg).train()
+# @skip_if_offline
+# @skip_slow_tests
+# def test_training_cycle_stretched(stretched_config: tuple[DictConfig, list[str]], get_test_archive: callable) -> None:
+#     cfg, urls = stretched_config
+#     for url in urls:
+#         get_test_archive(url)
+#     AnemoiTrainer(cfg).train()
 
 
-def test_config_validation_stretched(stretched_config: tuple[DictConfig, list[str]]) -> None:
-    cfg, _ = stretched_config
-    BaseSchema(**cfg)
+# def test_config_validation_stretched(stretched_config: tuple[DictConfig, list[str]]) -> None:
+#     cfg, _ = stretched_config
+#     BaseSchema(**cfg)
 
 
-@skip_if_offline
-@skip_slow_tests
-def test_training_cycle_lam(lam_config: tuple[DictConfig, list[str]], get_test_archive: callable) -> None:
-    cfg, urls = lam_config
-    for url in urls:
-        get_test_archive(url)
-    AnemoiTrainer(cfg).train()
+# @skip_if_offline
+# @skip_slow_tests
+# def test_training_cycle_lam(lam_config: tuple[DictConfig, list[str]], get_test_archive: callable) -> None:
+#     cfg, urls = lam_config
+#     for url in urls:
+#         get_test_archive(url)
+#     AnemoiTrainer(cfg).train()
 
 
-@skip_if_offline
-@skip_slow_tests
-def test_training_cycle_lam_with_existing_graph(
-    lam_config_with_graph: tuple[DictConfig, list[str]],
-    get_test_archive: callable,
-) -> None:
-    cfg, urls = lam_config_with_graph
-    for url in urls:
-        get_test_archive(url)
-    AnemoiTrainer(cfg).train()
+# @skip_if_offline
+# @skip_slow_tests
+# def test_training_cycle_lam_with_existing_graph(
+#     lam_config_with_graph: tuple[DictConfig, list[str]],
+#     get_test_archive: callable,
+# ) -> None:
+#     cfg, urls = lam_config_with_graph
+#     for url in urls:
+#         get_test_archive(url)
+#     AnemoiTrainer(cfg).train()
 
 
-def test_config_validation_lam(lam_config: DictConfig) -> None:
-    cfg, _ = lam_config
-    BaseSchema(**cfg)
+# def test_config_validation_lam(lam_config: DictConfig) -> None:
+#     cfg, _ = lam_config
+#     BaseSchema(**cfg)
 
 
-@skip_if_offline
-@skip_slow_tests
-def test_training_cycle_ensemble(ensemble_config: tuple[DictConfig, str], get_test_archive: callable) -> None:
-    cfg, url = ensemble_config
-    get_test_archive(url)
-    AnemoiTrainer(cfg).train()
+# @skip_if_offline
+# @skip_slow_tests
+# def test_training_cycle_ensemble(ensemble_config: tuple[DictConfig, str], get_test_archive: callable) -> None:
+#     cfg, url = ensemble_config
+#     get_test_archive(url)
+#     AnemoiTrainer(cfg).train()
 
 
-def test_config_validation_ensemble(ensemble_config: tuple[DictConfig, str]) -> None:
-    cfg, _ = ensemble_config
-    BaseSchema(**cfg)
+# def test_config_validation_ensemble(ensemble_config: tuple[DictConfig, str]) -> None:
+#     cfg, _ = ensemble_config
+#     BaseSchema(**cfg)
 
 
-@skip_if_offline
-@skip_slow_tests
-def test_restart_training(gnn_config: tuple[DictConfig, str], get_test_archive: callable) -> None:
-    cfg, url = gnn_config
-    get_test_archive(url)
+# @skip_if_offline
+# @skip_slow_tests
+# def test_restart_training(gnn_config: tuple[DictConfig, str], get_test_archive: callable) -> None:
+#     cfg, url = gnn_config
+#     get_test_archive(url)
 
-    AnemoiTrainer(cfg).train()
+#     AnemoiTrainer(cfg).train()
 
-    output_dir = Path(cfg.hardware.paths.output + "checkpoint")
+#     output_dir = Path(cfg.hardware.paths.output + "checkpoint")
 
-    assert output_dir.exists(), f"Checkpoint directory not found at: {output_dir}"
+#     assert output_dir.exists(), f"Checkpoint directory not found at: {output_dir}"
 
-    run_dirs = [item for item in output_dir.iterdir() if item.is_dir()]
-    assert (
-        len(run_dirs) == 1
-    ), f"Expected exactly one run_id directory, found {len(run_dirs)}: {[d.name for d in run_dirs]}"
+#     run_dirs = [item for item in output_dir.iterdir() if item.is_dir()]
+#     assert (
+#         len(run_dirs) == 1
+#     ), f"Expected exactly one run_id directory, found {len(run_dirs)}: {[d.name for d in run_dirs]}"
 
-    checkpoint_dir = run_dirs[0]
-    assert len(list(checkpoint_dir.glob("anemoi-by_epoch-*.ckpt"))) == 2, "Expected 2 checkpoints after first run"
+#     checkpoint_dir = run_dirs[0]
+#     assert len(list(checkpoint_dir.glob("anemoi-by_epoch-*.ckpt"))) == 2, "Expected 2 checkpoints after first run"
 
-    cfg.training.run_id = checkpoint_dir.name
-    cfg.training.max_epochs = 3
-    AnemoiTrainer(cfg).train()
+#     cfg.training.run_id = checkpoint_dir.name
+#     cfg.training.max_epochs = 3
+#     AnemoiTrainer(cfg).train()
 
-    assert len(list(checkpoint_dir.glob("anemoi-by_epoch-*.ckpt"))) == 3, "Expected 3 checkpoints after second run"
+#     assert len(list(checkpoint_dir.glob("anemoi-by_epoch-*.ckpt"))) == 3, "Expected 3 checkpoints after second run"
 
 
-@skip_if_offline
-@skip_slow_tests
-def test_restart_from_existing_checkpoint(gnn_config_with_checkpoint: DictConfig, get_test_archive: callable) -> None:
-    cfg, url = gnn_config_with_checkpoint
-    get_test_archive(url)
-    AnemoiTrainer(cfg).train()
+# @skip_if_offline
+# @skip_slow_tests
+# def test_restart_from_existing_checkpoint(gnn_config_with_checkpoint: DictConfig, get_test_archive: callable) -> None:
+#     cfg, url = gnn_config_with_checkpoint
+#     get_test_archive(url)
+#     AnemoiTrainer(cfg).train()

--- a/training/tests/integration/test_training_cycle.py
+++ b/training/tests/integration/test_training_cycle.py
@@ -9,11 +9,9 @@
 
 import logging
 import os
-from pathlib import Path
 
 from omegaconf import DictConfig
 
-from anemoi.training.schemas.base_schema import BaseSchema
 from anemoi.training.train.train import AnemoiTrainer
 from anemoi.utils.testing import skip_if_offline
 from anemoi.utils.testing import skip_slow_tests

--- a/training/tests/integration/test_training_cycle.py
+++ b/training/tests/integration/test_training_cycle.py
@@ -135,7 +135,7 @@ def test_restart_training(gnn_config: tuple[DictConfig, str], get_test_archive: 
 
 
 @skip_if_offline
-@pytest.mark.longtests
+@skip_slow_tests
 def test_restart_from_existing_checkpoint(gnn_config_with_checkpoint: DictConfig, get_test_archive: callable) -> None:
     cfg, url = gnn_config_with_checkpoint
     get_test_archive(url)

--- a/training/tests/integration/test_training_cycle.py
+++ b/training/tests/integration/test_training_cycle.py
@@ -11,12 +11,12 @@ import logging
 import os
 from pathlib import Path
 
-import pytest
 from omegaconf import DictConfig
 
 from anemoi.training.schemas.base_schema import BaseSchema
 from anemoi.training.train.train import AnemoiTrainer
 from anemoi.utils.testing import skip_if_offline
+from anemoi.utils.testing import skip_slow_tests
 
 os.environ["ANEMOI_BASE_SEED"] = "42"  # need to set base seed if running on github runners
 
@@ -25,7 +25,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 @skip_if_offline
-@pytest.mark.longtests
+@skip_slow_tests
 def test_training_cycle_architecture_configs(
     architecture_config: tuple[DictConfig, str],
     get_test_archive: callable,
@@ -41,7 +41,7 @@ def test_config_validation_architecture_configs(architecture_config: tuple[DictC
 
 
 @skip_if_offline
-@pytest.mark.longtests
+@skip_slow_tests
 def test_training_cycle_without_config_validation(
     gnn_config: tuple[DictConfig, str],
     get_test_archive: callable,
@@ -55,7 +55,7 @@ def test_training_cycle_without_config_validation(
 
 
 @skip_if_offline
-@pytest.mark.longtests
+@skip_slow_tests
 def test_training_cycle_stretched(stretched_config: tuple[DictConfig, list[str]], get_test_archive: callable) -> None:
     cfg, urls = stretched_config
     for url in urls:
@@ -69,7 +69,7 @@ def test_config_validation_stretched(stretched_config: tuple[DictConfig, list[st
 
 
 @skip_if_offline
-@pytest.mark.longtests
+@skip_slow_tests
 def test_training_cycle_lam(lam_config: tuple[DictConfig, list[str]], get_test_archive: callable) -> None:
     cfg, urls = lam_config
     for url in urls:
@@ -78,7 +78,7 @@ def test_training_cycle_lam(lam_config: tuple[DictConfig, list[str]], get_test_a
 
 
 @skip_if_offline
-@pytest.mark.longtests
+@skip_slow_tests
 def test_training_cycle_lam_with_existing_graph(
     lam_config_with_graph: tuple[DictConfig, list[str]],
     get_test_archive: callable,
@@ -95,7 +95,7 @@ def test_config_validation_lam(lam_config: DictConfig) -> None:
 
 
 @skip_if_offline
-@pytest.mark.longtests
+@skip_slow_tests
 def test_training_cycle_ensemble(ensemble_config: tuple[DictConfig, str], get_test_archive: callable) -> None:
     cfg, url = ensemble_config
     get_test_archive(url)
@@ -108,7 +108,7 @@ def test_config_validation_ensemble(ensemble_config: tuple[DictConfig, str]) -> 
 
 
 @skip_if_offline
-@pytest.mark.longtests
+@skip_slow_tests
 def test_restart_training(gnn_config: tuple[DictConfig, str], get_test_archive: callable) -> None:
     cfg, url = gnn_config
     get_test_archive(url)


### PR DESCRIPTION
[DO NOT MERGE before the action in reusable-workflows is updated and the pull_request trigger in the nightly workflow added for purposes of testing is removed (and the commenting out code in training tests is reverted)]

## Description
This updates the markers for slow running tests in training integration tests for consistency with anemoi-datasets using the functionality that anemoi-utils provides. It also updates the docs and github workflows accordingly.

## What issue or task does this change relate to?
https://github.com/ecmwf/anemoi-core/issues/257

##  Additional notes ##
Corresponding PRs in docs: https://github.com/ecmwf/anemoi-docs/pull/35
and in reusable-workflows: https://github.com/ecmwf/reusable-workflows/pull/33

Here is a successful run of the nightly workflow: https://github.com/ecmwf/anemoi-core/actions/runs/15923343211/job/44914932871?pr=387


***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***


<!-- readthedocs-preview anemoi-training start -->
----
📚 Documentation preview 📚: https://anemoi-training--387.org.readthedocs.build/en/387/

<!-- readthedocs-preview anemoi-training end -->

<!-- readthedocs-preview anemoi-graphs start -->
----
📚 Documentation preview 📚: https://anemoi-graphs--387.org.readthedocs.build/en/387/

<!-- readthedocs-preview anemoi-graphs end -->

<!-- readthedocs-preview anemoi-models start -->
----
📚 Documentation preview 📚: https://anemoi-models--387.org.readthedocs.build/en/387/

<!-- readthedocs-preview anemoi-models end -->