### PR TITLE
fix: Backward compatibility for inference

### DIFF
--- a/models/src/anemoi/models/layers/block.py
+++ b/models/src/anemoi/models/layers/block.py
@@ -702,8 +702,8 @@ class GraphTransformerMapperBlock(GraphTransformerBaseBlock):
         query, key, value, edges = self.get_qkve(x, edge_attr)
         if not hasattr(self, "shard_strategy"):
             query, key, value, edges = self.shard_qkve_heads(
-                    query, key, value, edges, shapes, batch_size, model_comm_group
-                )
+                query, key, value, edges, shapes, batch_size, model_comm_group
+            )
         else:
             if self.shard_strategy == "heads":
                 query, key, value, edges = self.shard_qkve_heads(

--- a/models/src/anemoi/models/layers/mapper.py
+++ b/models/src/anemoi/models/layers/mapper.py
@@ -424,6 +424,10 @@ class GraphTransformerBaseMapper(GraphEdgeMixin, BaseMapper):
         x_dst_is_sharded: bool = False,
         keep_x_dst_sharded: bool = False,
     ) -> PairTensor:
+        if not hasattr(self, "shard_strategy"):
+            return self.forward_with_heads_sharding(
+                x, batch_size, shard_shapes, model_comm_group, x_src_is_sharded, x_dst_is_sharded, keep_x_dst_sharded
+            )
         if self.shard_strategy == "edges":
             return self.forward_with_edge_sharding(
                 x, batch_size, shard_shapes, model_comm_group, x_src_is_sharded, x_dst_is_sharded, keep_x_dst_sharded

--- a/models/src/anemoi/models/models/encoder_processor_decoder.py
+++ b/models/src/anemoi/models/models/encoder_processor_decoder.py
@@ -159,7 +159,7 @@ class AnemoiModelEncProcDec(nn.Module):
 
     def _apply_truncation(self, x, grid_shard_shapes=None, model_comm_group=None):
         if not hasattr(self, "A_down") or not hasattr(self, "A_up"):
-            return x    
+            return x
         if self.A_down is not None or self.A_up is not None:
             if grid_shard_shapes is not None:
                 shard_shapes = self._get_shard_shapes(x, 0, grid_shard_shapes, model_comm_group)


### PR DESCRIPTION
## Description
Models from new anemoi versions have new attributes which are not expected for inference for older models (the forward call fails).

## What problem does this change solve?
We can run inference with models where no A_down/qk_norm/layer_norm_mlp_dst were defined.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
