### PR TITLE
fix: Update level retrieval logic

### DIFF
--- a/training/src/anemoi/training/losses/loss.py
+++ b/training/src/anemoi/training/losses/loss.py
@@ -17,13 +17,13 @@ from omegaconf import DictConfig
 from omegaconf import OmegaConf
 
 from anemoi.training.losses.base import BaseLoss
-from anemoi.training.utils.variables_metadata import ExtractVariableGroupAndLevel
 
 if TYPE_CHECKING:
     import numpy as np
 
     from anemoi.models.data_indices.collection import IndexCollection
     from anemoi.models.data_indices.tensor import OutputTensorIndex
+    from anemoi.training.utils.variables_metadata import ExtractVariableGroupAndLevel
 
 METRIC_RANGE_DTYPE = dict[str, list[int]]
 LOGGER = logging.getLogger(__name__)
@@ -119,16 +119,13 @@ def _get_metric_ranges(
 def get_metric_ranges(
     config: DictConfig,
     data_indices: IndexCollection,
-    metadata_variables: dict | None = None,
+    metadata_extractor: ExtractVariableGroupAndLevel,
 ) -> tuple[METRIC_RANGE_DTYPE, METRIC_RANGE_DTYPE]:
 
-    variable_groups = config.training.variable_groups
     metrics_to_log = config.training.metrics or []
 
-    extract_variable_group_and_level = ExtractVariableGroupAndLevel(variable_groups, metadata_variables)
-
     return _get_metric_ranges(
-        extract_variable_group_and_level,
+        metadata_extractor,
         data_indices.model.output,
         metrics_to_log,
     )

--- a/training/src/anemoi/training/losses/scalers/variable.py
+++ b/training/src/anemoi/training/losses/scalers/variable.py
@@ -16,12 +16,12 @@ import numpy as np
 
 from anemoi.training.losses.scalers.base_scaler import BaseScaler
 from anemoi.training.utils.enums import TensorDim
-from anemoi.training.utils.variables_metadata import ExtractVariableGroupAndLevel
 
 if TYPE_CHECKING:
     from omegaconf import DictConfig
 
     from anemoi.models.data_indices.collection import IndexCollection
+    from anemoi.training.utils.variables_metadata import ExtractVariableGroupAndLevel
 
 LOGGER = logging.getLogger(__name__)
 
@@ -33,9 +33,8 @@ class BaseVariableLossScaler(BaseScaler):
 
     def __init__(
         self,
-        group_config: DictConfig,
         data_indices: IndexCollection,
-        metadata_variables: dict | None = None,
+        metadata_extractor: ExtractVariableGroupAndLevel,
         norm: str | None = None,
         **kwargs,
     ) -> None:
@@ -53,7 +52,7 @@ class BaseVariableLossScaler(BaseScaler):
         super().__init__(norm=norm)
         del kwargs
         self.data_indices = data_indices
-        self.variable_metadata_extractor = ExtractVariableGroupAndLevel(group_config, metadata_variables)
+        self.variable_metadata_extractor = metadata_extractor
 
 
 class GeneralVariableLossScaler(BaseVariableLossScaler):
@@ -61,10 +60,9 @@ class GeneralVariableLossScaler(BaseVariableLossScaler):
 
     def __init__(
         self,
-        group_config: DictConfig,
         data_indices: IndexCollection,
         weights: DictConfig,
-        metadata_variables: dict | None = None,
+        metadata_extractor: ExtractVariableGroupAndLevel,
         norm: str | None = None,
         **kwargs,
     ) -> None:
@@ -72,20 +70,18 @@ class GeneralVariableLossScaler(BaseVariableLossScaler):
 
         Parameters
         ----------
-        group_config : DictConfig
-            Configuration of groups for variable loss scaling.
         data_indices : IndexCollection
             Collection of data indices.
         weights : DictConfig
             Configuration for variable loss scaling.
         scale_dim : int
             Dimension to scale
-        metadata_variables : dict, optional
-            Dictionary with variable names as keys and metadata as values, by default None
+        metadata_extractor : ExtractVariableGroupAndLevel
+            Metadata extractor for variable groups and levels.
         norm : str, optional
             Type of normalization to apply. Options are None, unit-sum, unit-mean and l1.
         """
-        super().__init__(group_config, data_indices, metadata_variables=metadata_variables, norm=norm)
+        super().__init__(data_indices, metadata_extractor=metadata_extractor, norm=norm)
         self.weights = weights
         del kwargs
 

--- a/training/src/anemoi/training/losses/scalers/variable.py
+++ b/training/src/anemoi/training/losses/scalers/variable.py
@@ -44,8 +44,8 @@ class BaseVariableLossScaler(BaseScaler):
         ----------
         data_indices : IndexCollection
             Collection of data indices.
-        metadata_variables : dict, optional
-            Dictionary with variable names as keys and metadata as values, by default None
+        metadata_extractor : ExtractVariableGroupAndLevel
+            Metadata extractor for variable groups and levels.
         norm : str, optional
             Type of normalization to apply. Options are None, unit-sum, unit-mean and l1.
         """

--- a/training/src/anemoi/training/losses/scalers/variable_level.py
+++ b/training/src/anemoi/training/losses/scalers/variable_level.py
@@ -18,9 +18,9 @@ import numpy as np
 from anemoi.training.losses.scalers.variable import BaseVariableLossScaler
 
 if TYPE_CHECKING:
-    from omegaconf import DictConfig
 
     from anemoi.models.data_indices.collection import IndexCollection
+    from anemoi.training.utils.variables_metadata import ExtractVariableGroupAndLevel
 
 LOGGER = logging.getLogger(__name__)
 
@@ -30,12 +30,11 @@ class BaseVariableLevelScaler(BaseVariableLossScaler):
 
     def __init__(
         self,
-        group_config: DictConfig,
         data_indices: IndexCollection,
         group: str,
         y_intercept: float,
         slope: float,
-        metadata_variables: dict | None = None,
+        metadata_extractor: ExtractVariableGroupAndLevel,
         norm: str | None = None,
         **kwargs,
     ) -> None:
@@ -43,8 +42,6 @@ class BaseVariableLevelScaler(BaseVariableLossScaler):
 
         Parameters
         ----------
-        group_config : DictConfig
-            Configuration of groups for variable loss scaling.
         data_indices : IndexCollection
             Collection of data indices.
         group : str
@@ -53,12 +50,12 @@ class BaseVariableLevelScaler(BaseVariableLossScaler):
             Y-axis shift of scaling function.
         slope : float
             Slope of scaling function.
-        metadata_variables : dict
-            Metadata of the dataset.
+        metadata_extractor : ExtractVariableGroupAndLevel
+            Metadata extractor for variable groups and levels.
         norm : str, optional
             Type of normalization to apply. Options are None, unit-sum, unit-mean and l1.
         """
-        super().__init__(group_config, data_indices, metadata_variables=metadata_variables, norm=norm)
+        super().__init__(data_indices, metadata_extractor=metadata_extractor, norm=norm)
         del kwargs
         self.scaling_group = group
         self.y_intercept = y_intercept
@@ -128,21 +125,19 @@ class NoVariableLevelScaler(BaseVariableLevelScaler):
 
     def __init__(
         self,
-        group_config: DictConfig,
         data_indices: IndexCollection,
         group: str,
-        metadata_variables: dict | None = None,
+        metadata_extractor: ExtractVariableGroupAndLevel,
         **kwargs,
     ) -> None:
         """Initialise Scaler with constant scaling of 1."""
         del kwargs
         super().__init__(
-            group_config,
             data_indices,
             group,
             y_intercept=1.0,
             slope=0.0,
-            metadata_variables=metadata_variables,
+            metadata_extractor=metadata_extractor,
         )
 
     @staticmethod

--- a/training/src/anemoi/training/train/forecaster/forecaster.py
+++ b/training/src/anemoi/training/train/forecaster/forecaster.py
@@ -31,6 +31,7 @@ from anemoi.training.losses.utils import print_variable_scaling
 from anemoi.training.schemas.base_schema import BaseSchema
 from anemoi.training.schemas.base_schema import convert_to_omegaconf
 from anemoi.training.utils.enums import TensorDim
+from anemoi.training.utils.variables_metadata import ExtractVariableGroupAndLevel
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -103,22 +104,26 @@ class GraphForecaster(pl.LightningModule):
 
         self.logger_enabled = config.diagnostics.log.wandb.enabled or config.diagnostics.log.mlflow.enabled
 
+        metadata_extractor = ExtractVariableGroupAndLevel(
+            variable_groups=config.model_dump(by_alias=True).training.variable_groups,
+            metadata_variables=metadata["dataset"].get("variables_metadata"),
+        )
+
         # Instantiate all scalers with the training configuration
         self.scalers, self.delayed_scaler_builders = create_scalers(
             config.model_dump(by_alias=True).training.scalers,
-            group_config=config.model_dump(by_alias=True).training.variable_groups,
             data_indices=data_indices,
             graph_data=graph_data,
             statistics=statistics,
             statistics_tendencies=statistics_tendencies,
-            metadata_variables=metadata["dataset"].get("variables_metadata"),
+            metadata_extractor=metadata_extractor,
             output_mask=self.output_mask,
         )
 
         self.val_metric_ranges = get_metric_ranges(
             config,
             data_indices,
-            metadata["dataset"].get("variables_metadata"),
+            metadata_extractor=metadata_extractor,
         )
 
         self.loss = get_loss_function(

--- a/training/src/anemoi/training/utils/variables_metadata.py
+++ b/training/src/anemoi/training/utils/variables_metadata.py
@@ -135,6 +135,32 @@ class ExtractVariableGroupAndLevel:
 
         return self.default_group
 
+    def _is_metadata_trusted(self, variable_name: str) -> bool:
+        """Check if the metadata for a variable is trusted.
+
+        This checks if the variable has metadata and checks
+        for valid relations.
+
+        Parameters
+        ----------
+        variable_name : str
+            Name of the variable.
+
+        Returns
+        -------
+        bool
+            True if the metadata is trusted, False otherwise.
+        """
+        if variable_name not in self.metadata_variables:
+            return False
+
+        level = self.metadata_variables[variable_name].level
+        is_vertical_level = not self.metadata_variables[variable_name].is_surface_level
+
+        # If level is not None and is not a surface level, True
+        # If level is None and is a surface level, True
+        return is_vertical_level ^ (level is None)
+
     def get_param(self, variable_name: str) -> str:
         """Get the parameter from a variable_name.
 
@@ -154,8 +180,8 @@ class ExtractVariableGroupAndLevel:
             Either from the metadata or cracked
             name.
         """
-        if variable_name in self.metadata_variables:
-            # if metadata is available: get variable name and level from metadata
+        if self._is_metadata_trusted(variable_name):
+            # if metadata is available: get param from metadata
             return self.metadata_variables[variable_name].param
 
         return _crack_variable_name(variable_name)[0]
@@ -174,15 +200,9 @@ class ExtractVariableGroupAndLevel:
             Variable level, checks the variable metadata, or attempts
             to crack the name, if not found None.
         """
-        if variable_name in self.metadata_variables:
+        if self._is_metadata_trusted(variable_name):
             # if metadata is available: get level from metadata
-            level = self.metadata_variables[variable_name].level
-            is_surface_level = self.metadata_variables[variable_name].is_surface_level
-
-            if level is not None and not is_surface_level:
-                return level
-            if level is None and is_surface_level:
-                return level
+            return self.metadata_variables[variable_name].level
 
         return _crack_variable_name(variable_name)[1]
 

--- a/training/src/anemoi/training/utils/variables_metadata.py
+++ b/training/src/anemoi/training/utils/variables_metadata.py
@@ -160,7 +160,7 @@ class ExtractVariableGroupAndLevel:
 
         return _crack_variable_name(variable_name)[0]
 
-    def get_level(self, variable_name: str) -> str | None:
+    def get_level(self, variable_name: str) -> int | None:
         """Get the level of a variable.
 
         Parameters
@@ -170,13 +170,19 @@ class ExtractVariableGroupAndLevel:
 
         Returns
         -------
-        variable_level : str | None
+        variable_level : int | None
             Variable level, checks the variable metadata, or attempts
             to crack the name, if not found None.
         """
         if variable_name in self.metadata_variables:
-            # if metadata is available: get variable name and level from metadata
-            return self.metadata_variables[variable_name].level
+            # if metadata is available: get level from metadata
+            level = self.metadata_variables[variable_name].level
+            is_surface_level = self.metadata_variables[variable_name].is_surface_level
+
+            if level is not None and not is_surface_level:
+                return level
+            if level is None and is_surface_level:
+                return level
 
         return _crack_variable_name(variable_name)[1]
 

--- a/training/tests/unit/train/test_loss_scaling.py
+++ b/training/tests/unit/train/test_loss_scaling.py
@@ -20,6 +20,7 @@ from anemoi.training.losses.loss import get_metric_ranges
 from anemoi.training.losses.scalers import create_scalers
 from anemoi.training.utils.enums import TensorDim
 from anemoi.training.utils.masks import NoOutputMask
+from anemoi.training.utils.variables_metadata import ExtractVariableGroupAndLevel
 
 
 @pytest.fixture
@@ -214,13 +215,17 @@ def test_variable_loss_scaling_vals(
 ) -> None:
     config, data_indices, statistics, statistics_tendencies = fake_data
 
+    metadata_extractor = ExtractVariableGroupAndLevel(
+        config.training.variable_groups,
+    )
+
     scalers, _ = create_scalers(
         config.training.scalers.builders,
-        group_config=config.training.variable_groups,
         data_indices=data_indices,
         graph_data=graph_with_nodes,
         statistics=statistics,
         statistics_tendencies=statistics_tendencies,
+        metadata_extractor=metadata_extractor,
         output_mask=NoOutputMask(),
     )
 
@@ -235,7 +240,8 @@ def test_variable_loss_scaling_vals(
 def test_metric_range(fake_data: tuple[DictConfig, IndexCollection]) -> None:
     config, data_indices, _, _ = fake_data
 
-    metric_range = get_metric_ranges(config, data_indices)
+    metadata_extractor = ExtractVariableGroupAndLevel(config.training.variable_groups)
+    metric_range = get_metric_ranges(config, data_indices, metadata_extractor=metadata_extractor)
 
     del metric_range["all"]
 

--- a/training/tests/unit/utils/test_variable_grouping.py
+++ b/training/tests/unit/utils/test_variable_grouping.py
@@ -152,24 +152,41 @@ def test_group_matching_raises_error(
 
 
 @pytest.mark.parametrize(
-    ("variable", "metadata", "expected_level"),
+    ("variable", "metadata", "expected_level", "expected_variable"),
     [
         # Pressure level variables
-        ("q_100", {"param": "q"}, 100),  # Missing levelist, but variable name has level
-        ("q_100", {"param": "q", "levtype": "sfc", "levelist": "204"}, 100),  # Incorrect levelist
+        ("q_100", {"param": "q"}, 100, "q"),  # Missing levelist, but variable name has level
+        ("q_100", {}, 100, "q"),  # Missing all metadata, but variable name has level
+        ("q_100", {"param": "q", "levtype": "sfc", "levelist": "204"}, 100, "q"),  # Incorrect levelist
+        ("a_100", {"param": "q", "levtype": "sfc", "levelist": "204"}, 100, "a"),  # Incorrect levelist and param
         (
             "q_100",
             {"param": "q", "levtype": "pl"},
             100,
+            "q",
         ),  # If no levelist, and levtype is pl, return level from variable name
-        ("q_127", {"param": "q", "levtype": "pl", "levelist": 200}, 200),  # Trust correctly formatted metadata
+        ("q_127", {"param": "q", "levtype": "pl", "levelist": 200}, 200, "q"),  # Trust correctly formatted metadata
         # Surface variables
-        ("2t", {"param": "2t"}, None),  # Surface var
-        ("2t", {"param": "2t", "levtype": "sfc"}, None),  # Surface var
-        ("2t", {"param": "2t", "levtype": "sfc", "levelist": 200}, None),  # Surface var, but malformed with levelist
+        ("2t", {"param": "2t"}, None, "2t"),  # Surface var
+        ("2t", {"param": "2t", "levtype": "sfc"}, None, "2t"),  # Surface var
+        (
+            "2t",
+            {"param": "2t", "levtype": "sfc", "levelist": 200},
+            None,
+            "2t",
+        ),  # Surface var, but malformed with levelist
     ],
 )
-def test_failover_to_crack_in_malformed_data(variable: str, metadata: dict, expected_level: int | None) -> None:
+def test_failover_to_crack_in_malformed_data(
+    variable: str,
+    metadata: dict,
+    expected_level: int | None,
+    expected_variable: str,
+) -> None:
     extractor = ExtractVariableGroupAndLevel({"default": "default"}, {variable: {"mars": metadata}})
     level = extractor.get_level(variable)
     assert level == expected_level, f"Expected level {expected_level} for variable {variable}, but got {level}"
+    variable_name = extractor.get_param(variable)
+    assert (
+        variable_name == expected_variable
+    ), f"Expected variable name {expected_variable} for {variable}, but got {variable_name}"


### PR DESCRIPTION
## Description
Closes #404 
Some datasets have malformed metadata, and fail on the level retrieval

## What problem does this change solve?
This updates the logic, including checks for surface level if attempting to use the variable metadata.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
