### PR TITLE
fix(training): callbacks when using rollout 

### DIFF
--- a/training/src/anemoi/training/diagnostics/callbacks/plot.py
+++ b/training/src/anemoi/training/diagnostics/callbacks/plot.py
@@ -994,11 +994,12 @@ class PlotSample(BasePerBatchPlotCallback):
             .cpu()
         )
         data = self.post_processors(input_tensor)[self.sample_idx]
-        output_tensor = torch.cat(tuple(
-            self.post_processors(
-                x[:, ...].detach().cpu(), in_place=False
-            )[self.sample_idx : self.sample_idx + 1] for x in outputs[1]
-        ))
+        output_tensor = torch.cat(
+            tuple(
+                self.post_processors(x[:, ...].detach().cpu(), in_place=False)[self.sample_idx : self.sample_idx + 1]
+                for x in outputs[1]
+            ),
+        )
         output_tensor = pl_module.output_mask.apply(output_tensor, dim=1, fill_value=np.nan).numpy()
         data[1:, ...] = pl_module.output_mask.apply(data[1:, ...], dim=2, fill_value=np.nan)
         data = data.numpy()
@@ -1051,11 +1052,12 @@ class BasePlotAdditionalMetrics(BasePerBatchPlotCallback):
             .cpu()
         )
         data = self.post_processors(input_tensor)[self.sample_idx]
-        output_tensor = torch.cat(tuple(
-            self.post_processors(
-                x[:, ...].detach().cpu(), in_place=False
-            )[self.sample_idx : self.sample_idx + 1] for x in outputs[1]
-        ))
+        output_tensor = torch.cat(
+            tuple(
+                self.post_processors(x[:, ...].detach().cpu(), in_place=False)[self.sample_idx : self.sample_idx + 1]
+                for x in outputs[1]
+            ),
+        )
         output_tensor = pl_module.output_mask.apply(output_tensor, dim=1, fill_value=np.nan).numpy()
         data[1:, ...] = pl_module.output_mask.apply(data[1:, ...], dim=2, fill_value=np.nan)
         data = data.numpy()


### PR DESCRIPTION
## Description

Since the imputer depends on the batchsize now, we need to first apply the postprocessors, and then concatenate several forecast steps when rollout is >1. This PR solves this. 
See artifacts on mlflow here: https://mlflow.ecmwf.int/#/experiments/335/runs/d568028a6ef941779f4fb7e3e0941f49/artifacts

At the moment, on main, the callbacks when using rollout > 1 and the imputer fail with a size-missmatch error.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
