### PR TITLE
test: replace longtest markers with slow

### DIFF
--- a/.github/workflows/integration-tests-hpc.yml
+++ b/.github/workflows/integration-tests-hpc.yml
@@ -41,7 +41,7 @@ jobs:
             source .venv/bin/activate
             pip install --upgrade pip
             pip install -e ./training[all,tests] -e ./models[all,tests] -e ./graphs[all,tests]
-            python3 -m pytest -v training/tests/integration --longtests
+            python3 -m pytest -v training/tests/integration --slow
             deactivate
             rm -rf $REPO_NAME
           sbatch_options: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -15,7 +15,7 @@ jobs:
           python-version: '3.10'
           install-package: "-e ./training[all,tests] -e ./graphs[all,tests] -e ./models[all,tests]"
           test-directory: "training/tests/integration"
-          pytest-options: "--longtests"
+          pytest-options: "--slow"
           manual: ${{github.event_name == 'workflow_dispatch' && 'true' || 'false'}}
 
   notify-team:

--- a/training/docs/contributing.rst
+++ b/training/docs/contributing.rst
@@ -244,7 +244,7 @@ available, then from the top-level directory of anemoi-core run:
 
 .. code:: bash
 
-   pytest training/tests/integration --longtests
+   pytest training/tests/integration --slow
 
 *********************************************
  Configuration handling in integration tests

--- a/training/pyproject.toml
+++ b/training/pyproject.toml
@@ -86,7 +86,7 @@ optional-dependencies.profile = [
   "rich>=13.6",
   "tabulate>=0.9",
 ]
-optional-dependencies.tests = [ "hypothesis>=6.11", "pytest>=8", "pytest-mock>=3" ]
+optional-dependencies.tests = [ "hypothesis>=6.11", "pytest>=8", "pytest-mock>=3", "pytest-skip-slow>=0.0.5" ]
 urls.Changelog = "https://github.com/ecmwf/anemoi-training/CHANGELOG.md"
 urls.Documentation = "https://anemoi-training.readthedocs.io/"
 urls.Homepage = "https://github.com/ecmwf/anemoi-training/"

--- a/training/pytest.ini
+++ b/training/pytest.ini
@@ -3,7 +3,7 @@ markers =
     data_dependent: marks tests depending on data (deselect with '-m "not data_dependent"')
     auth: marks tests that require authentication (deselect with '-m "not auth"')
     gpu: marks tests that require a GPU (deselect with '-m "not gpu"')
-    longtests: mark test as long-running (skipped unless --longtests is used)
+    slow: mark test as slow (skipped unless --slow is used)
 
 
 tmp_path_retention_policy = none

--- a/training/tests/conftest.py
+++ b/training/tests/conftest.py
@@ -22,30 +22,6 @@ from anemoi.training.data.datamodule import AnemoiDatasetsDataModule
 pytest_plugins = "anemoi.utils.testing"
 
 
-def pytest_addoption(parser: pytest.Parser) -> None:
-    parser.addoption(
-        "--longtests",
-        action="store_true",
-        dest="longtests",
-        default=False,
-        help="enable tests marked as longtests",
-    )
-
-
-def pytest_configure(config: pytest.Config) -> None:
-    """Register the 'longtests' marker to avoid warnings."""
-    config.addinivalue_line("markers", "longtests: mark tests as long-running")
-
-
-def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
-    """Automatically skip @pytest.mark.longtests tests unless --longtests is used."""
-    if not config.getoption("--longtests"):
-        skip_marker = pytest.mark.skip(reason="Skipping long test, use --longtests to enable")
-        for item in items:
-            if item.get_closest_marker("longtests"):
-                item.add_marker(skip_marker)
-
-
 @pytest.fixture
 def config(request: SubRequest) -> DictConfig:
     overrides = request.param

--- a/training/tests/integration/aicon/test_cicd_aicon_04_icon-dream_medium.py
+++ b/training/tests/integration/aicon/test_cicd_aicon_04_icon-dream_medium.py
@@ -99,7 +99,7 @@ def test_config_validation_aicon(aicon_config_with_tmp_dir: DictConfig) -> None:
     BaseSchema(**aicon_config_with_tmp_dir)
 
 
