### PR TITLE
fix: set correct base package for migrations imports

### DIFF
--- a/models/src/anemoi/models/migrations/migrator.py
+++ b/models/src/anemoi/models/migrations/migrator.py
@@ -229,11 +229,7 @@ def _migrations_from_path(location: str | PathLike, package: str) -> list[Migrat
         if not file.is_file() and file.suffix != ".py" or file.name == "__init__.py":
             continue
         LOGGER.debug("Loading migration .%s from %s", file.stem, package)
-        try:
-            migration = importlib.import_module(f".{file.stem}", package)
-        except ImportError as e:
-            LOGGER.warning("Error loading %s: %s", file.name, str(e))
-            continue
+        migration = importlib.import_module(f".{file.stem}", package)
 
         args: dict[str, Any] = dict(
             name=file.stem, metadata=migration.metadata, signature=_get_code_digest(getsource(migration))
@@ -338,7 +334,9 @@ class Migrator:
         """
 
         if migrations is None:
-            migrations = _migrations_from_path(MIGRATION_PATH, f"{__name__}.scripts")
+            # remove the ".migrator" at the end to get parent folder as migration package
+            migration_pkg, _, _ = __name__.rpartition(".")
+            migrations = _migrations_from_path(MIGRATION_PATH, f"{migration_pkg}.scripts")
 
         # Compatibility groups. Checkpoints cannot be migrated past their
         # own group. This is useful to indicate when migrating checkpoints is no longer


### PR DESCRIPTION
## Description
The migrator was setting the wrong path for the migrations scripts. This yielded some warnings that migrations could not be loaded.


This fixes this, and changes the warning into an error, so that it can be detected with the integration tests in the future.

## What problem does this change solve?
<!-- Describe if it's a bugfix, new feature, doc update, or breaking change -->

## What issue or task does this change relate to?
<!-- link to Issue Number -->

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
