### PR TITLE
perf: Avoid heavy imports through MlflowSchema

### DIFF
--- a/training/src/anemoi/training/diagnostics/logger.py
+++ b/training/src/anemoi/training/diagnostics/logger.py
@@ -36,8 +36,8 @@ def get_mlflow_logger(config: BaseSchema) -> None:
     os.environ["MLFLOW_HTTP_REQUEST_BACKOFF_FACTOR"] = "2"
     os.environ["MLFLOW_HTTP_REQUEST_BACKOFF_JITTER"] = "1"
 
-    from anemoi.training.diagnostics.mlflow.logger import LOG_MODEL
-    from anemoi.training.diagnostics.mlflow.logger import MAX_PARAMS_LENGTH
+    from anemoi.training.diagnostics.mlflow import LOG_MODEL
+    from anemoi.training.diagnostics.mlflow import MAX_PARAMS_LENGTH
     from anemoi.training.diagnostics.mlflow.logger import AnemoiMLflowLogger
 
     resumed = config.training.run_id is not None

--- a/training/src/anemoi/training/diagnostics/mlflow/__init__.py
+++ b/training/src/anemoi/training/diagnostics/mlflow/__init__.py
@@ -6,3 +6,6 @@
 # In applying this licence, ECMWF does not waive the privileges and immunities
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
+
+MAX_PARAMS_LENGTH = 2000
+LOG_MODEL = False

--- a/training/src/anemoi/training/diagnostics/mlflow/logger.py
+++ b/training/src/anemoi/training/diagnostics/mlflow/logger.py
@@ -30,6 +30,7 @@ from pytorch_lightning.loggers.mlflow import _flatten_dict
 from pytorch_lightning.utilities.rank_zero import rank_zero_only
 from typing_extensions import override
 
+from anemoi.training.diagnostics.mlflow import MAX_PARAMS_LENGTH
 from anemoi.training.diagnostics.mlflow.utils import FixedLengthSet
 from anemoi.training.diagnostics.mlflow.utils import clean_config_params
 from anemoi.training.diagnostics.mlflow.utils import expand_iterables
@@ -37,9 +38,6 @@ from anemoi.utils.mlflow.auth import TokenAuth
 from anemoi.utils.mlflow.utils import health_check
 
 LOGGER = logging.getLogger(__name__)
-
-MAX_PARAMS_LENGTH = 2000
-LOG_MODEL = False
 
 
 class LogsMonitor:
@@ -317,7 +315,11 @@ class AnemoiMLflowLogger(MLFlowLogger):
             if offline:
                 LOGGER.info("MLflow is logging offline.")
             else:
-                LOGGER.info("MLflow token authentication %s for %s", "enabled" if enabled else "disabled", tracking_uri)
+                LOGGER.info(
+                    "MLflow token authentication %s for %s",
+                    "enabled" if enabled else "disabled",
+                    tracking_uri,
+                )
                 self.auth.authenticate()
                 health_check(tracking_uri)
 
@@ -538,7 +540,12 @@ class AnemoiMLflowLogger(MLFlowLogger):
         log_monitor.start()
 
     @rank_zero_only