-@pytest.mark.longtests
+@pytest.mark.slow
 @typechecked
 def test_aicon_metadata(aicon_config_with_grid: DictConfig) -> None:
     """Test for presence of metadata required for inference.
@@ -134,7 +134,7 @@ def test_aicon_metadata(aicon_config_with_grid: DictConfig) -> None:
     assert trainer.model.model.model.decoder.proc.num_chunks == aicon_config_with_grid.model.decoder.num_chunks
 
 
-@pytest.mark.longtests
+@pytest.mark.slow
 @typechecked
 def test_aicon_training(trained_aicon: tuple) -> None:
     trainer, initial_sum, final_sum = trained_aicon

--- a/training/tests/integration/test_training_cycle.py
+++ b/training/tests/integration/test_training_cycle.py
@@ -26,7 +26,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 @skip_if_offline
-@pytest.mark.longtests
+@pytest.mark.slow
 def test_training_cycle_architecture_configs(
     architecture_config: tuple[DictConfig, str],
     get_test_archive: GetTestArchive,
@@ -42,7 +42,7 @@ def test_config_validation_architecture_configs(architecture_config: tuple[DictC
 
 
 @skip_if_offline
-@pytest.mark.longtests
+@pytest.mark.slow
 def test_training_cycle_without_config_validation(
     gnn_config: tuple[DictConfig, str],
     get_test_archive: GetTestArchive,
@@ -56,7 +56,7 @@ def test_training_cycle_without_config_validation(
 
 
 @skip_if_offline
-@pytest.mark.longtests
+@pytest.mark.slow
 def test_training_cycle_stretched(
     stretched_config: tuple[DictConfig, list[str]],
     get_test_archive: GetTestArchive,
@@ -73,7 +73,7 @@ def test_config_validation_stretched(stretched_config: tuple[DictConfig, list[st
 
 
 @skip_if_offline
-@pytest.mark.longtests
+@pytest.mark.slow
 def test_training_cycle_lam(lam_config: tuple[DictConfig, list[str]], get_test_archive: GetTestArchive) -> None:
     cfg, urls = lam_config
     for url in urls:
@@ -82,7 +82,7 @@ def test_training_cycle_lam(lam_config: tuple[DictConfig, list[str]], get_test_a
 
 
 @skip_if_offline
-@pytest.mark.longtests
+@pytest.mark.slow
 def test_training_cycle_lam_with_existing_graph(
     lam_config_with_graph: tuple[DictConfig, list[str]],
     get_test_archive: GetTestArchive,
@@ -99,7 +99,7 @@ def test_config_validation_lam(lam_config: DictConfig) -> None:
 
 
 @skip_if_offline
-@pytest.mark.longtests
+@pytest.mark.slow
 def test_training_cycle_ensemble(ensemble_config: tuple[DictConfig, str], get_test_archive: GetTestArchive) -> None:
     cfg, url = ensemble_config
     get_test_archive(url)
@@ -112,7 +112,7 @@ def test_config_validation_ensemble(ensemble_config: tuple[DictConfig, str]) -> 
 
 
 @skip_if_offline
-@pytest.mark.longtests
+@pytest.mark.slow
 def test_training_cycle_hierarchical(
     hierarchical_config: tuple[DictConfig, list[str]],
     get_test_archive: GetTestArchive,
@@ -129,7 +129,7 @@ def test_config_validation_hierarchical(hierarchical_config: tuple[DictConfig, l
 
 
 @skip_if_offline
-@pytest.mark.longtests
+@pytest.mark.slow
 def test_restart_training(gnn_config: tuple[DictConfig, str], get_test_archive: GetTestArchive) -> None:
     cfg, url = gnn_config
     get_test_archive(url)
@@ -156,7 +156,7 @@ def test_restart_training(gnn_config: tuple[DictConfig, str], get_test_archive: 
 
 
 @skip_if_offline
-@pytest.mark.longtests
+@pytest.mark.slow
 def test_restart_from_existing_checkpoint(
     gnn_config_with_checkpoint: tuple[DictConfig, str],
     get_test_archive: GetTestArchive,
@@ -167,7 +167,7 @@ def test_restart_from_existing_checkpoint(
 
 
 @skip_if_offline
-@pytest.mark.longtests
+@pytest.mark.slow
 def test_training_cycle_interpolator(
     interpolator_config: tuple[DictConfig, str],
     get_test_archive: GetTestArchive,


### PR DESCRIPTION
## Description
This PR replaces the longtest markers and --longtests cli option for pytest with slow markers and --slow.

## What problem does this change solve?
Make markers and cli for slow tests consistent across the anemoi packages.

## What issue or task does this change relate to?
https://github.com/ecmwf/anemoi-core/issues/257

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
