### PR TITLE
fix(training): sharding nan_loss_mask scaler

### DIFF
--- a/training/src/anemoi/training/diagnostics/callbacks/plot.py
+++ b/training/src/anemoi/training/diagnostics/callbacks/plot.py
@@ -914,7 +914,6 @@ class PlotLoss(BasePerBatchPlotCallback):
         batch_idx: int,
     ) -> None:
 
-
         if batch_idx % self.every_n_batches == 0:
 
             self.loss = copy.deepcopy(pl_module.loss)

--- a/training/src/anemoi/training/diagnostics/callbacks/plot.py
+++ b/training/src/anemoi/training/diagnostics/callbacks/plot.py
@@ -875,7 +875,7 @@ class PlotLoss(BasePerBatchPlotCallback):
             metadata_variables=self.metadata_variables,
         )
         self.parameter_names = [self.parameter_names[i] for i in argsort_indices]
-        if not isinstance(pl_module.loss, BaseLoss):
+        if not isinstance(self.loss, BaseLoss):
             LOGGER.warning(
                 "Loss function must be a subclass of BaseLoss, or provide `squash`.",
                 RuntimeWarning,
@@ -891,7 +891,7 @@ class PlotLoss(BasePerBatchPlotCallback):
                 ...,
                 pl_module.data_indices.data.output.full,
             ]
-            loss = pl_module.loss(y_hat, y_true, squash=False).detach().cpu().numpy()
+            loss = self.loss(y_hat, y_true, squash=False).detach().cpu().numpy()
 
             sort_by_parameter_group, colors, xticks, legend_patches = self.sort_and_color_by_parameter_group
             loss = loss[argsort_indices]
@@ -903,6 +903,31 @@ class PlotLoss(BasePerBatchPlotCallback):
                 epoch=epoch,
                 tag=f"loss_rstep_rstep{rollout_step:02d}_rank{pl_module.local_rank:01d}",
                 exp_log_tag=f"loss_sample_rstep{rollout_step:02d}_rank{pl_module.local_rank:01d}",
+            )
+
+    def on_validation_batch_end(
+        self,
+        trainer: pl.Trainer,
+        pl_module: pl.LightningModule,
+        output: list[torch.Tensor],
+        batch: torch.Tensor,
+        batch_idx: int,
+    ) -> None:
+
+
+        if batch_idx % self.every_n_batches == 0:
+
+            self.loss = copy.deepcopy(pl_module.loss)
+
+            if hasattr(self.loss.scaler, "nan_mask_weights"):
+                self.loss.scaler.nan_mask_weights = pl_module.allgather_batch(self.loss.scaler.nan_mask_weights)
+
+            super().on_validation_batch_end(
+                trainer,
+                pl_module,
+                output,
+                batch,
+                batch_idx,
             )
 
 

--- a/training/src/anemoi/training/losses/scaler_tensor.py
+++ b/training/src/anemoi/training/losses/scaler_tensor.py
@@ -186,7 +186,7 @@ class ScaleTensor(nn.Module):
             dimension = [dimension]
 
         for scaler_dim, dim in enumerate(dimension):
-            if dim not in self or scaler.shape[scaler_dim] == 1 or self.shape[dim] == 1:
+            if dim not in self or scaler.shape[scaler_dim] == 1 or self.shape[dim] == 1 or dim == TensorDim.GRID:
                 continue
 
             if self.shape[dim] != scaler.shape[scaler_dim]:
@@ -558,7 +558,7 @@ class ScaleTensor(nn.Module):
         for dims, scaler in tensors.values():
             if TensorDim.GRID in dims and grid_shard_slice is not None:
                 grid_index = dims.index(TensorDim.GRID)
-                if scaler.shape[grid_index] > 1:
+                if scaler.shape[grid_index] >= grid_shard_slice.stop:
                     slices = [slice(None)] * len(dims)
                     slices[grid_index] = grid_shard_slice
                     scaler = scaler[tuple(slices)]


### PR DESCRIPTION
Sharding over grid dimension for nan_mask_weights scaler fails at the moment on main.

Changes:
- do not validate sharded dims for scalers
- deep copy of loss function to gather nan scaler over grid dim for plotloss callback

Tested for:
- sharding over grid dimension
- with and without nan_mask_weights
- with and without imputer

## What problem does this change solve?
The scaler validation, which is triggered after every scaler definition and update, was causing an error, as the nan scaler is shared over the grid dimension.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
