### PR TITLE
fix: convert pre_processors from attribute to variable in models/encoder_processor_decoder

### DIFF
--- a/models/src/anemoi/models/models/encoder_processor_decoder.py
+++ b/models/src/anemoi/models/models/encoder_processor_decoder.py
@@ -454,7 +454,7 @@ class AnemoiModelEncProcDec(nn.Module):
                 grid_shard_shapes = [shape[-2] for shape in shard_shapes]
                 x = shard_tensor(x, -2, shard_shapes, model_comm_group)
 
-            x = self.pre_processors(x, in_place=False)
+            x = pre_processors(x, in_place=False)
 
             # Perform forward pass
             y_hat = self.forward(x, model_comm_group=model_comm_group, grid_shard_shapes=grid_shard_shapes, **kwargs)


### PR DESCRIPTION
## Description
Closes #502 

## What problem does this change solve?
Fixes a bug, where encoder processor decoder model called `self.pre_processors` rather than `pre_processors` in `predict_step`

## What issue or task does this change relate to?
#502 

##  Additional notes ##

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
