### PR TITLE
feat: Extend restart checkpoint to consider graphtransformer

### DIFF
--- a/training/tests/integration/conftest.py
+++ b/training/tests/integration/conftest.py
@@ -236,23 +236,28 @@ def gnn_config(testing_modifications_with_temp_dir: DictConfig, get_tmp_paths: G
 
 @pytest.fixture
 def architecture_config_with_checkpoint(
+    request: pytest.FixtureRequest,
     architecture_config: tuple[DictConfig, str],
     get_test_data: GetTestData,
 ) -> tuple[DictConfig, str]:
     cfg, dataset_url = architecture_config
 
+    model_type = request._pyfuncitem.callspec.params["architecture_config"][0]
+
     # Pick checkpoint path based on the model
-    if "gnn" in cfg.model.architecture:
-        ckpt_name = ("anemoi-integration-tests/training/checkpoints/testing-checkpoint-gnn-global-2025-07-31.ckpt",)
-    elif "graphtransformer" in cfg.model.architecture:
-        ckpt_name = (
+    if "gnn" in model_type:
+        existing_ckpt = get_test_data(
+            "anemoi-integration-tests/training/checkpoints/testing-checkpoint-gnn-global-2025-07-31.ckpt",
+        )
+    elif "graphtransformer" in model_type:
+        existing_ckpt = get_test_data(
             "anemoi-integration-tests/training/checkpoints/testing-checkpoint-graphtransformer-global-2025-07-31.ckpt",
         )
+
     else:
         msg_error = f"Unknown architecture in config: {cfg.model.architecture}"
         raise ValueError(msg_error)
 
-    existing_ckpt = get_test_data(ckpt_name)
     checkpoint_dir = Path(cfg.hardware.paths.output + "checkpoint/dummy_id")
     checkpoint_dir.mkdir(parents=True, exist_ok=True)
     shutil.copy(existing_ckpt, checkpoint_dir / "last.ckpt")

--- a/training/tests/integration/conftest.py
+++ b/training/tests/integration/conftest.py
@@ -8,6 +8,7 @@
 # nor does it submit to any jurisdiction.
 
 
+import logging
 import os
 import shutil
 from pathlib import Path
@@ -20,6 +21,8 @@ from omegaconf import OmegaConf
 
 from anemoi.utils.testing import GetTestData
 from anemoi.utils.testing import TemporaryDirectoryForTestData
+
+LOGGER = logging.getLogger(__name__)
 
 
 @pytest.fixture(autouse=True)
@@ -232,14 +235,24 @@ def gnn_config(testing_modifications_with_temp_dir: DictConfig, get_tmp_paths: G
 
 
 @pytest.fixture
-def gnn_config_with_checkpoint(
-    gnn_config: tuple[DictConfig, str],
+def architecture_config_with_checkpoint(
+    architecture_config: tuple[DictConfig, str],
     get_test_data: GetTestData,
 ) -> tuple[DictConfig, str]:
-    cfg, dataset_url = gnn_config
-    existing_ckpt = get_test_data(
-        "anemoi-integration-tests/training/checkpoints/testing-checkpoint-global-2025-07-31.ckpt",
-    )
+    cfg, dataset_url = architecture_config
+
+    # Pick checkpoint path based on the model
+    if "gnn" in cfg.model.architecture:
+        ckpt_name = ("anemoi-integration-tests/training/checkpoints/testing-checkpoint-gnn-global-2025-07-31.ckpt",)
+    elif "graphtransformer" in cfg.model.architecture:
+        ckpt_name = (
+            "anemoi-integration-tests/training/checkpoints/testing-checkpoint-graphtransformer-global-2025-07-31.ckpt",
+        )
+    else:
+        msg_error = f"Unknown architecture in config: {cfg.model.architecture}"
+        raise ValueError(msg_error)
+
+    existing_ckpt = get_test_data(ckpt_name)
     checkpoint_dir = Path(cfg.hardware.paths.output + "checkpoint/dummy_id")
     checkpoint_dir.mkdir(parents=True, exist_ok=True)
     shutil.copy(existing_ckpt, checkpoint_dir / "last.ckpt")

--- a/training/tests/integration/test_training_cycle.py
+++ b/training/tests/integration/test_training_cycle.py
@@ -158,10 +158,10 @@ def test_restart_training(gnn_config: tuple[DictConfig, str], get_test_archive: 
 @skip_if_offline
 @pytest.mark.slow
 def test_restart_from_existing_checkpoint(
-    gnn_config_with_checkpoint: tuple[DictConfig, str],
+    architecture_config_with_checkpoint: tuple[DictConfig, str],
     get_test_archive: GetTestArchive,
 ) -> None:
-    cfg, url = gnn_config_with_checkpoint
+    cfg, url = architecture_config_with_checkpoint
     get_test_archive(url)
     AnemoiTrainer(cfg).train()
 


### PR DESCRIPTION
## Description
Related to first point of https://github.com/ecmwf/anemoi-core/issues/484

## What problem does this change solve?
Extend restart checkpoint test with graphtransformer as it was just considering the gnn. 


## What issue or task does this change relate to?
[<!-- link to Issue Number -->
](https://github.com/ecmwf/anemoi-core/issues/484)

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
