### PR TITLE
fix(training): nan mask weights gather for plots

### DIFF
--- a/training/src/anemoi/training/config/training/lam.yaml
+++ b/training/src/anemoi/training/config/training/lam.yaml
@@ -67,7 +67,7 @@ training_loss:
   # A selection of available scalers are listed in training/scalers/scalers.yaml
   # '*' is a valid entry to use all `scalers` given, if a scaler is to be excluded
   # add `!scaler_name`, i.e. ['*', '!scaler_1'], and `scaler_1` will not be added.
-  scalers: ['pressure_level', 'general_variable', 'nan_mask_weights', 'node_weights']
+  scalers: ['pressure_level', 'general_variable', 'node_weights']
   ignore_nans: False
 
 # Validation metrics calculation,

--- a/training/src/anemoi/training/config/training/stretched.yaml
+++ b/training/src/anemoi/training/config/training/stretched.yaml
@@ -67,7 +67,7 @@ training_loss:
   # A selection of available scalers are listed in training/scalers/scalers.yaml
   # '*' is a valid entry to use all `scalers` given, if a scaler is to be excluded
   # add `!scaler_name`, i.e. ['*', '!scaler_1'], and `scaler_1` will not be added.
-  scalers: ['pressure_level', 'general_variable', 'nan_mask_weights', 'node_weights']
+  scalers: ['pressure_level', 'general_variable', 'node_weights']
   ignore_nans: False
 
 # Validation metrics calculation,

--- a/training/src/anemoi/training/diagnostics/callbacks/plot.py
+++ b/training/src/anemoi/training/diagnostics/callbacks/plot.py
@@ -918,7 +918,7 @@ class PlotLoss(BasePerBatchPlotCallback):
 
             self.loss = copy.deepcopy(pl_module.loss)
 
-            if hasattr(self.loss.scaler, "nan_mask_weights"):
+            if hasattr(self.loss.scaler, "nan_mask_weights") and self.loss.scaler.nan_mask_weights.shape[2] != 1:
                 self.loss.scaler.nan_mask_weights = pl_module.allgather_batch(self.loss.scaler.nan_mask_weights)
 
             super().on_validation_batch_end(

--- a/training/src/anemoi/training/diagnostics/callbacks/plot.py
+++ b/training/src/anemoi/training/diagnostics/callbacks/plot.py
@@ -918,7 +918,8 @@ class PlotLoss(BasePerBatchPlotCallback):
 
             self.loss = copy.deepcopy(pl_module.loss)
 
-            if hasattr(self.loss.scaler, "nan_mask_weights") and self.loss.scaler.nan_mask_weights.shape[2] != 1:
+            # gather nan_mask_weights along grid dim if necessary, don't gather if grid dim is broadcastable
+            if hasattr(self.loss.scaler, "nan_mask_weights") and self.loss.scaler.nan_mask_weights.shape[-2] != 1:
                 self.loss.scaler.nan_mask_weights = pl_module.allgather_batch(self.loss.scaler.nan_mask_weights)
 
             super().on_validation_batch_end(


### PR DESCRIPTION
## Description
Avoid gathering unresolved `nan_mask_weight` scaler with `grid_dim=1`.

## What problem does this change solve?
Fixes an bug where PlotLoss attempted to gather a nan_mask_weight scalar that wasn’t actually sharded but simply constant across the dimension (shape 1).

## What issue or task does this change relate to?
<!-- link to Issue Number -->

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
