### PR TITLE
docs: explain inference overrides

### DIFF
--- a/training/docs/user-guide/diffusion-set-up.rst
+++ b/training/docs/user-guide/diffusion-set-up.rst
@@ -121,6 +121,26 @@ These defaults can be overridden at inference time by passing
 `noise_scheduler_params` and `sampler_params` to the `predict_step`
 method.
 
+Here is an example of how to modify inference settings for a diffusion
+model in your configuration:
+
+.. code:: yaml
+
+   checkpoint: /path/to/your/checkpoint
+   date: 20250101T00:00:00
+   predict_kwargs:
+     noise_scheduler_params:
+       num_steps: 20
+       sigma_max: 90.0
+       sigma_min: 0.03
+       rho: 7.0
+     sampler_params:
+       sampler: "heun"
+       S_churn: 2.5
+       S_min: 0.75
+       S_max: 90
+       S_noise: 1.05
+
 ****************************
  Changes in training config
 ****************************


### PR DESCRIPTION
## Description
Example of how to override inference defaults in diffusion

<!-- readthedocs-preview anemoi-training start -->
----
📚 Documentation preview 📚: https://anemoi-training--487.org.readthedocs.build/en/487/

<!-- readthedocs-preview anemoi-training end -->

<!-- readthedocs-preview anemoi-graphs start -->
----
📚 Documentation preview 📚: https://anemoi-graphs--487.org.readthedocs.build/en/487/

<!-- readthedocs-preview anemoi-graphs end -->

<!-- readthedocs-preview anemoi-models start -->
----
📚 Documentation preview 📚: https://anemoi-models--487.org.readthedocs.build/en/487/

<!-- readthedocs-preview anemoi-models end -->