-    def log_hyperparams(self, params: dict[str, Any] | Namespace, *, expand_keys: list[str] | None = None) -> None:
+    def log_hyperparams(
+        self,
+        params: dict[str, Any] | Namespace,
+        *,
+        expand_keys: list[str] | None = None,
+    ) -> None:
         """Overwrite the log_hyperparams method.
 
         - flatten config params using '.'.

--- a/training/src/anemoi/training/schemas/diagnostics.py
+++ b/training/src/anemoi/training/schemas/diagnostics.py
@@ -18,7 +18,7 @@ from pydantic import NonNegativeInt
 from pydantic import PositiveInt
 from pydantic import root_validator
 
-from anemoi.training.diagnostics.mlflow.logger import MAX_PARAMS_LENGTH
+from anemoi.training.diagnostics.mlflow import MAX_PARAMS_LENGTH
 from anemoi.utils.schemas import BaseModel
 
 LOGGER = logging.getLogger(__name__)

--- a/training/src/anemoi/training/utils/mlflow_sync.py
+++ b/training/src/anemoi/training/utils/mlflow_sync.py
@@ -19,7 +19,7 @@ from urllib.parse import urlparse
 
 import mlflow.entities
 
-from anemoi.training.diagnostics.mlflow.logger import MAX_PARAMS_LENGTH
+from anemoi.training.diagnostics.mlflow import MAX_PARAMS_LENGTH
 from anemoi.training.diagnostics.mlflow.utils import clean_config_params
 
 
@@ -77,7 +77,13 @@ LOGGER = logging.getLogger(__name__)
 
 
 # # This functions are based on the existing functions in mlflow_export_import.run.run_data_importer.py
-def _log_tags(client: mlflow.MlflowClient, run_dct: dict, run_id: str, batch_size: int, src_user_id: str) -> None:
+def _log_tags(
+    client: mlflow.MlflowClient,
+    run_dct: dict,
+    run_id: str,
+    batch_size: int,
+    src_user_id: str,
+) -> None:
     def get_data(run_dct: dict, *args) -> list:
         del args  # unused
         tags = run_dct["tags"]
@@ -213,7 +219,12 @@ class MlFlowSync:
             artifact_path = Path(temp_dir, run.info.run_id)
             artifact_path.mkdir(parents=True, exist_ok=True)
         else:
-            artifact_path = Path(self.source_tracking_uri, run.info.experiment_id, run.info.run_id, "artifacts")
+            artifact_path = Path(
+                self.source_tracking_uri,
+                run.info.experiment_id,
+                run.info.run_id,
+                "artifacts",
+            )
 
         return artifact_path
 
@@ -226,7 +237,12 @@ class MlFlowSync:
 
         mlflow.set_tracking_uri(self.source_tracking_uri)  # OTHERWISE IT WILL NOT WORK
         artifacts = client.list_artifacts(run_id)
-        LOGGER.info("Downloading artifacts %s for run %s to %s", len(artifacts), run_id, artifact_path)
+        LOGGER.info(
+            "Downloading artifacts %s for run %s to %s",
+            len(artifacts),
+            run_id,
+            artifact_path,
+        )
         for artifact in artifacts:
             # Download artifact file from the server
             mlflow.artifacts.download_artifacts(run_id=run_id, artifact_path=artifact.path, dst_path=artifact_path)
@@ -314,7 +330,11 @@ class MlFlowSync:
         server2server = self._check_source_tracking_uri()
         run_logged = self.check_run_is_logged(status=run.info.status)
         if run_logged:
-            LOGGER.info("Run already imported %s into experiment %s", self.run_id, self.experiment_name)
+            LOGGER.info(
+                "Run already imported %s into experiment %s",
+                self.run_id,
+                self.experiment_name,
+            )
             return
 
         if run.info.lifecycle_stage == "deleted" and not self.export_deleted_runs:


### PR DESCRIPTION
## Description
The MlflowSchema uses an imported constant [MAX_PARAMS_LENGTH](https://github.com/ecmwf/anemoi-core/blob/87a61c0901c7e291b164912bbe4613dace3677ca/training/src/anemoi/training/schemas/diagnostics.py#L284)

That constant lives in the diagnostics.mlflow.logger module, which imports PTL that in turn pulls in a bunch of heavy imports like torch. 

The result is that anywhere the BaseSchema is imported, we now also import torch for no good reason. For example, in the [config CLI](https://github.com/ecmwf/anemoi-core/blob/87a61c0901c7e291b164912bbe4613dace3677ca/training/src/anemoi/training/commands/config.py#L30), slowing it down massively the first time you run the command. 

This is solved by moving the constant to a place that doesn't do heavy imports. I moved it to the top level mlflow module. 
pre-commit hook also reformatted some stuff, not sure why but seems fine.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
