### PR TITLE
feat: Add option for source server auth in mlflow sync

### DIFF
--- a/training/src/anemoi/training/commands/mlflow.py
+++ b/training/src/anemoi/training/commands/mlflow.py
@@ -88,6 +88,12 @@ class MlFlow(Command):
             help="The destination server requires authentication.",
         )
         sync.add_argument(
+            "--source_authentication",
+            "-A",
+            action="store_true",
+            help="The source server requires authentication.",
+        )
+        sync.add_argument(
             "--export-deleted-runs",
             "-x",
             action="store_true",
@@ -154,6 +160,12 @@ class MlFlow(Command):
                 from anemoi.utils.mlflow.auth import TokenAuth
 
                 auth = TokenAuth(url=args.destination)
+                auth.login()
+                auth.authenticate()
+            if args.source_authentication:
+                from anemoi.utils.mlflow.auth import TokenAuth
+
+                auth = TokenAuth(url=args.source)
                 auth.login()
                 auth.authenticate()
 


### PR DESCRIPTION
## Description
Adds option for syncing from a server that requires authentication. 

## What problem does this change solve?
`anemoi-training mlflow sync` fails if the source server requires authentication. This PR allows enabling authentication on the source server through a new boolean flag `-A`, `--source_authentication`.

## What issue or task does this change relate to?
No issue

##  Additional notes ##
No notes

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
