### PR TITLE
feat(training)!: Configurable weight averaging (exponential moving average (EMA), ...)

### DIFF
--- a/models/src/anemoi/models/migrations/scripts/1776237003_rename_swa_to_weight_averaging.py
+++ b/models/src/anemoi/models/migrations/scripts/1776237003_rename_swa_to_weight_averaging.py
@@ -54,19 +54,3 @@ def migrate(ckpt: CkptType) -> CkptType:
     training.pop("swa", None)
     training.weight_averaging = None
     return ckpt
-
-
-def rollback(ckpt: CkptType) -> CkptType:
-    """Rollback the checkpoint.
-
-    Parameters
-    ----------
-    ckpt : CkptType
-        The checkpoint dict.
-
-    Returns
-    -------
-    CkptType
-        The rollbacked checkpoint dict.
-    """
-    return ckpt

--- a/models/src/anemoi/models/migrations/scripts/1776237003_rename_swa_to_weight_averaging.py
+++ b/models/src/anemoi/models/migrations/scripts/1776237003_rename_swa_to_weight_averaging.py
@@ -1,0 +1,72 @@
+# (C) Copyright 2025 Anemoi contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+from anemoi.models.migrations import CkptType
+from anemoi.models.migrations import MigrationContext
+from anemoi.models.migrations import MigrationMetadata
+
+# DO NOT CHANGE -->
+metadata = MigrationMetadata(
+    versions={
+        "migration": "1.0.0",
+        "anemoi-models": "%NEXT_ANEMOI_MODELS_VERSION%",
+    },
+)
+# <-- END DO NOT CHANGE
+
+
+def migrate_setup(context: MigrationContext) -> None:
+    """Migrate setup callback to be run before loading the checkpoint.
+
+    Parameters
+    ----------
+    context : MigrationContext
+       A MigrationContext instance
+    """
+    context.delete_attribute("anemoi.training.schemas.training.SWA")
+
+
+def migrate(ckpt: CkptType) -> CkptType:
+    """Migrate the checkpoint.
+
+    Renames the removed ``training.swa`` config key to ``training.weight_averaging``.
+    Any previously-configured SWA is silently disabled; users who want weight
+    averaging on a migrated checkpoint should re-enable it via the new
+    ``weight_averaging`` Hydra-instantiate config.
+
+    Parameters
+    ----------
+    ckpt : CkptType
+        The checkpoint dict.
+
+    Returns
+    -------
+    CkptType
+        The migrated checkpoint dict.
+    """
+    training = ckpt["hyper_parameters"]["config"].training
+    training.pop("swa", None)
+    training.weight_averaging = None
+    return ckpt
+
+
+def rollback(ckpt: CkptType) -> CkptType:
+    """Rollback the checkpoint.
+
+    Parameters
+    ----------
+    ckpt : CkptType
+        The checkpoint dict.
+
+    Returns
+    -------
+    CkptType
+        The rollbacked checkpoint dict.
+    """
+    return ckpt

--- a/training/docs/user-guide/training.rst
+++ b/training/docs/user-guide/training.rst
@@ -635,3 +635,50 @@ to be used by PyTorch. For example:
 
 Note that both entries are optional and can be left unspecified. The default precision is ``f16-mixed`` while the BLAS backend will fall back to the
 default selection of PyTorch.
