### PR TITLE
feat(models): Spherical Harmonics Transform(s) - Octahedral & HEALPix Grids

### DIFF
--- a/models/src/anemoi/models/layers/spectral.py
+++ b/models/src/anemoi/models/layers/spectral.py
@@ -154,7 +154,7 @@ def legpoly(
     for l in range(2, nmax):
         for m in range(0, l - 1):
             vdm[m, l, :] = (
-                +x * np.sqrt((2 * l - 1) / (l - m) * (2 * l + 1) / (l + m)) * vdm[m, l - 1, :]
+                x * np.sqrt((2 * l - 1) / (l - m) * (2 * l + 1) / (l + m)) * vdm[m, l - 1, :]
                 - np.sqrt((l + m - 1) / (l - m) * (2 * l + 1) / (2 * l - 3) * (l - m - 1) / (l + m)) * vdm[m, l - 2, :]
             )
 


### PR DESCRIPTION
## Description
Draft, to be coordinated with https://github.com/ecmwf/anemoi-core/pull/678 and https://github.com/ecmwf/anemoi-core/pull/709.

Introduces the groundwork for a "general" Spherical Harmonics Transform. Currently, four grids are supported: Gaussian, Equiangular, Octahedral and HEALPix (inverse). This approach can be extended to any "isolatitudinal grid" (i.e., a grid in which the nodes are distributed along rings of constant latitude). It can't, however, be extended to other grids, such as the "triangular refined icosahedron".

The "base" transform, Gaussian and Equiangular (exact quadrature), is from [torch-harmonics](https://github.com/NVIDIA/torch-harmonics) ([arxiv](https://arxiv.org/abs/2306.03838)). The extensions to both Octahedral and HEALPix (inexact) were inspired by [S2FFT](https://astro-informatics.github.io/s2fft/) ([arxiv](https://arxiv.org/abs/2311.14670)).

Basic example - forward transform from a Gaussian grid, followed by an inverse transform to an Octahedral grid.
```
sht_gaussian = CartesianRealSHT(
    nlat=NLAT,
    nlon=NLON,
    grid="legendre-gauss",
)

isht_octahedral = OctahedralInverseRealSHT(
    nlat=(2 * N),
    lmax=sht_gaussian.lmax,
    mmax=sht_gaussian.mmax,
)

spectral = sht_gaussian(spatial_gaussian)
spatial_octahedral = isht_octahedral(spectral)
```

Basic example - three plots of the same field after consecutive forward/inverse transforms to different grids (Gaussian, Octahedral and HEALPix, respectively). The reconstruction error (measured in the spectral domain) is MSE ~1e-14. The field is bandwidth-limited to 16.
<img width="1125" height="585" alt="gaussian" src="https://github.com/user-attachments/assets/633acceb-7cad-4f31-8529-b982de9cfd3c" />
<img width="1136" height="582" alt="octahedral" src="https://github.com/user-attachments/assets/412c1463-8024-4b47-8710-7147ecb9cb91" />
<img width="1129" height="582" alt="healpix" src="https://github.com/user-attachments/assets/a431bcb7-1122-412f-b837-69d7c3f30ce5" />



## What problem does this change solve?
<!-- Describe if it's a bugfix, new feature, doc update, or breaking change -->
Spectral losses and other "operations" defined on the spectral domain - for instance, the learnable spectral filter in a SFNO-type module ([example](https://github.com/Predictia/anemoi-core/blob/0019972fc74cd18fd368adb98f2ca2bc3e982560/models/src/anemoi/models/layers/sfno.py#L41)).

## What issue or task does this change relate to?
<!-- link to Issue Number -->
https://github.com/ecmwf/anemoi-core/pull/678, https://github.com/ecmwf/anemoi-core/pull/709 and https://github.com/ecmwf/anemoi-core/issues/599.

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
