### PR TITLE
feat: Allow custom MLFLOW_SYSTEM_METRICS_SAMPLING_INTERVAL

### DIFF
--- a/training/src/anemoi/training/config/diagnostics/evaluation.yaml
+++ b/training/src/anemoi/training/config/diagnostics/evaluation.yaml
@@ -50,6 +50,7 @@ log:
     experiment_name: 'anemoi-debug'
     project_name: 'Anemoi'
     system: False
+    system_metrics_sampling_interval: 100 # in seconds
     terminal: True
     run_name: null # If set to null, the run name will be the a random UUID
     on_resume_create_child: True

--- a/training/src/anemoi/training/diagnostics/logger.py
+++ b/training/src/anemoi/training/diagnostics/logger.py
@@ -90,6 +90,7 @@ def get_mlflow_logger(config: BaseSchema) -> None:
         authentication=config.diagnostics.log.mlflow.authentication,
         on_resume_create_child=config.diagnostics.log.mlflow.on_resume_create_child,
         max_params_length=max_params_length,
+        system_metrics_sampling_interval=config.diagnostics.log.mlflow.system_metrics_sampling_interval,
     )
     config_params = OmegaConf.to_container(convert_to_omegaconf(config), resolve=True)
     logger.log_hyperparams(

--- a/training/src/anemoi/training/diagnostics/mlflow/logger.py
+++ b/training/src/anemoi/training/diagnostics/mlflow/logger.py
@@ -263,6 +263,7 @@ class AnemoiMLflowLogger(MLFlowLogger):
         log_hyperparams: bool | None = True,
         on_resume_create_child: bool | None = True,
         max_params_length: int | None = MAX_PARAMS_LENGTH,
+        system_metrics_sampling_interval: int | None = 100,
     ) -> None:
         """Initialize the AnemoiMLflowLogger.
 
@@ -309,7 +310,7 @@ class AnemoiMLflowLogger(MLFlowLogger):
         self._parent_run_server2server = None
         self._parent_dry_run = False
         self._max_params_length = max_params_length
-
+        self._system_metrics_sampling_interval = system_metrics_sampling_interval
         enabled = authentication and not offline
         self.auth = TokenAuth(tracking_uri, enabled=enabled)
 
@@ -511,8 +512,9 @@ class AnemoiMLflowLogger(MLFlowLogger):
         mlflow.enable_system_metrics_logging()
         # https://mlflow.org/docs/latest/system-metrics/
         # By default, system metrics are sampled every 10 seconds
-        # we choose to update this to 100 - system metrics are logged every 1 min 30 seconds
-        mlflow.set_system_metrics_sampling_interval(interval=100)
+        # we choose to update this to 100 by default - system metrics are logged every 1 min 40 seconds
+        if not mlflow.environment_variables.MLFLOW_SYSTEM_METRICS_SAMPLING_INTERVAL.is_set():
+            mlflow.set_system_metrics_sampling_interval(interval=self._system_metrics_sampling_interval)
         system_monitor = CustomSystemMetricsMonitor(
             self.run_id,
             resume_logging=self.run_id is not None,

--- a/training/src/anemoi/training/schemas/diagnostics.py
+++ b/training/src/anemoi/training/schemas/diagnostics.py
@@ -271,6 +271,8 @@ class MlflowSchema(BaseModel):
     "Name of project."
     system: bool
     "Activate system metrics."
+    system_metrics_sampling_interval: PositiveInt = Field(example=100)
+    "Specifies the sampling interval (in seconds) of system metrics, if enabled."
     terminal: bool
     "Log terminal logs to MLflow."
     run_name: str | None


### PR DESCRIPTION
Can be set either through config or via environment variable

## Description
The MLFlow system metrics logging interval was reduced to 100s in #333, but it is hard coded and overwrites the environment variable. This PR allows changing the value either through the config or via setting the environment variable MLFLOW_SYSTEM_METRICS_SAMPLING_INTERVAL

## What problem does this change solve?
new feature I guess?

## What issue or task does this change relate to?
No issue

##  Additional notes ##


***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
