### PR TITLE
fix: Make TimeLimit callback compliant with multiple nodes 

### DIFF
--- a/training/src/anemoi/training/diagnostics/callbacks/stopping.py
+++ b/training/src/anemoi/training/diagnostics/callbacks/stopping.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 import pytorch_lightning as pl
 from omegaconf import DictConfig
+from pytorch_lightning.utilities import rank_zero_only
 
 from anemoi.utils.dates import frequency_to_string
 from anemoi.utils.dates import frequency_to_timedelta
@@ -64,6 +65,7 @@ class TimeLimit(pl.callbacks.Callback):
         _ = pl_module
         self._run_stopping_check(trainer)
 
+    @rank_zero_only
     def _run_stopping_check(self, trainer: pl.Trainer) -> None:
         """Check if the time limit has been reached and stop the training if so.
 
@@ -79,6 +81,7 @@ class TimeLimit(pl.callbacks.Callback):
         trainer.should_stop = True
         self._log_to_file(trainer)
 
+    @rank_zero_only
     def _log_to_file(self, trainer: pl.Trainer) -> None:
         """Log the last checkpoint path to a file if given.
 


### PR DESCRIPTION
## Description
The PR fixed the TimeLimit callback to make it work when using multiple nodes.

## What problem does this change solve?
Runs check time and log in file for the rank zero only.

## What issue or task does this change relate to?
ML workflows based on anemoi-training.

##  Additional notes ##
Slurm setup:
```
#SBATCH --nodes=2
#SBATCH --ntasks-per-node=2
#SBATCH --gpus-per-node=2
```

Before fix:
```
[2025-09-23 14:42:56,052][anemoi.training.diagnostics.callbacks.stopping][INFO] - Time limit of 2m reached. Stopping training.
[2025-09-23 14:42:56,052][anemoi.training.diagnostics.callbacks.stopping][INFO] - Time limit of 2m reached. Stopping training.
[2025-09-23 14:42:56,052][anemoi.training.diagnostics.callbacks.stopping][INFO] - Time limit of 2m reached. Stopping training.
[2025-09-23 14:42:56,052][anemoi.training.diagnostics.callbacks.stopping][INFO] - Time limit of 2m reached. Stopping training.

  File "/etc/ecmwf/nfs/dh1_home_a/ecm6116/Documents/workingdir/tools/python/anemoi/anemoi-core/training/src/anemoi/training/train/train.py", line 541, in main
    AnemoiTrainer(config).train()
...
  File "/perm/ecm6116/conda/envs/anemoi-training/lib/python3.12/site-packages/pytorch_lightning/trainer/call.py", line 222, in _call_callback_hooks
    fn(trainer, trainer.lightning_module, *args, **kwargs)
  File "/etc/ecmwf/nfs/dh1_home_a/ecm6116/Documents/workingdir/tools/python/anemoi/anemoi-core/training/src/anemoi/training/diagnostics/callbacks/stopping.py", line 65, in on_validation_end
    self._run_stopping_check(trainer)
  File "/etc/ecmwf/nfs/dh1_home_a/ecm6116/Documents/workingdir/tools/python/anemoi/anemoi-core/training/src/anemoi/training/diagnostics/callbacks/stopping.py", line 80, in _run_stopping_check
    self._log_to_file(trainer)
  File "/etc/ecmwf/nfs/dh1_home_a/ecm6116/Documents/workingdir/tools/python/anemoi/anemoi-core/training/src/anemoi/training/diagnostics/callbacks/stopping.py", line 95, in _log_to_file
    self._record_file.unlink()
  File "/perm/ecm6116/conda/envs/anemoi-training/lib/python3.12/pathlib.py", line 1342, in unlink
    os.unlink(self)
FileNotFoundError: [Errno 2] No such file or directory: 'stop_file'
...
slurmstepd: error: *** STEP 32173914.0 ON ac6-307 CANCELLED AT 2025-09-23T14:43:42 ***
```

After the fix:
```
Validation DataLoader 0: 100%|██████████| 5/5 [00:03<00:00,  1.30it/s][A[2025-09-23 14:51:04,678][anemoi.training.diagnostics.callbacks.stopping][INFO] - Time limit of 2m reached. Stopping training.
...
[2025-09-23 14:51:09,617][anemoi.training.diagnostics.callbacks.plot][INFO] - Teardown of the Plot Callback ...
```

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
