### PR TITLE
chore: update paths after organizing training test data in ewc

### DIFF
--- a/training/tests/integration/config/test_config.yaml
+++ b/training/tests/integration/config/test_config.yaml
@@ -1,7 +1,7 @@
 # Modifications for the basic template "config.yaml"
 hardware:
   files:
-    dataset: anemoi-integration-tests/aifs-ea-an-oper-0001-mars-o48-1979-19-6h-v6-testset.zarr
+    dataset: anemoi-integration-tests/training/datasets/aifs-ea-an-oper-0001-mars-o48-1979-19-6h-v6-testset.zarr
   paths:
     data: https://object-store.os-api.cci1.ecmwf.int/ml-tests/test-data/samples
 

--- a/training/tests/integration/config/test_ensemble_crps.yaml
+++ b/training/tests/integration/config/test_ensemble_crps.yaml
@@ -4,7 +4,7 @@ hardware:
     data: https://object-store.os-api.cci1.ecmwf.int/ml-tests/test-data/samples
     truncation: null
   files:
-    dataset: anemoi-integration-tests/regional-use-cases/aifs-ea-an-oper-0001-mars-o96-2017-2017-6h-v8-testing.zarr
+    dataset: anemoi-integration-tests/training/datasets/aifs-ea-an-oper-0001-mars-o96-2017-2017-6h-v8-testing.zarr
     truncation: null
     truncation_inv: null
     graph: null

--- a/training/tests/integration/config/test_lam.yaml
+++ b/training/tests/integration/config/test_lam.yaml
@@ -16,10 +16,10 @@ hardware:
   paths:
     data: https://object-store.os-api.cci1.ecmwf.int/ml-tests/test-data/samples
   files:
-    dataset: anemoi-integration-tests/regional-use-cases/cerra-rr-an-oper-0001-mars-5p5km-2017-2017-6h-v3-testing.zarr
-    forcing_dataset: anemoi-integration-tests/regional-use-cases/aifs-ea-an-oper-0001-mars-o96-2017-2017-6h-v8-testing.zarr
+    dataset: anemoi-integration-tests/training/datasets/cerra-rr-an-oper-0001-mars-5p5km-2017-2017-6h-v3-testing.zarr
+    forcing_dataset: anemoi-integration-tests/training/datasets/aifs-ea-an-oper-0001-mars-o96-2017-2017-6h-v8-testing.zarr
     # We only use the graph file in test_training_cycle_lam_with_existing_graph, not in test_training_cycle_lam
-    graph: anemoi-integration-tests/regional-use-cases/lam-graph.pt
+    graph: anemoi-integration-tests/training/graphs/lam-graph.pt
 
 # need this modification since some variables set in the default zarr config are not part of the dataset
 data:

--- a/training/tests/integration/config/test_stretched.yaml
+++ b/training/tests/integration/config/test_stretched.yaml
@@ -45,8 +45,8 @@ hardware:
   paths:
     data: https://object-store.os-api.cci1.ecmwf.int/ml-tests/test-data/samples
   files:
-    dataset: anemoi-integration-tests/regional-use-cases/cerra-rr-an-oper-0001-mars-5p5km-2017-2017-6h-v3-testing.zarr
-    forcing_dataset: anemoi-integration-tests/regional-use-cases/aifs-ea-an-oper-0001-mars-o96-2017-2017-6h-v8-testing.zarr
+    dataset: anemoi-integration-tests/training/datasets/cerra-rr-an-oper-0001-mars-5p5km-2017-2017-6h-v3-testing.zarr
+    forcing_dataset: anemoi-integration-tests/training/datasets/aifs-ea-an-oper-0001-mars-o96-2017-2017-6h-v8-testing.zarr
 
 graph:
   nodes:


### PR DESCRIPTION
## Description
Update paths to test data in order to clean up the folder anemoi-integration-tests in the object store. When this is merged, I'll delete the old copies of the datasets.

## What problem does this change solve?
Just maintenance

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
