### PR TITLE
Fix dry run check to use current run object

### DIFF
--- a/training/src/anemoi/training/diagnostics/mlflow/logger.py
+++ b/training/src/anemoi/training/diagnostics/mlflow/logger.py
@@ -427,7 +427,7 @@ class AnemoiMLflowLogger(MLFlowLogger):
                 run = mlflow_client.get_run(run_id)
                 run_name = run.info.run_name
                 self._check_server2server_lineage(run)
-                self._check_dry_run(parent_run)
+                self._check_dry_run(run)
                 mlflow_client.update_run(run_id=run_id, status="RUNNING")
                 tags["resumedRun"] = "True"
             # This block is used when a run is forked and an existing run ID is specified


### PR DESCRIPTION
A quick fix to something found when setting

```yaml
diagnostics:
  log:
    mflow:
      on_resume_create_child: False
```

I don't think this code path was previously explored by tests (it's an undefined variable error) — probably a bigger issue to review how the MLFlow logging is being tested.

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
