### PR TITLE
fix: allow int values in variable group schema

### DIFF
--- a/training/docs/modules/losses.rst
+++ b/training/docs/modules/losses.rst
@@ -206,6 +206,12 @@ are available.
         is_model_level: True
         param: 'z'
 
+The list of available metadata attributes is:
+
+.. autoclass:: anemoi.transforms.variable.Variable
+   :members:
+   :no-undoc-members:
+
 If metadata is not available, complex variable groups cannot be defined,
 and an error will be raised.
 

--- a/training/src/anemoi/training/schemas/training.py
+++ b/training/src/anemoi/training/schemas/training.py
@@ -345,7 +345,7 @@ class BaseTrainingSchema(BaseModel):
     "Scalers to use in the computation of the loss and validation scores."
     validation_metrics: dict[str, LossSchemas]
     "List of validation metrics configurations."
-    variable_groups: dict[str, str | list[str] | dict[str, str | bool | list[str]]]
+    variable_groups: dict[str, str | list[str] | dict[str, str | bool | list[str | int]]]
     "Groups for variable loss scaling"
     max_epochs: PositiveInt | None = None
     "Maximum number of epochs, stops earlier if max_steps is reached first."

--- a/training/src/anemoi/training/utils/variables_metadata.py
+++ b/training/src/anemoi/training/utils/variables_metadata.py
@@ -66,7 +66,6 @@ class ExtractVariableGroupAndLevel:
         variable_groups: dict[str, GROUP_SPEC | dict[str, GROUP_SPEC]],
         metadata_variables: dict[str, dict | Variable] | None = None,
     ) -> None:
-
         if isinstance(variable_groups, DictConfig):
             variable_groups = OmegaConf.to_container(variable_groups, resolve=True)
 


### PR DESCRIPTION
## Description
Previously the variable groups schema did not allow int values for complex descriptions like:
```yaml
variable_groups:
     l_50:
        param: [z]
        level: [50]  # not allowed
```

## What problem does this change solve?
<!-- Describe if it's a bugfix, new feature, doc update, or breaking change -->

## What issue or task does this change relate to?
Related to and supersedes PR #532

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
