### PR TITLE
chore: Replace `pynvml` dependency

### DIFF
--- a/training/pyproject.toml
+++ b/training/pyproject.toml
@@ -51,8 +51,8 @@ dependencies = [
   "matplotlib>=3.7.1",
   "mlflow-skinny>=2.11.1",
   "numpy<2",                                         # Pinned until we can confirm it works with anemoi graphs
+  "nvidia-ml-py>=13.580.82",
   "pydantic>=2.9",
-  "pynvml>=11.5",
   "pyshtools>=4.13",
   "pytorch-lightning>=2.1",
   "timm>=0.9.2",


### PR DESCRIPTION
## Description
Update pyproject with correct dependency as pypvml is no longer mantained.

Tested that code runs fine https://mlflow.ecmwf.int/#/experiments/264/runs/558c6a3e9cbd47808aa4b5f1bb9be4f6

## What problem does this change solve?
(https://github.com/ecmwf/anemoi-core/issues/540)

## What issue or task does this change relate to?
(https://github.com/ecmwf/anemoi-core/issues/540)

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
