### PR TITLE
[DRAFT] add option to cache graph structures

### DIFF
--- a/models/src/anemoi/models/layers/mapper.py
+++ b/models/src/anemoi/models/layers/mapper.py
@@ -27,7 +27,7 @@ from torch_geometric.typing import PairTensor
 from anemoi.models.distributed.graph import gather_tensor
 from anemoi.models.distributed.graph import shard_tensor
 from anemoi.models.distributed.graph import sync_tensor
-from anemoi.models.distributed.khop_edges import bipartite_subgraph
+from anemoi.models.distributed.khop_edges import cached_bipartite_subgraph
 from anemoi.models.distributed.khop_edges import drop_unconnected_src_nodes
 from anemoi.models.distributed.khop_edges import sort_edges_1hop_sharding
 from anemoi.models.distributed.shapes import change_channels_in_shape
@@ -364,7 +364,7 @@ class GraphTransformerBaseMapper(GraphEdgeMixin, BaseMapper):
 
         # get subgraph of x_dst_chunk and incoming edges, drop unconnected src nodes
         nodes_src_full = torch.arange(size[0], device=edge_index.device)
-        edge_index, edge_attr = bipartite_subgraph(
+        edge_index, edge_attr = cached_bipartite_subgraph(
             (nodes_src_full, dst_chunk),
             edge_index,
             edge_attr,


### PR DESCRIPTION
## Description
Repeated operation on edge_index structures (sorting, chunking) etc., technically don't contribute in a major fashion to the overall runtime, however, can add overheads by causing host-device syncs or by mostly being a series of small kernels exposing latencies. Overall, this also can lead to further latencies being exposed down the road due to 

## What problem does this change solve?
- add env-var which allows to trade-off memory and potentially reduced latencies by caching graph operations
- use index_select instead indexing kernels

## What issue or task does this change relate to?
NA
##  Additional notes ##
Looking forward, moving operations like those into the start-up / initialization phase likely is more elegant. The index_select also currently stills adds overheads by not exploiting the indices of most masks being unique, i.e. there usually are compaction and other kernels scheduled beforehand to extract information out of index tensors.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
