### PR TITLE
fix: truncation shard shapes

### DIFF
--- a/models/src/anemoi/models/models/encoder_processor_decoder.py
+++ b/models/src/anemoi/models/models/encoder_processor_decoder.py
@@ -164,7 +164,7 @@ class AnemoiModelEncProcDec(nn.Module):
     def _apply_truncation(self, x, grid_shard_shapes=None, model_comm_group=None):
         if self.A_down is not None or self.A_up is not None:
             if grid_shard_shapes is not None:
-                shard_shapes = self._get_shard_shapes(x, 0, grid_shard_shapes, model_comm_group)
+                shard_shapes = self._get_shard_shapes(x, -2, grid_shard_shapes, model_comm_group)
                 # grid-sharded input: reshard to channel-shards to apply truncation
                 x = shard_channels(x, shard_shapes, model_comm_group)  # we get the full sequence here
 


### PR DESCRIPTION
## Description
Fix a bug were grid_shard_shapes were applied to the wrong dimension leading to errors when using uneven grid shards.

## What problem does this change solve?
<!-- Describe if it's a bugfix, new feature, doc update, or breaking change -->

## What issue or task does this change relate to?
<!-- link to Issue Number -->

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
