### PR TITLE
fix: increase timeout on benchmark github action

### DIFF
--- a/.github/workflows/integration-tests-hpc.yml
+++ b/.github/workflows/integration-tests-hpc.yml
@@ -55,6 +55,7 @@ jobs:
           troika_user: ${{ secrets.HPC_CI_INTEGRATION_USER }}
   benchmark-tests:
     runs-on: hpc
+    timeout-minutes: 360 #increase timeout, if slurm queues for ~1 hour then github actions can timeout
     needs: check_date
     if: ${{ needs.check_date.outputs.should_run != 'false' }}
     steps:


### PR DESCRIPTION
## Description
If the benchmark CI test queues for over an hour, the github action will timeout, failing the test.
This job increases the timeout to 6 hrs, so that it should run somepoint during the night.
This doesnt impact the slurm timeout, which is still 1 hour. this change just effects how long github actions will wait for the slurm job to complete.

<img width="1450" height="561" alt="Screenshot 2025-09-02 at 09 27 55" src="https://github.com/user-attachments/assets/ffe5ab86-ff27-412b-bcd5-938fc0bedf9d" />


***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
