### PR TITLE
feat(training): ens batch broadcast

### DIFF
--- a/training/src/anemoi/training/data/dataset/ensdataset.py
+++ b/training/src/anemoi/training/data/dataset/ensdataset.py
@@ -134,6 +134,7 @@ class EnsNativeGridDataset(NativeGridDataset):
         ens_comm_num_groups: int,
         reader_group_rank: int,
         reader_group_size: int,
+        ens_comm_subgroup_rank: int,
     ) -> None:
         """Set model and reader communication group information (called by DDPGroupStrategy).
 
@@ -157,6 +158,8 @@ class EnsNativeGridDataset(NativeGridDataset):
             Reader group rank
         reader_group_size : int
             Reader group size
+        ens_comm_subgroup_rank : int
+            Ensemble communication subgroup rank
         """
         self.global_rank = global_rank
         self.model_comm_group_id = model_comm_group_id
@@ -170,6 +173,8 @@ class EnsNativeGridDataset(NativeGridDataset):
 
         self.sample_comm_group_id = ens_comm_group_id  # groups that work on the same sample / batch
         self.sample_comm_num_groups = ens_comm_num_groups
+
+        self.ens_sample_comm_group_rank = ens_comm_subgroup_rank # used to only read data once (rank0) per ensemble group
 
         assert self.reader_group_size >= 1, "reader_group_size must be positive"
 
@@ -265,6 +270,23 @@ class EnsNativeGridDataset(NativeGridDataset):
             self.sample_comm_group_id,
             shuffled_chunk_indices[:10],
         )
+
+        # load dummy data on non-rank-0 of the ensemble subgroup (will be broadcasted)
+        if self.ens_sample_comm_group_rank != 0:
+            dates = len(self.relative_date_indices)
+            variables, ens = self.data.shape[1:3]
+            grid_shard_indices = self.grid_indices.get_shard_indices(self.reader_group_rank)
+            if isinstance(grid_shard_indices, slice):
+                grid = (grid_shard_indices.stop - grid_shard_indices.start)
+            else:
+                grid = len(grid_shard_indices)
+
+            shape = [dates, ens, grid, variables] # correct shape for easy broadcasting
+
+            for _ in range(len(shuffled_chunk_indices)):
+                yield (torch.empty(shape),)
+
+            return
 
         for i in shuffled_chunk_indices:
             # start and end time indices, for analysis and EDA

--- a/training/src/anemoi/training/distributed/strategy.py
+++ b/training/src/anemoi/training/distributed/strategy.py
@@ -436,6 +436,8 @@ class DDPEnsGroupStrategy(DDPStrategy):
         ens_comm_subgroup_id = ens_comm_group_id * self.model_comm_group_size + model_comm_group_rank
         ens_comm_subgroup_rank = ens_comm_group_rank // self.model_comm_group_size
         ens_comm_num_subgroups = self.world_size // ens_comm_subgroup_size
+        # global rank 0 in each ensemble subgroup for broadcasting
+        ens_comm_subgroup_rank_0 = ens_comm_subgroup_ranks[ens_comm_subgroup_id][0]
 
         ens_comm_subgroup = ens_comm_subgroups[ens_comm_subgroup_id]
         self.model.set_ens_comm_subgroup(
@@ -444,6 +446,7 @@ class DDPEnsGroupStrategy(DDPStrategy):
             ens_comm_subgroup_rank,
             ens_comm_num_subgroups,
             ens_comm_subgroup_size,
+            ens_comm_subgroup_rank_0,
         )
 
         LOGGER.info(
@@ -530,6 +533,8 @@ class DDPEnsGroupStrategy(DDPStrategy):
             self.world_size,
         )
 
+        ens_comm_subgroup_rank = ens_comm_group_rank // self.model_comm_group_size
+
         dataloader.dataset.set_comm_group_info(
             self.global_rank,
             model_comm_group_id,
@@ -540,6 +545,7 @@ class DDPEnsGroupStrategy(DDPStrategy):
             ens_comm_num_groups,
             reader_group_rank,
             self.read_group_size,
+            ens_comm_subgroup_rank,
         )
 
         return dataloader

--- a/training/src/anemoi/training/train/tasks/ensforecaster.py
+++ b/training/src/anemoi/training/train/tasks/ensforecaster.py
@@ -368,10 +368,7 @@ class GraphEnsForecaster(BaseGraphModule):
     def _setup_batch_sharding(self, batch: tuple[torch.Tensor, ...]) -> tuple[torch.Tensor, ...]:
         assert len(batch) == 1, "EDA perturbations not supported in allgather_batch atm."
 
-        if self.ens_comm_subgroup_rank == 0:
-            torch.distributed.broadcast(batch[0], src=self.ens_comm_subgroup_rank_0, group=self.ens_comm_subgroup)
-        else:
-            torch.distributed.broadcast(batch[0], src=self.ens_comm_subgroup_rank_0, group=self.ens_comm_subgroup)
+        torch.distributed.broadcast(batch[0], src=self.ens_comm_subgroup_rank_0, group=self.ens_comm_subgroup)
 
         return super()._setup_batch_sharding(batch)
 

--- a/training/src/anemoi/training/train/tasks/ensforecaster.py
+++ b/training/src/anemoi/training/train/tasks/ensforecaster.py
@@ -141,12 +141,14 @@ class GraphEnsForecaster(BaseGraphModule):
         ens_comm_subgroup_rank: int,
         ens_comm_subgroup_num_groups: int,
         ens_comm_subgroup_size: int,
+        ens_comm_subgroup_rank_0: int,
     ) -> None:
         self.ens_comm_subgroup = ens_comm_subgroup
         self.ens_comm_subgroup_id = ens_comm_subgroup_id
         self.ens_comm_subgroup_rank = ens_comm_subgroup_rank
         self.ens_comm_subgroup_num_groups = ens_comm_subgroup_num_groups
         self.ens_comm_subgroup_size = ens_comm_subgroup_size
+        self.ens_comm_subgroup_rank_0 = ens_comm_subgroup_rank_0
 
     def gather_and_compute_loss(
         self,
@@ -362,6 +364,16 @@ class GraphEnsForecaster(BaseGraphModule):
 
         loss *= 1.0 / self.rollout
         return loss, metrics, y_preds, _ens_ic
+
+    def _setup_batch_sharding(self, batch: tuple[torch.Tensor, ...]) -> tuple[torch.Tensor, ...]:
+        assert len(batch) == 1, "EDA perturbations not supported in allgather_batch atm."
+
+        if self.ens_comm_subgroup_rank == 0:
+            torch.distributed.broadcast(batch[0], src=self.ens_comm_subgroup_rank_0, group=self.ens_comm_subgroup)
+        else:
+            torch.distributed.broadcast(batch[0], src=self.ens_comm_subgroup_rank_0, group=self.ens_comm_subgroup)
+
+        return super()._setup_batch_sharding(batch)
 
     def allgather_batch(self, batch: torch.Tensor) -> torch.Tensor:
         batch[0] = super().allgather_batch(batch[0])


### PR DESCRIPTION
## Description
Avoid redundant reads across ensemble members, broadcast batch from member 0 instead.

## What problem does this change solve?
Reduce load on the filesystem caused by replicated reads across ensemble members.

## What issue or task does this change relate to?
<!-- link to Issue Number -->

##  Additional notes ##
Could do better by further splitting grid-shards across ens members + allgather.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
