### PR TITLE
fix(graphs,schemas): missing type for mask_attr_name in schema

### DIFF
--- a/graphs/src/anemoi/graphs/schemas/node_schemas.py
+++ b/graphs/src/anemoi/graphs/schemas/node_schemas.py
@@ -12,6 +12,7 @@ import logging
 from pathlib import Path  # noqa: TC003
 from typing import Annotated
 from typing import Literal
+from typing import Optional
 
 from pydantic import Field
 from pydantic import PositiveFloat
@@ -106,7 +107,7 @@ class LimitedAreaNPZFileNodesSchema(BaseModel):
     "The grid resolution."
     reference_node_name: str  # TODO(Helen): Check that reference nodes exists in the config
     "Name of the reference nodes in the graph to consider for the Area Mask."
-    mask_attr_name: str  # TODO(Helen): Check that mask_attr_name exists in the dataset config
+    mask_attr_name: Optional[str]  # TODO(Helen): Check that mask_attr_name exists in the dataset config
     "Name of a node to attribute to mask the reference nodes, if desired. Defaults to consider all reference nodes."
     margin_radius_km: PositiveFloat = Field(example=100.0)
     "Maximum distance to the reference nodes to consider a node as valid, in kilometers. Defaults to 100 km."
@@ -134,7 +135,7 @@ class LimitedAreaIcosahedralandHealPixNodeSchema(BaseModel):
     "Refinement level of the mesh."
     reference_node_name: str  # TODO(Helen): Discuss check that reference nodes exists in the config
     "Name of the reference nodes in the graph to consider for the Area Mask."
-    mask_attr_name: str  # TODO(Helen): Discuss check that mask_attr_name exists in the dataset config
+    mask_attr_name: Optional[str]  # TODO(Helen): Discuss check that mask_attr_name exists in the dataset config
     "Name of a node to attribute to mask the reference nodes, if desired. Defaults to consider all reference nodes."
     margin_radius_km: PositiveFloat = Field(example=100.0)
     "Maximum distance to the reference nodes to consider a node as valid, in kilometers. Defaults to 100 km."
@@ -149,7 +150,7 @@ class StretchedIcosahdralNodeSchema(BaseModel):
     "Refinement level of the mesh on the local area."
     reference_node_name: str
     "Name of the reference nodes in the graph to consider for the Area Mask."
-    mask_attr_name: str
+    mask_attr_name: Optional[str]
     "Name of a node to attribute to mask the reference nodes, if desired. Defaults to consider all reference nodes."
     margin_radius_km: PositiveFloat = Field(example=100.0)
     "Maximum distance to the reference nodes to consider a node as valid, in kilometers. Defaults to 100 km."


### PR DESCRIPTION
## Description
<!-- What issue or task does this change relate to? -->
The `mask_attr_name` is only needed for LAM with boundary forcing, but if you want to build a LAM without boundary forcing, your data nodes will correspond to the area of interest, so you will not need to specify the extra `mask_attr_name`.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
