### PR TITLE
fix(training): Add default diagnostics to empty list

### DIFF
--- a/training/src/anemoi/training/schemas/data.py
+++ b/training/src/anemoi/training/schemas/data.py
@@ -52,7 +52,7 @@ class DataSchema(PydanticBaseModel):
             Processors including imputers and normalizers are applied in order of definition."
     forcing: list[str]
     "Features that are not part of the forecast state but are used as forcing to generate the forecast state."
-    diagnostic: list[str]
+    diagnostic: list[str] = Field(default_factory=list)
     "Features that are only part of the forecast state and are not used as an input to the model."
     target: list[str] | None = None
     (


### PR DESCRIPTION
## Description
Add default empty list by default when there are no diagnostics, so you don't need to specify variables that you don't use 