+
+******************
+ Weight Averaging
+******************
+
+Weight averaging is a technique to improve model generalization by
+averaging model weights during training. Anemoi Training supports weight
+averaging methods through PyTorch Lightning callbacks:
+
+-  **Exponential Moving Average (EMA)**: Maintains an exponential moving
+      average of model weights, which can lead to smoother convergence
+      and better generalization.
+
+      .. code:: yaml
+
+         weight_averaging:
+            _target_: pytorch_lightning.callbacks.EMAWeightAveraging
+            decay: 0.999
+
+      The ``decay`` parameter (typically between 0.99 and 0.9999)
+      controls the smoothing factor. Higher values give more weight to
+      historical weights, resulting in a more stable average. By
+      default, the decay is set to 0.999.
+
+-  **Stochastic Weight Averaging (SWA)**: Averages weights from multiple
+      points along the training trajectory, typically resulting in wider
+      optima and improved generalization.
+
+      .. code:: yaml
+
+         weight_averaging:
+            _target_: pytorch_lightning.callbacks.StochasticWeightAveraging
+            swa_lrs: 1.e-4
+
+      The ``swa_lrs`` parameter specifies the learning rate to use
+      during the SWA phase. By default, the learning rate is set to
+      1e-4. Additional parameters can be configured as described in the
+      [PyTorch Lightning
+      documentation](https://lightning.ai/docs/pytorch/latest/api/lightning.pytorch.callbacks.StochasticWeightAveraging.html#lightning.pytorch.callbacks.StochasticWeightAveraging)
+
+By default, weight averaging is disabled. To explicitly disable it or to
+override a parent configuration, set ``weight_averaging`` to null.
+
+.. note::
+
+   Weight averaging is only supported in PyTorch Lightning 2.6 and later
+   versions.

--- a/training/src/anemoi/training/config/training/diffusion.yaml
+++ b/training/src/anemoi/training/config/training/diffusion.yaml
@@ -29,11 +29,14 @@ gradient_clip:
   val: 1.
   algorithm: norm
 
-# stochastic weight averaging
-# https://pytorch.org/blog/stochastic-weight-averaging-in-pytorch/
-swa:
-  enabled: False
-  lr: 1.e-4
+# weight averaging only supported in Lightning 2.6+
+weight_averaging: null
+# For EMA:
+#  _target_: pytorch_lightning.callbacks.EMAWeightAveraging
+#  decay: 0.999
+# For SWA:
+#  _target_: pytorch_lightning.callbacks.StochasticWeightAveraging
+#  swa_lrs: 1.e-4
 
 optimization:
   optimizer:

--- a/training/src/anemoi/training/config/training/diffusion.yaml
+++ b/training/src/anemoi/training/config/training/diffusion.yaml
@@ -2,6 +2,7 @@
 defaults:
   - scalers: global
   - optimization: default
+  - weight_averaging: null
 
 # resume or fork a training from a checkpoint last.ckpt or specified in system.input.warm_start
 run_id: null
@@ -28,15 +29,6 @@ num_sanity_val_steps: 6
 gradient_clip:
   val: 1.
   algorithm: norm
-
-# weight averaging only supported in Lightning 2.6+
-weight_averaging: null
-# For EMA:
-#  _target_: pytorch_lightning.callbacks.EMAWeightAveraging
-#  decay: 0.999
-# For SWA:
-#  _target_: pytorch_lightning.callbacks.StochasticWeightAveraging
-#  swa_lrs: 1.e-4
 
 optimization:
   optimizer:

--- a/training/src/anemoi/training/config/training/ensemble.yaml
+++ b/training/src/anemoi/training/config/training/ensemble.yaml
@@ -29,11 +29,14 @@ gradient_clip:
   val: 32.
   algorithm: value
 
-# stochastic weight averaging
-# https://pytorch.org/blog/stochastic-weight-averaging-in-pytorch/
-swa:
-  enabled: False
-  lr: 1.e-4
+# weight averaging only supported in Lightning 2.6+
+weight_averaging: null
+# For EMA:
+#  _target_: pytorch_lightning.callbacks.EMAWeightAveraging
+#  decay: 0.999
+# For SWA:
+#  _target_: pytorch_lightning.callbacks.StochasticWeightAveraging
+#  swa_lrs: 1.e-4
 
 
 # select model

--- a/training/src/anemoi/training/config/training/ensemble.yaml
+++ b/training/src/anemoi/training/config/training/ensemble.yaml
@@ -2,6 +2,7 @@
 defaults:
   - scalers: global
   - optimization: default
+  - weight_averaging: null
 
 # resume or fork a training from a checkpoint last.ckpt or specified in system.input.warm_start
 run_id: null
@@ -28,16 +29,6 @@ num_sanity_val_steps: 6
 gradient_clip:
   val: 32.
   algorithm: value
-
-# weight averaging only supported in Lightning 2.6+
-weight_averaging: null
-# For EMA:
-#  _target_: pytorch_lightning.callbacks.EMAWeightAveraging
-#  decay: 0.999
-# For SWA:
-#  _target_: pytorch_lightning.callbacks.StochasticWeightAveraging
-#  swa_lrs: 1.e-4
-
 
 # select model
 training_method: anemoi.training.train.methods.EnsembleTraining

--- a/training/src/anemoi/training/config/training/lam.yaml
+++ b/training/src/anemoi/training/config/training/lam.yaml
@@ -29,11 +29,14 @@ gradient_clip:
   val: 32.
   algorithm: value
 
-# stochastic weight averaging
-# https://pytorch.org/blog/stochastic-weight-averaging-in-pytorch/
-swa:
-  enabled: False
-  lr: 1.e-4
+# weight averaging only supported in Lightning 2.6+
+weight_averaging: null
+# For EMA:
+#  _target_: pytorch_lightning.callbacks.EMAWeightAveraging
+#  decay: 0.999
+# For SWA:
+#  _target_: pytorch_lightning.callbacks.StochasticWeightAveraging
+#  swa_lrs: 1.e-4
 
 # Optimizer settings
 

--- a/training/src/anemoi/training/config/training/lam.yaml
+++ b/training/src/anemoi/training/config/training/lam.yaml
@@ -2,6 +2,7 @@
 defaults:
   - scalers: lam
   - optimization: default
+  - weight_averaging: null
 
 # resume or fork a training from a checkpoint last.ckpt or specified in system.input.warm_start
 run_id: null
@@ -28,15 +29,6 @@ num_sanity_val_steps: 6
 gradient_clip:
   val: 32.
   algorithm: value
-
-# weight averaging only supported in Lightning 2.6+
-weight_averaging: null
-# For EMA:
-#  _target_: pytorch_lightning.callbacks.EMAWeightAveraging
-#  decay: 0.999
-# For SWA:
-#  _target_: pytorch_lightning.callbacks.StochasticWeightAveraging
-#  swa_lrs: 1.e-4
 
 # Optimizer settings
 

--- a/training/src/anemoi/training/config/training/multi.yaml
+++ b/training/src/anemoi/training/config/training/multi.yaml
@@ -2,6 +2,7 @@
 defaults:
   - scalers: multi
   - optimization: default
+  - weight_averaging: null
 
 # resume or fork a training from a checkpoint last.ckpt or specified in hardware.files.warm_start
 run_id: null
@@ -28,15 +29,6 @@ num_sanity_val_steps: 6
 gradient_clip:
   val: 32.
   algorithm: value
-
-# weight averaging only supported in Lightning 2.6+
-weight_averaging: null
-# For EMA:
-#  _target_: pytorch_lightning.callbacks.EMAWeightAveraging
-#  decay: 0.999
-# For SWA:
-#  _target_: pytorch_lightning.callbacks.StochasticWeightAveraging
-#  swa_lrs: 1.e-4
 
 # =====================================================================
 # Optimizer configuration

--- a/training/src/anemoi/training/config/training/multi.yaml
+++ b/training/src/anemoi/training/config/training/multi.yaml
@@ -29,11 +29,14 @@ gradient_clip:
   val: 32.
   algorithm: value
 
-# stochastic weight averaging
-# https://pytorch.org/blog/stochastic-weight-averaging-in-pytorch/
-swa:
-  enabled: False
-  lr: 1.e-4
+# weight averaging only supported in Lightning 2.6+
+weight_averaging: null
+# For EMA:
+#  _target_: pytorch_lightning.callbacks.EMAWeightAveraging
+#  decay: 0.999
+# For SWA:
+#  _target_: pytorch_lightning.callbacks.StochasticWeightAveraging
+#  swa_lrs: 1.e-4
 
 # =====================================================================
 # Optimizer configuration

--- a/training/src/anemoi/training/config/training/single.yaml
+++ b/training/src/anemoi/training/config/training/single.yaml
@@ -29,11 +29,14 @@ gradient_clip:
   val: 32.
   algorithm: value
 
-# stochastic weight averaging
-# https://pytorch.org/blog/stochastic-weight-averaging-in-pytorch/
-swa:
-  enabled: False
-  lr: 1.e-4
+# weight averaging only supported in Lightning 2.6+
+weight_averaging: null
+# For EMA:
+#  _target_: pytorch_lightning.callbacks.EMAWeightAveraging
+#  decay: 0.999
+# For SWA:
+#  _target_: pytorch_lightning.callbacks.StochasticWeightAveraging
+#  swa_lrs: 1.e-4
 
 
 # select model

--- a/training/src/anemoi/training/config/training/single.yaml
+++ b/training/src/anemoi/training/config/training/single.yaml
@@ -2,6 +2,7 @@
 defaults:
   - scalers: global
   - optimization: default
+  - weight_averaging: null
 
 # resume or fork a training from a checkpoint last.ckpt or specified in system.input.warm_start
 run_id: null
@@ -28,16 +29,6 @@ num_sanity_val_steps: 6
 gradient_clip:
   val: 32.
   algorithm: value
-
-# weight averaging only supported in Lightning 2.6+
-weight_averaging: null
-# For EMA:
-#  _target_: pytorch_lightning.callbacks.EMAWeightAveraging
-#  decay: 0.999
-# For SWA:
-#  _target_: pytorch_lightning.callbacks.StochasticWeightAveraging
-#  swa_lrs: 1.e-4
-
 
 # select model
 training_method: anemoi.training.train.methods.SingleTraining

--- a/training/src/anemoi/training/config/training/stretched.yaml
+++ b/training/src/anemoi/training/config/training/stretched.yaml
@@ -30,11 +30,14 @@ gradient_clip:
   val: 32.
   algorithm: value
 
-# stochastic weight averaging
-# https://pytorch.org/blog/stochastic-weight-averaging-in-pytorch/
-swa:
-  enabled: False
-  lr: 1.e-4
+# weight averaging only supported in Lightning 2.6+
+weight_averaging: null
+# For EMA:
+#  _target_: pytorch_lightning.callbacks.EMAWeightAveraging
+#  decay: 0.999
+# For SWA:
+#  _target_: pytorch_lightning.callbacks.StochasticWeightAveraging
+#  swa_lrs: 1.e-4
 
 # Optimizer settings
 

--- a/training/src/anemoi/training/config/training/stretched.yaml
+++ b/training/src/anemoi/training/config/training/stretched.yaml
@@ -2,6 +2,7 @@
 defaults:
   - scalers: stretched
   - optimization: default
+  - weight_averaging: null
 
 # resume or fork a training from a checkpoint last.ckpt or specified in system.input.warm_start
 run_id: null
@@ -29,15 +30,6 @@ num_sanity_val_steps: 6
 gradient_clip:
   val: 32.
   algorithm: value
-
-# weight averaging only supported in Lightning 2.6+
-weight_averaging: null
-# For EMA:
-#  _target_: pytorch_lightning.callbacks.EMAWeightAveraging
-#  decay: 0.999
-# For SWA:
-#  _target_: pytorch_lightning.callbacks.StochasticWeightAveraging
-#  swa_lrs: 1.e-4
 
 # Optimizer settings
 

--- a/training/src/anemoi/training/config/training/weight_averaging/ema.yaml
+++ b/training/src/anemoi/training/config/training/weight_averaging/ema.yaml
@@ -1,0 +1,3 @@
+_target_: pytorch_lightning.callbacks.EMAWeightAveraging
+decay: 0.999
+update_starting_at_step: ${training.lr.warmup}

--- a/training/src/anemoi/training/config/training/weight_averaging/ema.yaml
+++ b/training/src/anemoi/training/config/training/weight_averaging/ema.yaml
@@ -1,3 +1,2 @@
 _target_: pytorch_lightning.callbacks.EMAWeightAveraging
 decay: 0.999
-update_starting_at_step: ${training.lr.warmup}

--- a/training/src/anemoi/training/config/training/weight_averaging/swa.yaml
+++ b/training/src/anemoi/training/config/training/weight_averaging/swa.yaml
@@ -1,0 +1,2 @@
+_target_: pytorch_lightning.callbacks.StochasticWeightAveraging
+swa_lrs: 1.e-4

--- a/training/src/anemoi/training/diagnostics/callbacks/__init__.py
+++ b/training/src/anemoi/training/diagnostics/callbacks/__init__.py
@@ -9,7 +9,6 @@
 
 
 import logging
-import types
 from collections.abc import Callable
 from collections.abc import Iterable
 from datetime import timedelta
@@ -26,6 +25,7 @@ from anemoi.training.diagnostics.callbacks.checkpoint import AnemoiCheckpoint
 from anemoi.training.diagnostics.callbacks.optimiser import LearningRateMonitor
 from anemoi.training.diagnostics.callbacks.provenance import ParentUUIDCallback
 from anemoi.training.diagnostics.callbacks.sanity import CheckVariableOrder
+from anemoi.training.diagnostics.callbacks.weight_averaging import _get_weight_averaging_callback
 from anemoi.training.schemas.base_schema import BaseSchema
 from anemoi.training.utils.checkpoint import RegisterMigrations
 
@@ -55,96 +55,6 @@ CONFIG_ENABLED_CALLBACKS: list[tuple[list[str] | str | Callable[[DictConfig], bo
         LearningRateMonitor,
     ),
 ]
-
-
-def _safe_swap_models(self: Any, pl_module: Any) -> None:
-    """Swap buffers between the averaged model and the current model.
-
-    Uses name-based matching to allow buffer reordering as can happen with dynamic scalers (e.g.
-    NaNMaskScaler).
-
-    Args:
-        pl_module : The PyTorch Lightning module
-    """
-    assert self._average_model is not None
-
-    avg_params = dict(self._average_model.module.named_parameters())
-    for name, current_param in pl_module.named_parameters():
-        avg_param = avg_params[name]
-        tmp = avg_param.data.clone()
-        avg_param.data.copy_(current_param.data)
-        current_param.data.copy_(tmp)
-
-    avg_buffers = dict(self._average_model.module.named_buffers())
-    for name, current_buf in pl_module.named_buffers():
-        if name not in avg_buffers:
-            continue
-        avg_buf = avg_buffers[name]
-        if avg_buf.shape != current_buf.shape:
-            continue
-        tmp = avg_buf.data.clone()
-        avg_buf.data.copy_(current_buf.data)
-        current_buf.data.copy_(tmp)
-
-
-def _safe_copy_average_to_current(self: Any, pl_module: Any) -> None:
-    """Copy averaged buffers to the current model.
-
-    Same as ``_safe_swap_models`` but for the copy performed at the end of training.
-    """
-    assert self._average_model is not None
-
-    avg_params = dict(self._average_model.module.named_parameters())
-    for name, current_param in pl_module.named_parameters():
-        current_param.data.copy_(avg_params[name].data)
-
-    avg_buffers = dict(self._average_model.module.named_buffers())
-    for name, current_buf in pl_module.named_buffers():
-        if name not in avg_buffers:
-            continue
-        avg_buf = avg_buffers[name]
-        if avg_buf.shape != current_buf.shape:
-            continue
-        current_buf.data.copy_(avg_buf.data)
-
-
-def _get_weight_averaging_callback(config: DictConfig) -> list[Callback]:
-    """Get weight averaging callback.
-
-    Supported are ExponentialMovingAverage and StochasticWeightAveraging.
-
-    Example config:
-        weight_averaging:
-          _target_: anemoi.training.diagnostics.callbacks.optimiser.ExponentialMovingAverage
-          decay: 0.999
-
-    Parameters
-    ----------
-    config : DictConfig
-        Job configuration
-
-    Returns
-    -------
-    list[Callback]
-        List containing the weight averaging callback, or empty list if not configured.
-    """
-    weight_averaging_config = nestedget(config, "training.weight_averaging", None)
-    if weight_averaging_config is None:
-        return []
-    if not isinstance(weight_averaging_config, dict | DictConfig):
-        return []
-    if "_target_" not in weight_averaging_config:
-        return []
-
-    callback = instantiate(weight_averaging_config)
-
-    # Patch swap/copy methods to use name-based matching. Needed for dynamic scalers like NaNMaskScaler.
-    if hasattr(callback, "_swap_models"):
-        callback._swap_models = types.MethodType(_safe_swap_models, callback)
-    if hasattr(callback, "_copy_average_to_current"):
-        callback._copy_average_to_current = types.MethodType(_safe_copy_average_to_current, callback)
-
-    return [callback]
 
 
 def _get_checkpoint_callback(config: BaseSchema) -> list[AnemoiCheckpoint]:

--- a/training/src/anemoi/training/diagnostics/callbacks/__init__.py
+++ b/training/src/anemoi/training/diagnostics/callbacks/__init__.py
@@ -9,6 +9,7 @@
 
 
 import logging
+import types
 from collections.abc import Callable
 from collections.abc import Iterable
 from datetime import timedelta
@@ -56,6 +57,57 @@ CONFIG_ENABLED_CALLBACKS: list[tuple[list[str] | str | Callable[[DictConfig], bo
 ]
 
 
+def _safe_swap_models(self: Any, pl_module: Any) -> None:
+    """Swap buffers between the averaged model and the current model.
+
+    Uses name-based matching to allow buffer reordering as can happen with dynamic scalers (e.g.
+    NaNMaskScaler).
+
+    Args:
+        pl_module : The PyTorch Lightning module
+    """
+    assert self._average_model is not None
+
+    avg_params = dict(self._average_model.module.named_parameters())
+    for name, current_param in pl_module.named_parameters():
+        avg_param = avg_params[name]
+        tmp = avg_param.data.clone()
+        avg_param.data.copy_(current_param.data)
+        current_param.data.copy_(tmp)
+
+    avg_buffers = dict(self._average_model.module.named_buffers())
+    for name, current_buf in pl_module.named_buffers():
+        if name not in avg_buffers:
+            continue
+        avg_buf = avg_buffers[name]
+        if avg_buf.shape != current_buf.shape:
+            continue
+        tmp = avg_buf.data.clone()
+        avg_buf.data.copy_(current_buf.data)
+        current_buf.data.copy_(tmp)
+
+
+def _safe_copy_average_to_current(self: Any, pl_module: Any) -> None:
+    """Copy averaged buffers to the current model.
+
+    Same as ``_safe_swap_models`` but for the copy performed at the end of training.
+    """
+    assert self._average_model is not None
+
+    avg_params = dict(self._average_model.module.named_parameters())
+    for name, current_param in pl_module.named_parameters():
+        current_param.data.copy_(avg_params[name].data)
+
+    avg_buffers = dict(self._average_model.module.named_buffers())
+    for name, current_buf in pl_module.named_buffers():
+        if name not in avg_buffers:
+            continue
+        avg_buf = avg_buffers[name]
+        if avg_buf.shape != current_buf.shape:
+            continue
+        current_buf.data.copy_(avg_buf.data)
+
+
 def _get_weight_averaging_callback(config: DictConfig) -> list[Callback]:
     """Get weight averaging callback.
 
@@ -77,16 +129,22 @@ def _get_weight_averaging_callback(config: DictConfig) -> list[Callback]:
         List containing the weight averaging callback, or empty list if not configured.
     """
     weight_averaging_config = nestedget(config, "training.weight_averaging", None)
+    if weight_averaging_config is None:
+        return []
+    if not isinstance(weight_averaging_config, dict | DictConfig):
+        return []
+    if "_target_" not in weight_averaging_config:
+        return []
 
-    if weight_averaging_config is not None:
-        try:
-            weight_averaging = instantiate(weight_averaging_config)
-            LOGGER.info("Using weight averaging: %s", type(weight_averaging))
-        except InstantiationException:
-            LOGGER.warning("Failed to instantiate weight averaging callback from config: %s", weight_averaging_config)
-        else:
-            return [weight_averaging]
-    return []
+    callback = instantiate(weight_averaging_config)
+
+    # Patch swap/copy methods to use name-based matching. Needed for dynamic scalers like NaNMaskScaler.
+    if hasattr(callback, "_swap_models"):
+        callback._swap_models = types.MethodType(_safe_swap_models, callback)
+    if hasattr(callback, "_copy_average_to_current"):
+        callback._copy_average_to_current = types.MethodType(_safe_copy_average_to_current, callback)
+
+    return [callback]
 
 
 def _get_checkpoint_callback(config: BaseSchema) -> list[AnemoiCheckpoint]:

--- a/training/src/anemoi/training/diagnostics/callbacks/__init__.py
+++ b/training/src/anemoi/training/diagnostics/callbacks/__init__.py
@@ -23,7 +23,6 @@ from pytorch_lightning.callbacks import TQDMProgressBar
 
 from anemoi.training.diagnostics.callbacks.checkpoint import AnemoiCheckpoint
 from anemoi.training.diagnostics.callbacks.optimiser import LearningRateMonitor
-from anemoi.training.diagnostics.callbacks.optimiser import StochasticWeightAveraging
 from anemoi.training.diagnostics.callbacks.provenance import ParentUUIDCallback
 from anemoi.training.diagnostics.callbacks.sanity import CheckVariableOrder
 from anemoi.training.schemas.base_schema import BaseSchema
@@ -49,13 +48,45 @@ def nestedget(config: DictConfig, key: str, default: Any) -> Any:
 # Callbacks to add according to flags in the config
 # Can be function to check status from config
 CONFIG_ENABLED_CALLBACKS: list[tuple[list[str] | str | Callable[[DictConfig], bool], type[Callback]]] = [
-    ("training.swa.enabled", StochasticWeightAveraging),
     (
         lambda config: nestedget(config, "diagnostics.log.wandb.enabled", False)
         or nestedget(config, "diagnostics.log.mlflow.enabled", False),
         LearningRateMonitor,
     ),
 ]
+
+
+def _get_weight_averaging_callback(config: DictConfig) -> list[Callback]:
+    """Get weight averaging callback.
+
+    Supported are ExponentialMovingAverage and StochasticWeightAveraging.
+
+    Example config:
+        weight_averaging:
+          _target_: anemoi.training.diagnostics.callbacks.optimiser.ExponentialMovingAverage
+          decay: 0.999
+
+    Parameters
+    ----------
+    config : DictConfig
+        Job configuration
+
+    Returns
+    -------
+    list[Callback]
+        List containing the weight averaging callback, or empty list if not configured.
+    """
+    weight_averaging_config = nestedget(config, "training.weight_averaging", None)
+
+    if weight_averaging_config is not None:
+        try:
+            weight_averaging = instantiate(weight_averaging_config)
+            LOGGER.info("Using weight averaging: %s", type(weight_averaging))
+        except InstantiationException:
+            LOGGER.warning("Failed to instantiate weight averaging callback from config: %s", weight_averaging_config)
+        else:
+            return [weight_averaging]
+    return []
 
 
 def _get_checkpoint_callback(config: BaseSchema) -> list[AnemoiCheckpoint]:
@@ -224,6 +255,9 @@ def get_callbacks(config: DictConfig) -> list[Callback]:
 
     # Plotting callbacks
     trainer_callbacks.extend(instantiate(callback, config) for callback in config.diagnostics.plot.callbacks)
+
+    # Weight averaging callback (SWA or EMA)
+    trainer_callbacks.extend(_get_weight_averaging_callback(config))
 
     # Extend with config enabled callbacks
     trainer_callbacks.extend(_get_config_enabled_callbacks(config))

--- a/training/src/anemoi/training/diagnostics/callbacks/optimiser.py
+++ b/training/src/anemoi/training/diagnostics/callbacks/optimiser.py
@@ -12,7 +12,6 @@ import logging
 
 from omegaconf import DictConfig
 from pytorch_lightning.callbacks import LearningRateMonitor as pl_LearningRateMonitor
-from pytorch_lightning.callbacks.stochastic_weight_avg import StochasticWeightAveraging as pl_StochasticWeightAveraging
 
 LOGGER = logging.getLogger(__name__)
 
@@ -27,47 +26,4 @@ class LearningRateMonitor(pl_LearningRateMonitor):
         log_momentum: bool = False,
     ) -> None:
         super().__init__(logging_interval=logging_interval, log_momentum=log_momentum)
-        self.config = config
-
-
-class StochasticWeightAveraging(pl_StochasticWeightAveraging):
-    """Provide StochasticWeightAveraging from pytorch_lightning as a callback."""
-
-    def __init__(
-        self,
-        config: DictConfig,
-        swa_lrs: int | None = None,
-        swa_epoch_start: int | None = None,
-        annealing_epochs: int | None = None,
-        annealing_strategy: str | None = None,
-        device: str | None = None,
-        **kwargs,
-    ) -> None:
-        """Stochastic Weight Averaging Callback.
-
-        Parameters
-        ----------
-        config : OmegaConf
-            Full configuration object
-        swa_lrs : int, optional
-            Stochastic Weight Averaging Learning Rate, by default None
-        swa_epoch_start : int, optional
-            Epoch start, by default 0.75 * config.training.max_epochs
-        annealing_epochs : int, optional
-            Annealing Epoch, by default 0.25 * config.training.max_epochs
-        annealing_strategy : str, optional
-            Annealing Strategy, by default 'cos'
-        device : str, optional
-            Device to use, by default None
-        """
-        kwargs["swa_lrs"] = swa_lrs or config.training.swa.lr
-        kwargs["swa_epoch_start"] = swa_epoch_start or min(
-            int(0.75 * config.training.max_epochs),
-            config.training.max_epochs - 1,
-        )
-        kwargs["annealing_epochs"] = annealing_epochs or max(int(0.25 * config.training.max_epochs), 1)
-        kwargs["annealing_strategy"] = annealing_strategy or "cos"
-        kwargs["device"] = device
-
-        super().__init__(**kwargs)
         self.config = config

--- a/training/src/anemoi/training/diagnostics/callbacks/weight_averaging.py
+++ b/training/src/anemoi/training/diagnostics/callbacks/weight_averaging.py
@@ -1,0 +1,128 @@
+# (C) Copyright 2024 Anemoi contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+
+import logging
+import types
+from typing import Any
+
+import pytorch_lightning as pl
+from hydra.utils import instantiate
+from omegaconf import DictConfig
+from packaging.version import Version
+from pytorch_lightning.callbacks import Callback
+
+LOGGER = logging.getLogger(__name__)
+
+MIN_PL_VERSION = "2.6.0"
+
+
+def _safe_swap_models(self: Any, pl_module: Any) -> None:
+    """Swap buffers between the averaged model and the current model.
+
+    Uses name-based matching to allow buffer reordering as can happen with dynamic scalers (e.g.
+    NaNMaskScaler).
+
+    Args:
+        pl_module : The PyTorch Lightning module
+    """
+    assert self._average_model is not None
+
+    avg_params = dict(self._average_model.module.named_parameters())
+    for name, current_param in pl_module.named_parameters():
+        avg_param = avg_params[name]
+        tmp = avg_param.data.clone()
+        avg_param.data.copy_(current_param.data)
+        current_param.data.copy_(tmp)
+
+    avg_buffers = dict(self._average_model.module.named_buffers())
+    for name, current_buf in pl_module.named_buffers():
+        if name not in avg_buffers:
+            continue
+        avg_buf = avg_buffers[name]
+        if avg_buf.shape != current_buf.shape:
+            continue
+        tmp = avg_buf.data.clone()
+        avg_buf.data.copy_(current_buf.data)
+        current_buf.data.copy_(tmp)
+
+
+def _safe_copy_average_to_current(self: Any, pl_module: Any) -> None:
+    """Copy averaged buffers to the current model.
+
+    Same as ``_safe_swap_models`` but for the copy performed at the end of training.
+    """
+    assert self._average_model is not None
+
+    avg_params = dict(self._average_model.module.named_parameters())
+    for name, current_param in pl_module.named_parameters():
+        current_param.data.copy_(avg_params[name].data)
+
+    avg_buffers = dict(self._average_model.module.named_buffers())
+    for name, current_buf in pl_module.named_buffers():
+        if name not in avg_buffers:
+            continue
+        avg_buf = avg_buffers[name]
+        if avg_buf.shape != current_buf.shape:
+            continue
+        current_buf.data.copy_(avg_buf.data)
+
+
+def _get_weight_averaging_callback(config: DictConfig) -> list[Callback]:
+    """Get weight averaging callback from the config.
+
+    Example config for EMA weight averaging:
+        weight_averaging:
+            _target_: pytorch_lightning.callbacks.EMAWeightAveraging
+            decay: 0.999
+
+    Parameters
+    ----------
+    config : DictConfig
+        Job configuration
+
+    Returns
+    -------
+    list[Callback]
+        List containing the weight averaging callback, or empty list if not configured.
+    """
+    from anemoi.training.diagnostics.callbacks import nestedget
+
+    weight_averaging_config = nestedget(config, "training.weight_averaging", None)
+    if weight_averaging_config is None:
+        LOGGER.debug("No weight averaging configured. Skipping.")
+        return []
+    if not isinstance(weight_averaging_config, dict | DictConfig):
+        LOGGER.warning(
+            "training.weight_averaging has unexpected type %s; expected a dict with '_target_'. Skipping.",
+            type(weight_averaging_config).__name__,
+        )
+        return []
+    if "_target_" not in weight_averaging_config:
+        LOGGER.warning("training.weight_averaging is set but has no '_target_' field. Skipping.")
+        return []
+
+    if Version(pl.__version__) < Version(MIN_PL_VERSION):
+        msg = (
+            f"Weight averaging callback {weight_averaging_config['_target_']!r} requires "
+            f"pytorch_lightning>={MIN_PL_VERSION}, but found {pl.__version__}. "
+            f"Please upgrade pytorch_lightning to use this callback."
+        )
+        raise RuntimeError(msg)
+
+    callback = instantiate(weight_averaging_config)
+    LOGGER.info("Loaded weight averaging callback: %s", weight_averaging_config["_target_"])
+
+    # Patch swap/copy methods to use name-based matching. Needed for dynamic scalers like NaNMaskScaler.
+    if hasattr(callback, "_swap_models"):
+        callback._swap_models = types.MethodType(_safe_swap_models, callback)
+    if hasattr(callback, "_copy_average_to_current"):
+        callback._copy_average_to_current = types.MethodType(_safe_copy_average_to_current, callback)
+
+    return [callback]

--- a/training/src/anemoi/training/losses/scaler_tensor.py
+++ b/training/src/anemoi/training/losses/scaler_tensor.py
@@ -336,7 +336,7 @@ class ScaleTensor(nn.Module):
         dimension = self._tensors[name][0]
 
         original_scaler = self._tensors.pop(name)
-        original_scaler_buffer = self._buffers.pop(name, None)
+        original_scaler_buffer = self._buffers.get(name)
 
         if not override:
             self.validate_scaler(dimension, scaler)

--- a/training/src/anemoi/training/schemas/training.py
+++ b/training/src/anemoi/training/schemas/training.py
@@ -66,11 +66,8 @@ class GradientClip(BaseModel):
     "The gradient clipping algorithm to use"
 
 
-class WeightAveragingSchema(BaseModel):
-    """Weight averaging configuration (SWA or EMA).
-
-    Uses Hydra instantiate pattern with _target_ to specify the callback class.
-    See https://pytorch.org/blog/stochastic-weight-averaging-in-pytorch/
+class WeightAveragingSchema(GenericSchema):
+    """Hydra instantiation config for a weight averaging callback (EMA or SWA).
 
     Example:
         weight_averaging:
@@ -78,30 +75,6 @@ class WeightAveragingSchema(BaseModel):
           decay: 0.999
           update_starting_at_step: 1000
     """
-
-    target_: Literal[
-        "pytorch_lightning.callbacks.EMAWeightAveraging",
-        "pytorch_lightning.callbacks.StochasticWeightAveraging",
-    ] = Field(..., alias="_target_")
-    "Target callback class for weight averaging. Either EMAWeightAveraging or StochasticWeightAveraging."
-    # EMA specific
-    decay: NonNegativeFloat | None = Field(default=None)
-    "EMA decay rate (only used for EMAWeightAveraging)."
-    update_every_n_steps: PositiveInt = Field(default=1)
-    "Update every n steps (only used for EMAWeightAveraging)."
-    update_starting_at_step: PositiveInt | None = Field(default=None)
-    "Update starting at step (only used for EMAWeightAveraging)."
-    update_starting_at_epoch: PositiveInt | None = Field(default=None)
-    "Update starting at epoch (only used for EMAWeightAveraging)."
-    # SWA specific
-    swa_lrs: NonNegativeFloat | list[NonNegativeFloat] = Field(default=0.8)
-    "SWA learning rate (only used for StochasticWeightAveraging)."
-    swa_epoch_start: NonNegativeFloat = Field(default=0.8)
-    "SWA epoch start (only used for StochasticWeightAveraging)."
-    annealing_epochs: PositiveInt = Field(default=10)
-    "Annealing epochs (only used for StochasticWeightAveraging)."
-    annealing_strategy: Literal["cos", "linear"] = Field(default="cos")
-    "Annealing strategy (only used for StochasticWeightAveraging)."
 
 
 class OptimizationSchema(BaseModel):

--- a/training/src/anemoi/training/schemas/training.py
+++ b/training/src/anemoi/training/schemas/training.py
@@ -66,16 +66,42 @@ class GradientClip(BaseModel):
     "The gradient clipping algorithm to use"
 
 
-class SWA(BaseModel):
-    """Stochastic weight averaging configuration.
+class WeightAveragingSchema(BaseModel):
+    """Weight averaging configuration (SWA or EMA).
 
+    Uses Hydra instantiate pattern with _target_ to specify the callback class.
     See https://pytorch.org/blog/stochastic-weight-averaging-in-pytorch/
+
+    Example:
+        weight_averaging:
+          _target_: pytorch_lightning.callbacks.EMAWeightAveraging
+          decay: 0.999
+          update_starting_at_step: 1000
     """
 
-    enabled: bool = Field(example=False)
-    "Enable stochastic weight averaging."
-    lr: NonNegativeFloat = Field(example=1.0e-4)
-    "Learning rate for SWA."
+    target_: Literal[
+        "pytorch_lightning.callbacks.EMAWeightAveraging",
+        "pytorch_lightning.callbacks.StochasticWeightAveraging",
+    ] = Field(..., alias="_target_")
+    "Target callback class for weight averaging. Either EMAWeightAveraging or StochasticWeightAveraging."
+    # EMA specific
+    decay: NonNegativeFloat | None = Field(default=None)
+    "EMA decay rate (only used for EMAWeightAveraging)."
+    update_every_n_steps: PositiveInt = Field(default=1)
+    "Update every n steps (only used for EMAWeightAveraging)."
+    update_starting_at_step: PositiveInt | None = Field(default=None)
+    "Update starting at step (only used for EMAWeightAveraging)."
+    update_starting_at_epoch: PositiveInt | None = Field(default=None)
+    "Update starting at epoch (only used for EMAWeightAveraging)."
+    # SWA specific
+    swa_lrs: NonNegativeFloat | list[NonNegativeFloat] = Field(default=0.8)
+    "SWA learning rate (only used for StochasticWeightAveraging)."
+    swa_epoch_start: NonNegativeFloat = Field(default=0.8)
+    "SWA epoch start (only used for StochasticWeightAveraging)."
+    annealing_epochs: PositiveInt = Field(default=10)
+    "Annealing epochs (only used for StochasticWeightAveraging)."
+    annealing_strategy: Literal["cos", "linear"] = Field(default="cos")
+    "Annealing strategy (only used for StochasticWeightAveraging)."
 
 
 class OptimizationSchema(BaseModel):
@@ -425,8 +451,8 @@ class BaseTrainingSchema(BaseModel):
     "Config for gradient clipping."
     strategy: StrategySchemas
     "Strategy to use."
-    swa: SWA = Field(default_factory=SWA)
-    "Config for stochastic weight averaging."
+    weight_averaging: WeightAveragingSchema | None = Field(default=None)
+    "Config for weight averaging (SWA or EMA). Set to null to disable."
     training_loss: DatasetDict[LossSchemas]
     "Training loss configuration."
     loss_gradient_scaling: bool = False

--- a/training/tests/integration/aicon/test_cicd_aicon_04_icon-dream_medium.yaml
+++ b/training/tests/integration/aicon/test_cicd_aicon_04_icon-dream_medium.yaml
@@ -230,9 +230,7 @@ training:
   gradient_clip:
     val: 32.0
     algorithm: value
-  swa:
-    enabled: false
-    lr: 0.0001
+  weight_averaging: null
   optimization:
     lr: 6.25e-05
     optimizer:

--- a/training/tests/unit/diagnostics/callbacks/test_weight_averaging.py
+++ b/training/tests/unit/diagnostics/callbacks/test_weight_averaging.py
@@ -1,0 +1,47 @@
+# (C) Copyright 2024 Anemoi contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Unit tests for weight averaging callback functionality."""
+
+import omegaconf
+import pytest
+import yaml
+
+from anemoi.training.diagnostics.callbacks import _get_weight_averaging_callback
+
+default_config = """
+training:
+  weight_averaging: null
+"""
+
+
+def test_weight_averaging_disabled_when_null() -> None:
+    """Test that weight averaging is disabled when set to null."""
+    config = omegaconf.OmegaConf.create(yaml.safe_load(default_config))
+    callbacks = _get_weight_averaging_callback(config)
+    assert callbacks == []
+
+
+def test_ema_callback_available() -> None:
+    """Test that EMA weight averaging callback can be instantiated."""
+    pytest.importorskip("pytorch_lightning.callbacks", reason="EMA requires PyTorch Lightning 2.6+")
+
+    try:
+        from pytorch_lightning.callbacks import EMAWeightAveraging
+    except ImportError:
+        pytest.skip("EMAWeightAveraging not available in this PyTorch Lightning version")
+
+    config = omegaconf.OmegaConf.create(yaml.safe_load(default_config))
+    config.training.weight_averaging = {
+        "_target_": "pytorch_lightning.callbacks.EMAWeightAveraging",
+        "decay": 0.999,
+    }
+    callbacks = _get_weight_averaging_callback(config)
+    assert len(callbacks) == 1
+    assert isinstance(callbacks[0], EMAWeightAveraging)


### PR DESCRIPTION
Weight averaging is a technique to improve model generalization by averaging model weights during training. In the new pytorch lightning version (2.6.0) different versions of weight averaging are now supported. 

Here, I refactor the existing SWA implementation to support general weight averaging methods through the config. For example, EMA training can be used by adding the following to the `config.training`: 
```
         weight_averaging:
            _target_: pytorch_lightning.callbacks.EMAWeightAveraging
            decay: 0.999
```

The impact of EMA for smoother training and less fluctuation between checkpoints is especially important for the biases at longer rollout: 

<img width="546" height="297" alt="image" src="https://github.com/user-attachments/assets/5cd80788-1ee6-4dce-ac06-31261592872f" />

Figure: Validation loss over training iterations for 2t. Upper panel shows validation loss at step 1 (1 day) and lower panel step 14 (14 days). 



**Note:** 
- I've deliberately deleted the previous version of weight initialization to keep the code cleaner. 
- Old configs should still work, since defaults are null if `weight_averaging` does not exist, but this is still a breaking change if swa was used before.



***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)


<!-- readthedocs-preview anemoi-training start -->
----
📚 Documentation preview 📚: https://anemoi-training--743.org.readthedocs.build/en/743/

<!-- readthedocs-preview anemoi-training end -->

<!-- readthedocs-preview anemoi-graphs start -->
----
📚 Documentation preview 📚: https://anemoi-graphs--743.org.readthedocs.build/en/743/

<!-- readthedocs-preview anemoi-graphs end -->

<!-- readthedocs-preview anemoi-models start -->
----
📚 Documentation preview 📚: https://anemoi-models--743.org.readthedocs.build/en/743/

<!-- readthedocs-preview anemoi-models end -->