### PR TITLE
ci: Use uv in testing workflow 🚀

### DIFF
--- a/.github/workflows/python-pull-request.yml
+++ b/.github/workflows/python-pull-request.yml
@@ -1,4 +1,4 @@
-name: Test PR
+name: Code Quality and Testing
 
 on:
   pull_request:
@@ -9,6 +9,9 @@ on:
   schedule:
     - cron: "9 2 * * 0" # at 9:02 on sunday
   workflow_dispatch:
+
+env:
+  UV_SYSTEM_PYTHON: 1
 
 jobs:
   quality:
@@ -26,7 +29,7 @@ jobs:
     timeout-minutes: 60
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
         fetch-tags: true
@@ -35,17 +38,16 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-        cache: 'pip'
 
-    - name: Install test dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install pytest pytest-md pytest-emoji
+    - name: Install uv
+      uses: astral-sh/setup-uv@v6
+      with:
+        version: 0.7.19
 
     - name: Install packages
       run: |
         # Install all packages from local
-        pip install -e ./training[all,tests] -e ./graphs[all,tests] -e ./models[all,tests]
+        uv pip install -e ./training[all,tests] -e ./graphs[all,tests] -e ./models[all,tests] pytest pytest-md pytest-emoji
 
     - name: Run pytest for training package
       uses: pavelzw/pytest-action@v2


### PR DESCRIPTION
## Description
Replace the `pip install` with `uv pip install` in the testing workflow. This workflow was already reasonably fast, but with uv the dependency installation time goes from 1-3 min (depending on the arch and python version) down to 30s.

I also renamed the workflow to the same name used in the other anemois, for consistency. 


***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
