### PR TITLE
docs: update diffusion documentation

### DIFF
--- a/training/docs/user-guide/diffusion-set-up.rst
+++ b/training/docs/user-guide/diffusion-set-up.rst
@@ -78,7 +78,7 @@ The diffusion configuration includes:
 -  `rho`: Controls the noise schedule distribution
 -  `noise_embedder`: Sinusoidal embeddings for noise conditioning
 -  `inference_defaults`: Default parameters for noise scheduler and
-   sampler
+   sampler, these are not used during training.
 
 .. code:: yaml
 


### PR DESCRIPTION
## Description
Fixes for diffusion documentation

<!-- readthedocs-preview anemoi-training start -->
----
📚 Documentation preview 📚: https://anemoi-training--486.org.readthedocs.build/en/486/

<!-- readthedocs-preview anemoi-training end -->

<!-- readthedocs-preview anemoi-graphs start -->
----
📚 Documentation preview 📚: https://anemoi-graphs--486.org.readthedocs.build/en/486/

<!-- readthedocs-preview anemoi-graphs end -->

<!-- readthedocs-preview anemoi-models start -->
----
📚 Documentation preview 📚: https://anemoi-models--486.org.readthedocs.build/en/486/

<!-- readthedocs-preview anemoi-models end -->