### PR TITLE
ci: Add checkpoint migrations workflow

### DIFF
--- a/.github/workflows/pr-release.yml
+++ b/.github/workflows/pr-release.yml
@@ -1,0 +1,43 @@
+# This workflow runs on release PRs created by release-please (DeployDuck).
+# Here we can do extra things required before releasing.
+name: "[PR] Release"
+
+on:
+  pull_request:
+    branches:
+      - main
+      - hotfix/*
+    paths:
+      - .release-please-manifest.json
+    types: [opened, synchronize, reopened]
+
+jobs:
+  migrations:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+      - name: "Replace migrations placeholder with next version"
+        run: |
+          MIGRATION_FOLDER=models/src/anemoi/models/migrations/scripts
+          NEXT_MODELS_VERSION=$(jq -r '."models"' .release-please-manifest.json)
+
+          echo "Next version: $NEXT_MODELS_VERSION"
+
+          find $MIGRATION_FOLDER -type f -name "*.py" -print0 | while IFS= read -r -d '' file; do
+            sed -i "s/%NEXT_ANEMOI_MODELS_VERSION%/$NEXT_MODELS_VERSION/g" "$file"
+          done
+
+          echo "$(git diff)"
+
+          if [ -n "$(git status --porcelain)" ]; then
+            git config user.name "DeployDuck"
+            git config user.email "150700357+DeployDuck@users.noreply.github.com"
+            git add .
+            git commit -m "chore: Update checkpoint migrations placeholder to $NEXT_MODELS_VERSION"
+            git push
+          else
+            echo "Nothing to commit, migrations are up to date."
+          fi


### PR DESCRIPTION
## Description
The upcoming checkpoint migrations rely on the migration files having a reference to the next anemoi-models version that the migration is targeting. This is done with a placeholder `%NEXT_ANEMOI_MODELS_VERSION%` that is replaced on release time with the version being released.

This workflow does that. It runs on the release-please (DeployDuck) PRs, and it updates the placeholder in all the migration files and commits it to the release-please branch. If there are no migrations to update, it does nothing. Since release-please regularly force-pushes its branch to the latest state of main, any new migrations made since the opening of the PR will be automatically updated.

When the release PR is merged, the migrations go into main with the correct versions.

I made it a general workflow where we can put all future things to do at release time.

## What issue or task does this change relate to?
#386


***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
