### PR TITLE
fix: outdated docs for loss functions

### DIFF
--- a/training/docs/modules/losses.rst
+++ b/training/docs/modules/losses.rst
@@ -38,7 +38,7 @@ weighting either spatial, vertical or specific to the variables used.
 Those weights are defined via `scalers`. For example spatial scaling
 based on the area of the nodes needs is done using the ``node_weights``
 as a scaler. For more details on the loss function scaling please refer
-to :ref: `_loss_function_scaling`
+to :ref:`loss-function-scaling`.
 
 These are available in the ``anemoi.training.losses`` module, at
 ``anemoi.training.losses.{short_name}.{class_name}``.

--- a/training/docs/modules/losses.rst
+++ b/training/docs/modules/losses.rst
@@ -25,13 +25,16 @@ in the config file at ``config.training.training_loss``, and
 
 The following loss functions are available by default:
 
--  ``MSELoss``: Latitude-weighted node-weighted mean-squared-error.
--  ``RMSELoss``: Latitude-weighted node-weighted root
-   mean-squared-error.
--  ``MAELoss``: Latitude-weighted mean-absolute-error.
--  ``HuberLoss``: Latitude-weighted Huber loss.
--  ``LogCoshLoss``: Latitude-weighted log-cosh loss.
+-  ``MSELoss``: mean-squared-error.
+-  ``RMSELoss``: root mean-squared-error.
+-  ``MAELoss``: mean-absolute-error.
+-  ``HuberLoss``: Huber loss.
+-  ``LogCoshLoss``: log-cosh loss.
 -  ``CombinedLoss``: Combined component weighted loss.
+
+All the above losses by default are averaged across the grid nodes. To
+apply latitude-weighted scaling one needs to pass ``node_weights`` as a
+scaler.
 
 These are available in the ``anemoi.training.losses`` module, at
 ``anemoi.training.losses.{short_name}.{class_name}``.

--- a/training/docs/modules/losses.rst
+++ b/training/docs/modules/losses.rst
@@ -17,8 +17,8 @@ scaler multiplication, and graph node weighting.
  Deterministic Loss Functions
 ******************************
 
-By default anemoi-training trains the model using a latitude-weighted
-mean-squared-error, which is defined in the ``WeightedMSELoss`` class in
+By default anemoi-training trains the model using a mean-squared-error,
+which is defined in the ``MSELoss`` class in
 ``anemoi/training/losses/mse.py``. The loss function can be configured
 in the config file at ``config.training.training_loss``, and
 ``config.training.validation_metrics``.
@@ -32,9 +32,13 @@ The following loss functions are available by default:
 -  ``LogCoshLoss``: log-cosh loss.
 -  ``CombinedLoss``: Combined component weighted loss.
 
-All the above losses by default are averaged across the grid nodes. To
-apply latitude-weighted scaling one needs to pass ``node_weights`` as a
-scaler.
+All the above losses by default are averaged across the grid nodes,
+ensemble dimension and batch size. Losses can also consider specific
+weighting either spatial, vertical or specific to the variables used.
+Those weights are defined via `scalers`. For example spatial scaling
+based on the area of the nodes needs is done using the ``node_weights``
+as a scaler. For more details on the loss function scaling please refer
+to :ref: `_loss_function_scaling`
 
 These are available in the ``anemoi.training.losses`` module, at
 ``anemoi.training.losses.{short_name}.{class_name}``.

--- a/training/docs/modules/losses.rst
+++ b/training/docs/modules/losses.rst
@@ -56,8 +56,8 @@ The following probabilistic loss functions are available by default:
 -  ``KernelCRPSLoss``: Kernel CRPS loss.
 -  ``AlmostFairKernelCRPSLoss``: Almost fair Kernel CRPS loss see `Lang
    et al. (2024) <http://arxiv.org/abs/2412.15832>`_.
--  ``WeightedMSELoss`` : is WeightedMSELoss used for the diffussion
-   model to handle noise weights
+-  ``WeightedMSELoss`` : is the MSELoss used for the diffussion model to
+   handle noise weights
 
 The config for these loss functions is the same as for the
 deterministic:

--- a/training/docs/modules/losses.rst
+++ b/training/docs/modules/losses.rst
@@ -25,11 +25,12 @@ in the config file at ``config.training.training_loss``, and
 
 The following loss functions are available by default:
 
--  ``WeightedMSELoss``: Latitude-weighted mean-squared-error.
--  ``WeightedMAELoss``: Latitude-weighted mean-absolute-error.
--  ``WeightedHuberLoss``: Latitude-weighted Huber loss.
--  ``WeightedLogCoshLoss``: Latitude-weighted log-cosh loss.
--  ``WeightedRMSELoss``: Latitude-weighted root-mean-squared-error.
+-  ``MSELoss``: Latitude-weighted node-weighted mean-squared-error.
+-  ``RMSELoss``: Latitude-weighted node-weighted root
+   mean-squared-error.
+-  ``MAELoss``: Latitude-weighted mean-absolute-error.
+-  ``HuberLoss``: Latitude-weighted Huber loss.
+-  ``LogCoshLoss``: Latitude-weighted log-cosh loss.
 -  ``CombinedLoss``: Combined component weighted loss.
 
 These are available in the ``anemoi.training.losses`` module, at
@@ -55,6 +56,8 @@ The following probabilistic loss functions are available by default:
 -  ``KernelCRPSLoss``: Kernel CRPS loss.
 -  ``AlmostFairKernelCRPSLoss``: Almost fair Kernel CRPS loss see `Lang
    et al. (2024) <http://arxiv.org/abs/2412.15832>`_.
+-  ``WeightedMSELoss`` : is WeightedMSELoss used for the diffussion
+   model to handle noise weights
 
 The config for these loss functions is the same as for the
 deterministic:

--- a/training/docs/user-guide/training.rst
+++ b/training/docs/user-guide/training.rst
@@ -341,7 +341,7 @@ For ensemble training, the following loss functions are available:
 -  **AlmostFairKernelCRPS**: A variant of Kernel CRPS which accounts for
    the number of ensemble members used.
 
-.. _loss_function_scaling:
+.. _loss-function-scaling:
 
 ***********************
  Loss function scaling

--- a/training/docs/user-guide/training.rst
+++ b/training/docs/user-guide/training.rst
@@ -341,6 +341,8 @@ For ensemble training, the following loss functions are available:
 -  **AlmostFairKernelCRPS**: A variant of Kernel CRPS which accounts for
    the number of ensemble members used.
 
+.. _loss_function_scaling:
+
 ***********************
  Loss function scaling
 ***********************


### PR DESCRIPTION
## Description
https://github.com/ecmwf/anemoi-core/issues/506

## What problem does this change solve?
Outdated docs about loss function.
## What issue or task does this change relate to?

<!-- link to Issue Number -->

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)


<!-- readthedocs-preview anemoi-training start -->
----
📚 Documentation preview 📚: https://anemoi-training--525.org.readthedocs.build/en/525/

<!-- readthedocs-preview anemoi-training end -->

<!-- readthedocs-preview anemoi-graphs start -->
----
📚 Documentation preview 📚: https://anemoi-graphs--525.org.readthedocs.build/en/525/

<!-- readthedocs-preview anemoi-graphs end -->

<!-- readthedocs-preview anemoi-models start -->
----
📚 Documentation preview 📚: https://anemoi-models--525.org.readthedocs.build/en/525/

<!-- readthedocs-preview anemoi-models end -->