### PR TITLE
fix(graphs): revert PR #397

### DIFF
--- a/graphs/src/anemoi/graphs/create.py
+++ b/graphs/src/anemoi/graphs/create.py
@@ -162,7 +162,9 @@ class GraphCreator:
             torch.save(graph, save_path)
             LOGGER.info(f"Graph saved at {save_path}.")
         else:
-            raise ValueError(f"Graph already exists at {save_path}. Use overwrite=True to overwrite.")
+            # The error is only logged for compatibility with multi-gpu training in anemoi-training.
+            # Currently, distributed graph creation is not supported so we create the same graph in each gpu.
+            LOGGER.error(f"Graph already exists at {save_path}. Use overwrite=True to overwrite.")
 
     def create(self, save_path: Path | None = None, overwrite: bool = False) -> HeteroData:
         """Create the graph and save it to the output path.

--- a/graphs/src/anemoi/graphs/create.py
+++ b/graphs/src/anemoi/graphs/create.py
@@ -162,7 +162,7 @@ class GraphCreator:
             torch.save(graph, save_path)
             LOGGER.info(f"Graph saved at {save_path}.")
         else:
-            # The error is only logged for compatibility with multi-gpu training in anemoi-training.
+            # The error is only logged for compatibility with multi-gpu training in anemoi-training.
             # Currently, distributed graph creation is not supported so we create the same graph in each gpu.
             LOGGER.error(f"Graph already exists at {save_path}. Use overwrite=True to overwrite.")
 


### PR DESCRIPTION
## Description
<!-- What issue or task does this change relate to? -->

Revert PR #379 .

Thanks to @havardhhaugen for spotting this.

## What problem does this change solve?
<!-- Describe if it's a bugfix, new feature, doc update, or breaking change -->

Raising an error during graph creation will break multi-GPU training. Currently, one limitation of `anemoi-graphs` is that it does not support distributed creation. For example, during multi-GPU training with on-the-fly graph creation, the same graph is created on all GPUs. In this case, raising an error will cause the code to fail on some of the GPUs.

## What issue or task does this change relate to?
<!-- link to Issue Number -->

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
