### PR TITLE
fix: fix-pytest-triton-error

### DIFF
--- a/models/src/anemoi/models/triton/gt.py
+++ b/models/src/anemoi/models/triton/gt.py
@@ -9,8 +9,16 @@
 
 
 import torch
-import triton
-import triton.language as tl
+
+# check if triton is installed
+# If pytorch is installed on CPU then torch is not available
+try:
+    import triton
+    import triton.language as tl
+except ImportError:
+    raise ValueError(
+        "Error. The 'triton' backend was selected for the GraphTransformer but Triton is not installed. To use this backend please install Triton. Otherwise, select a different backend for the GraphTransformer in the models config."
+    )
 
 
 @triton.jit
@@ -291,6 +299,12 @@ def _gt_bwd_src_pass(
 
 class GraphTransformerFunction(torch.autograd.Function):
     """Custom autograd for GraphTransformer using Triton kernels."""
+
+    def __init__(self):
+        if not torch.cuda.is_available():
+            raise ValueError(
+                "Error. The 'triton' backend was selected for the GraphTransformer but 'torch.cuda.is_available()' returned 'False'. The 'triton' backend is currently only supported on GPUs. To run on other device types, please select a different backend for the GraphTransformer in the models config. If you intend to run on GPUs, please ensure your torch install supports running on GPUs."
+            )
 
     @staticmethod
     def forward(ctx, q, k, v, e, csc, reverse):

--- a/models/src/anemoi/models/triton/utils.py
+++ b/models/src/anemoi/models/triton/utils.py
@@ -49,3 +49,20 @@ def edge_index_to_csc(edge_index: Adj, num_nodes: Optional[Tuple[int, int]] = No
         return (row, colptr), perm, (rowptr, edge_id_per_src, edge_dst)
 
     return (row, colptr), perm
+
+
+def is_triton_available():
+    """Checks if triton is available.
+
+    Triton is supported if the triton library is installed and if Anemoi is running on GPU.
+    """
+    try:
+        import triton  # noqa: F401
+    except ImportError:
+        triton_available = False
+    else:
+        triton_available = True
+
+    gpus_present = torch.cuda.is_available()
+
+    return triton_available and gpus_present

--- a/models/tests/integration/triton/test_triton_gt.py
+++ b/models/tests/integration/triton/test_triton_gt.py
@@ -13,8 +13,11 @@ import pytest
 import torch
 
 from anemoi.models.layers.conv import GraphTransformerConv
-from anemoi.models.triton.gt import GraphTransformerFunction
 from anemoi.models.triton.utils import edge_index_to_csc
+from anemoi.models.triton.utils import is_triton_available
+
+if is_triton_available():
+    from anemoi.models.triton.gt import GraphTransformerFunction
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Description
fixes some errors where triton is tried to be imported when its not installed which causes pytests to fail when run on CPU.

also changed the behaviour to fallback to pyg if triton backend is not installed.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
