### PR TITLE
fix(models): remove redundant logic in enc-proc-dec instantiation

### DIFF
--- a/models/src/anemoi/models/models/encoder_processor_decoder.py
+++ b/models/src/anemoi/models/models/encoder_processor_decoder.py
@@ -71,11 +71,6 @@ class AnemoiModelEncProcDec(nn.Module):
         self.data_indices = data_indices
         self.statistics = statistics
 
-        self.multi_step = model_config.training.multistep_input
-        self.num_channels = model_config.model.num_channels
-
-        self.node_attributes = NamedNodesAttributes(model_config.model.trainable_parameters.hidden, self._graph_data)
-
         self._truncation_data = truncation_data
 
         # we can't register these as buffers because DDP does not support sparse tensors


### PR DESCRIPTION
## Description
This change removes duplicated instantiation logic in the model’s constructor — `multi_step`, `num_channels`, and `node_attributes` were previously set twice.

## What problem does this change solve?
This is a cleanup of redundant logic in model initialization. 