### PR TITLE
Feature/postprocessor for nans in diagnostic fields

### DIFF
--- a/models/src/anemoi/models/preprocessing/imputer.py
+++ b/models/src/anemoi/models/preprocessing/imputer.py
@@ -92,7 +92,7 @@ class BaseImputer(BasePreprocessor, ABC):
                 # if the variable is not in inference input (diagnostic variable), we cannot place NaNs in its inference output
                 if method != self.default:
                     LOGGER.warning(
-                        "Placement of NaNs for diagnostic variables in inference output is not supported: {name}"
+                        f"If placement of NaNs for diagnostic variables in inference output is desired, this needs to be handled by postprocessors: {name}"
                     )
 
             self.index_training_input.append(name_to_index_training_input[name])

--- a/models/src/anemoi/models/preprocessing/postprocessor.py
+++ b/models/src/anemoi/models/preprocessing/postprocessor.py
@@ -202,23 +202,11 @@ class NormalizedReluPostprocessor(Postprocessor):
         return postprocessor_function
 
 
-class ConditionalZeroPostprocessor(Postprocessor):
-    """Sets values to specified value where another variable is zero.
+class ConditionalPostprocessor(Postprocessor):
+    """Base class for postprocessors that conditionally apply a transformation based on another variable.
 
-    Expects the config to have keys corresponding to customizable values and lists of variables to postprocess and a variable to use for postprocessing.:
-
-    ```
-    default: "none"
-    remap: "x"
-    0:
-        - y
-    5.0:
-        - x
-    3.14:
-        - q
-    ```
-
-    If "x" is zero, "y" will be postprocessed with 0, "x" with 5.0 and "q" with 3.14.
+    This class is intended to be subclassed for specific implementations.
+    It expects the config to have keys corresponding to customizable values and lists of variables to postprocess.
     """
 
     def __init__(
@@ -243,24 +231,9 @@ class ConditionalZeroPostprocessor(Postprocessor):
             self.masking_variable, None
         )
 
-    def _get_postprocessor_function(self, method: float, name: str):
-        """For ConditionalZeroPostprocessor, the 'method' is the constant value to fill
-        when the masking variable is zero. This function simply returns the value.
-        """
-        LOGGER.info(
-            f"ConditionalZeroPostprocessor: replacing valus in {name} with value {method} if {self.masking_variable} is zero."
-        )
-        return method
-
     def _expand_subset_mask(self, x: torch.Tensor, mask: torch.tensor) -> torch.Tensor:
         """Expand the subset of the mask to the correct shape."""
         return mask.expand(*x.shape[:-2], -1)
-
-    def get_zeros(self, x: torch.Tensor) -> torch.Tensor:
-        """Get zero mask from data"""
-        # The mask is only saved for the last dimension (grid)
-        idx = [slice(0, 1)] * (x.ndim - 2) + [slice(None), slice(None)]
-        return (x[idx] == 0).squeeze()
 
     def fill_with_value(self, x: torch.Tensor, index: list[int], fill_mask: torch.tensor):
         for idx_dst, value in zip(index, self.postprocessorfunctions):
@@ -286,7 +259,73 @@ class ConditionalZeroPostprocessor(Postprocessor):
                 f"({self.num_training_output_vars}) or inference shape ({self.num_inference_output_vars})",
             )
 
-        zero_mask = self.get_zeros(x[..., masking_variable])
+        postprocessor_mask = self.get_locations(x[..., masking_variable])
 
         # Replace values
-        return self.fill_with_value(x, index, zero_mask)
+        return self.fill_with_value(x, index, postprocessor_mask)
+
+
+class ConditionalZeroPostprocessor(ConditionalPostprocessor):
+    """Sets values to specified value where another variable is zero.
+
+    Expects the config to have keys corresponding to customizable values and lists of variables to postprocess and a variable to use for postprocessing.:
+
+    ```
+    default: "none"
+    remap: "x"
+    0:
+        - y
+    5.0:
+        - x
+    3.14:
+        - q
+    ```
+
+    If "x" is zero, "y" will be postprocessed with 0, "x" with 5.0 and "q" with 3.14.
+    """
+
+    def _get_postprocessor_function(self, method: float, name: str):
+        """For ConditionalZeroPostprocessor, the 'method' is the constant value to fill
+        when the masking variable is zero. This function simply returns the value.
+        """
+        LOGGER.info(
+            f"ConditionalZeroPostprocessor: replacing valus in {name} with value {method} if {self.masking_variable} is zero."
+        )
+        return method
+
+    def get_locations(self, x: torch.Tensor) -> torch.Tensor:
+        """Get zero mask from data"""
+        # The mask is only saved for the last dimension (grid)
+        idx = [slice(0, 1)] * (x.ndim - 2) + [slice(None), slice(None)]
+        return (x[idx] == 0).squeeze()
+
+
+class ConditionalNaNPostprocessor(ConditionalPostprocessor):
+    """Sets values to NaNs where another variable is NaN.
+
+    Expects the config to have list of variables to postprocess and a variable to use for postprocessing.:
+
+    ```
+    default: "none"
+    remap: "x"
+    nan:
+        - y
+    ```
+
+    If "x" is NaN, "y" will be postprocessed with NaN.
+    """
+
+    def _get_postprocessor_function(self, method: float, name: str):
+        """For ConditionalNaNPostprocessor, the 'method' is a NaN to fill
+        when the masking variable is NaN. This function simply returns a NaN.
+        """
+        LOGGER.info(
+            f"ConditionalNaNPostprocessor: replacing valus in {name} with value NaN if {self.masking_variable} is NaN."
+        )
+        return torch.nan
+
+    def get_locations(self, x: torch.Tensor) -> torch.Tensor:
+        """Get NaN mask from data"""
+        # The mask is only saved for the last dimension (grid)
+        idx = [slice(0, 1)] * (x.ndim - 2) + [slice(None), slice(None)]
+        return (torch.isnan(x[idx])).squeeze()

--- a/models/src/anemoi/models/schemas/data_processor.py
+++ b/models/src/anemoi/models/schemas/data_processor.py
@@ -42,8 +42,9 @@ class NormalizerSchema(BaseModel):
 class ImputerSchema(BaseModel):
     default: str = Field(literals=["none", "mean", "stdev"])
     "Imputer default method to apply."
-    maximum: Union[list[str], None]
-    minimum: Union[list[str], None]
+    maximum: Union[list[str], None] = Field(default_factory=list)
+    minimum: Union[list[str], None] = Field(default_factory=list)
+    mean: Union[list[str], None] = Field(default_factory=list)
     none: Union[list[str], None] = Field(default_factory=list)
     "Variables not to be imputed."
 
@@ -213,6 +214,17 @@ class ConditionalZeroPostprocessorSchema(RootModel[dict[Any, Any]]):
         return values
 
 
+class ConditionalNaNPostprocessorSchema(BaseModel):
+    default: str = Field(literals=["none", "nan"], default="none")
+    "Postprocessor default method to apply."
+    remap: str
+    "Name of conditional variable."
+    nan: Union[list[str], None] = Field(default_factory=list)
+    "Variables to postprocess with NaNs."
+    none: Union[list[str], None] = Field(default_factory=list)
+    "Variables not to be postprocessed."
+
+
 class RemapperSchema(BaseModel):
     default: str = Field(literals=["none", "log1p", "sqrt", "boxcox"])
     "Remapper default method to apply."
@@ -227,6 +239,7 @@ class PreprocessorTarget(str, Enum):
     remapper = "anemoi.models.preprocessing.remapper.Remapper"
     postprocessor = "anemoi.models.preprocessing.postprocessor.Postprocessor"
     conditional_zero_postprocessor = "anemoi.models.preprocessing.postprocessor.ConditionalZeroPostprocessor"
+    conditional_nan_postprocessor = "anemoi.models.preprocessing.postprocessor.ConditionalNaNPostprocessor"
     normalized_relu_postprocessor = "anemoi.models.preprocessing.postprocessor.NormalizedReluPostprocessor"
 
 
@@ -237,6 +250,7 @@ target_to_schema = {
     PreprocessorTarget.remapper: RemapperSchema,
     PreprocessorTarget.postprocessor: PostprocessorSchema,
     PreprocessorTarget.conditional_zero_postprocessor: ConditionalZeroPostprocessorSchema,
+    PreprocessorTarget.conditional_nan_postprocessor: ConditionalNaNPostprocessorSchema,
     PreprocessorTarget.normalized_relu_postprocessor: NormalizedReluPostprocessorSchema,
 }
 

--- a/training/src/anemoi/training/diagnostics/plots.py
+++ b/training/src/anemoi/training/diagnostics/plots.py
@@ -580,7 +580,7 @@ def plot_flat_sample(
         norms[1] = norm
         norms[2] = norm
 
-    if sum(input_) != 0:
+    if np.nansum(input_) != 0:
         # prognostic fields: plot input and increment as well
         data[0] = input_
         data[4] = pred - input_


### PR DESCRIPTION
## Description
Place NaNs in the output of diagnostic variables at locations of NaNs of another variable.

## What problem does this change solve?
The new logic of the imputer takes the NaN locations from the input and places them in the output. This is not possible for diagnostic variables as they are not present in the input.

## What issue or task does this change relate to?
Part of https://github.com/ecmwf/anemoi-core/issues/370


***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
