### PR TITLE
fix GraphInterpolator Lightning Module - add rollout member for compa…

### DIFF
--- a/training/src/anemoi/training/train/tasks/interpolator.py
+++ b/training/src/anemoi/training/train/tasks/interpolator.py
@@ -83,6 +83,8 @@ class GraphInterpolator(BaseGraphModule):
         sorted_indices = sorted(set(self.boundary_times + self.interp_times))
         self.imap = {data_index: batch_index for batch_index, data_index in enumerate(sorted_indices)}
 
+        self.rollout = 1
+
     def _step(
         self,
         batch: torch.Tensor,


### PR DESCRIPTION
…t with callbacks & DataLoading

## Description

PR #399 created a BaseGraphModule which all LightningModule classes now inherit from. Previously, Interpolator Lightning Module inherited from the Forecastor Lightning Module. The new Graph Interpolator Lightning Module after #PR399 did not inherit from Forecastor Lightning Module which previously assigned itself a "rollout" attribute. 

This fix simply adds a self.rollout = 1 to the __init__ of The Interpolator Lightning Module. 

This is needed for compatibility with callbacks 

## What problem does this change solve?
bug-fix - see above


## What issue or task does this change relate to?
NA

##  Additional notes ##

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
