### PR TITLE
feat(graphs): support to export edges to npz

### DIFF
--- a/graphs/src/anemoi/graphs/commands/export_to_sparse.py
+++ b/graphs/src/anemoi/graphs/commands/export_to_sparse.py
@@ -7,16 +7,16 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
+
 from anemoi.graphs.export import GraphExporter
 
-import argparse
 from . import Command
 
 
 class ExportToSparse(Command):
     """
     Export a graph edges to a sparse format.
-    
+
     Example usage specifying an edge attribute:
     ```
     anemoi-graphs export-to-sparse graph.pt output_path --edge_attribute_name edge_attr
@@ -34,17 +34,13 @@ class ExportToSparse(Command):
     def add_arguments(self, command_parser):
         command_parser.add_argument("graph", help="Path to the graph (a .PT file) or a config file defining the graph.")
         command_parser.add_argument("output_path", help="Path to store the inspection results.")
-        command_parser.add_argument(
-            "--edge_attribute_name", 
-            default=None,
-            help="Name of the edge attribute to export."
-        )
+        command_parser.add_argument("--edge_attribute_name", default=None, help="Name of the edge attribute to export.")
         command_parser.add_argument(
             "--edges-name",
             nargs=2,
-            action='append',
-            metavar=('NODE1', 'NODE2'),
-            help="Specify an edge by its two node names. Can be used multiple times."
+            action="append",
+            metavar=("NODE1", "NODE2"),
+            help="Specify an edge by its two node names. Can be used multiple times.",
         )
 
     def run(self, args):

--- a/graphs/src/anemoi/graphs/commands/export_to_sparse.py
+++ b/graphs/src/anemoi/graphs/commands/export_to_sparse.py
@@ -14,7 +14,19 @@ from . import Command
 
 
 class ExportToSparse(Command):
-    """Export a graph edges to a sparse format."""
+    """
+    Export a graph edges to a sparse format.
+    
+    Example usage specifying an edge attribute:
+    ```
+    anemoi-graphs export-to-sparse graph.pt output_path --edge_attribute_name edge_attr
+    ```
+
+    Example usage specifying a subset of edges:
+    ```
+    anemoi-graphs export-to-sparse graph.pt output_path --edges-name data down --edges-name down data
+    ```
+    """
 
     internal = True
     timestamp = True

--- a/graphs/src/anemoi/graphs/commands/export_to_sparse.py
+++ b/graphs/src/anemoi/graphs/commands/export_to_sparse.py
@@ -1,0 +1,53 @@
+# (C) Copyright 2024 Anemoi contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+from anemoi.graphs.export import GraphExporter
+
+import argparse
+from . import Command
+
+
+class ExportToSparse(Command):
+    """Export a graph edges to a sparse format."""
+
+    internal = True
+    timestamp = True
+
+    def add_arguments(self, command_parser):
+        command_parser.add_argument("graph", help="Path to the graph (a .PT file) or a config file defining the graph.")
+        command_parser.add_argument("output_path", help="Path to store the inspection results.")
+        command_parser.add_argument(
+            "--edge_attribute_name", 
+            default=None,
+            help="Name of the edge attribute to export."
+        )
+        command_parser.add_argument(
+            "--edges-name",
+            nargs=2,
+            action='append',
+            metavar=('NODE1', 'NODE2'),
+            help="Specify an edge by its two node names. Can be used multiple times."
+        )
+
+    def run(self, args):
+        kwargs = vars(args)
+        edges_name = kwargs.get("edges_name", None)
+        if edges_name is not None:
+            # Convert list of lists to list of tuples
+            kwargs["edges_name"] = [tuple(pair) for pair in edges_name]
+
+        GraphExporter(
+            graph=kwargs["graph"],
+            output_path=kwargs["output_path"],
+            edge_attribute_name=kwargs["edge_attribute_name"],
+            edges_name=kwargs["edges_name"],
+        ).export()
+
+
+command = ExportToSparse

--- a/graphs/src/anemoi/graphs/edges/attributes.py
+++ b/graphs/src/anemoi/graphs/edges/attributes.py
@@ -185,6 +185,6 @@ class GaussianWeights(EdgeLength):
     
     def aggregate(self, edge_features: torch.Tensor, index: torch.Tensor, ptr=None, dim_size=None) -> torch.Tensor:
         # L2 normalization per target node
-        weights_sum = torch.zeros(dim_size, device=edge_features.device, dtype=edge_features.dtype)
-        weights_sum.index_add_(0, index, edge_features.squeeze())
+        weights_sum = torch.zeros(dim_size, 1, device=edge_features.device, dtype=edge_features.dtype)
+        weights_sum.index_add_(0, index, edge_features)
         return edge_features / weights_sum[index]

--- a/graphs/src/anemoi/graphs/edges/attributes.py
+++ b/graphs/src/anemoi/graphs/edges/attributes.py
@@ -173,16 +173,17 @@ class AttributeFromTargetNode(BaseEdgeAttributeFromNodeBuilder):
 
 class GaussianWeights(EdgeLength):
     """Gaussian weights."""
+
     def __init__(self, sigma: float = 1.0, **kwargs) -> None:
         self.sigma = sigma
         assert kwargs.get("norm", None) == None, f"{self.__class__.__name__} does not support custom normalisation."
         super().__init__()
-    
+
     def compute(self, x_i: torch.Tensor, x_j: torch.Tensor) -> torch.Tensor:
         dists = super().compute(x_i, x_j)
-        gaussian_weights = torch.exp(-dists**2 / (2 * self.sigma**2))
+        gaussian_weights = torch.exp(-(dists**2) / (2 * self.sigma**2))
         return gaussian_weights
-    
+
     def aggregate(self, edge_features: torch.Tensor, index: torch.Tensor, ptr=None, dim_size=None) -> torch.Tensor:
         # L2 normalization per target node
         weights_sum = torch.zeros(dim_size, 1, device=edge_features.device, dtype=edge_features.dtype)

--- a/graphs/src/anemoi/graphs/edges/attributes.py
+++ b/graphs/src/anemoi/graphs/edges/attributes.py
@@ -173,8 +173,9 @@ class AttributeFromTargetNode(BaseEdgeAttributeFromNodeBuilder):
 
 class GaussianWeights(EdgeLength):
     """Gaussian weights."""
-    def __init__(self, sigma: float = 1.0) -> None:
+    def __init__(self, sigma: float = 1.0, **kwargs) -> None:
         self.sigma = sigma
+        assert kwargs.get("norm", None) == None, f"{self.__class__.__name__} does not support custom normalisation."
         super().__init__()
     
     def compute(self, x_i: torch.Tensor, x_j: torch.Tensor) -> torch.Tensor:

--- a/graphs/src/anemoi/graphs/export.py
+++ b/graphs/src/anemoi/graphs/export.py
@@ -1,0 +1,102 @@
+# (C) Copyright 2024 Anemoi contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+import os
+from pathlib import Path
+from typing import Tuple
+from typing import Union, Iterable
+
+import torch
+from anemoi.graphs.create import GraphCreator
+import scipy.sparse as sp
+
+
+class GraphExporter:
+    """Class for exporting the graph to a sparse format."""
+
+    def __init__(
+        self,
+        graph: Union[str, Path],
+        output_path: Union[str, Path],
+        edges_name: Iterable[Tuple[str, str, str]] = None,
+        edge_attribute_name: str = None,
+        **kwargs,
+    ):
+        if isinstance(graph, Path) or isinstance(graph, str):
+            if graph.endswith(".pt"):
+                self.graph = torch.load(graph, weights_only=False, map_location="cpu")
+            elif not graph.endswith(".yaml"):
+                raise ValueError("The argument graph must be an actual graph (.pt) or a recipe to build one (.yaml).")
+                
+        self.graph = GraphCreator(graph).create(save_path=None).to("cpu")
+
+        self.edges_name = self.graph.edge_types if edges_name is None else edges_name
+        self.edge_attribute_name = edge_attribute_name
+        self.output_path = output_path
+
+    def get_edges_info(self, source_name: str, target_name: str) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Get the edges info from the graph."""
+        edge_index = self.graph[(source_name, "to", target_name)]["edge_index"]
+
+        if self.edge_attribute_name is None:
+            edge_attribute = torch.ones(edge_index.shape[1])
+        else:
+            assert self.edge_attribute_name in self.graph[(source_name, "to", target_name)], f"Edge attribute {self.edge_attribute_name} not found in graph edges from {source_name} to {target_name}"
+            edge_attribute = self.graph[(source_name, "to", target_name)][self.edge_attribute_name].squeeze()
+
+        assert edge_attribute.ndim == 1, f"Edge attribute {self.edge_attribute_name} should be 1D."
+        return edge_index, edge_attribute
+    
+
+    def get_nodes_info(self, source_name: str, target_name: str) -> Tuple[int, int]:
+        """Get the nodes info from the graph."""
+        num_source_nodes = self.graph[source_name].num_nodes
+        num_target_nodes = self.graph[target_name].num_nodes
+        return num_source_nodes, num_target_nodes
+
+    @staticmethod
+    def get_sparse_matrix(edge_index, edge_attribute, num_source_nodes, num_target_nodes):
+        # Create sparse matrix
+        A = torch.sparse_coo_tensor(
+            edge_index, 
+            edge_attribute,
+            (num_source_nodes, num_target_nodes),
+            device=edge_index.device
+        )
+        return A.coalesce()
+
+    @staticmethod
+    def convert_to_scipy_sparse(A):
+        """
+        Convert PyTorch sparse tensor to SciPy sparse matrix and save.
+        
+        Args:
+            A: PyTorch sparse COO tensor
+            filename: Output filename (.npz extension)
+        """
+        # Get indices and values from PyTorch sparse tensor
+        indices = A.indices().cpu().numpy()
+        values = A.values().cpu().numpy()
+        shape = A.shape
+        
+        # Create SciPy sparse matrix (COO format)
+        scipy_sparse = sp.coo_matrix((values, (indices[0], indices[1])), shape=shape)
+        return scipy_sparse
+
+    def export(self):
+        """Export the graph to a sparse format."""
+        os.makedirs(self.output_path, exist_ok=True)
+        for source_nodes, _, target_nodes in self.edges_name:
+            edge_index, edge_attribute = self.get_edges_info(source_nodes, target_nodes)
+            num_source_nodes, num_target_nodes = self.get_nodes_info(source_nodes, target_nodes)
+            A = GraphExporter.get_sparse_matrix(edge_index, edge_attribute, num_source_nodes, num_target_nodes)
+            A = GraphExporter.convert_to_scipy_sparse(A)
+
+            output_path = Path(self.output_path) / f"{self.edge_attribute_name}-{source_nodes}_to_{target_nodes}.npz"
+            sp.save_npz(output_path, A)


### PR DESCRIPTION
## Description
<!-- What issue or task does this change relate to? -->
This PR adds new functionality to `anemoi-graphs` so users are able to create NPZ files with the truncation matrices.

Example:
```
anemoi-graphs export_to_sparse recipe_graph.yaml truncation_matrices/ --edges-attributes-name gauss_weight --edges-name data down --edges-name down data
```

## What problem does this change solve?
<!-- Describe if it's a bugfix, new feature, doc update, or breaking change -->
It allows to create the sparse matrices inside anemoi.

## What issue or task does this change relate to?
<!-- link to Issue Number -->

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
