### PR TITLE
fix: Fix check for checkpoint path in the dry run case.

### DIFF
--- a/training/src/anemoi/training/train/train.py
+++ b/training/src/anemoi/training/train/train.py
@@ -436,7 +436,7 @@ class AnemoiTrainer(ABC):
         if self.config.diagnostics.log.mlflow.enabled:
             # Check if the run ID is dry - e.g. without a checkpoint
             self.dry_run = (
-                self.mlflow_logger._parent_dry_run and not Path(self.config.system.output.checkpoints).is_dir()
+                self.mlflow_logger._parent_dry_run and not Path(self.config.system.output.checkpoints.root).is_dir()
             )
             self.start_from_checkpoint = (
                 False if (self.dry_run and not bool(self.config.training.fork_run_id)) else self.start_from_checkpoint


### PR DESCRIPTION
## Description
anemoi-training using a dry run is broken:
```
+ 2025-12-16 14:29:16 srun anemoi-training train --config-name=dev_1_epoch system.output.root=./training_output// 'training.run_id='\''d6151a261f5a4df8b25e85f99c14bfc5'\''' 'diagnostics.log.mlflow.run_name='\''fond-tick'\'''
...
[2025-12-16 14:29:29,041][anemoi.training.train.train][INFO] - Checkpoints path: root=PosixPath('training_output/checkpoint/d6151a261f5a4df8b25e85f99c14bfc5') every_n_epochs='anemoi-by_epoch-epoch_{epoch:03d}-step_{step:06d}' every_n_train_steps='anemoi-by_step-epoch_{epoch:03d}-step_{step:06d}' every_n_minutes='anemoi-by_time-epoch_{epoch:03d}-step_{step:06d}'
[2025-12-16 14:29:29,041][anemoi.training.train.train][INFO] - Plots path: training_output/plots/d6151a261f5a4df8b25e85f99c14bfc5
Error executing job with overrides: ['system.output.root=./training_output//', "training.run_id='d6151a261f5a4df8b25e85f99c14bfc5'", "diagnostics.log.mlflow.run_name='fond-tick'"]
Traceback (most recent call last):
  File "/etc/ecmwf/nfs/dh1_home_a/ecm6116/Documents/workingdir/tools/python/anemoi/anemoi-core/training/src/anemoi/training/train/train.py", line 529, in main
    AnemoiTrainer(config).train()
    ^^^^^^^^^^^^^^^^^^^^^
  File "/etc/ecmwf/nfs/dh1_home_a/ecm6116/Documents/workingdir/tools/python/anemoi/anemoi-core/training/src/anemoi/training/train/train.py", line 99, in __init__
    self._check_dry_run()
  File "/etc/ecmwf/nfs/dh1_home_a/ecm6116/Documents/workingdir/tools/python/venv/anemoi-training/lib/python3.12/site-packages/lightning_utilities/core/rank_zero.py", line 41, in wrapped_fn
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/etc/ecmwf/nfs/dh1_home_a/ecm6116/Documents/workingdir/tools/python/anemoi/anemoi-core/training/src/anemoi/training/train/train.py", line 439, in _check_dry_run
    self.mlflow_logger._parent_dry_run and not Path(self.config.system.output.checkpoints).is_dir()
                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ecm6116/.local/share/uv/python/cpython-3.12.11-linux-x86_64-gnu/lib/python3.12/pathlib.py", line 1162, in __init__
    super().__init__(*args)
  File "/home/ecm6116/.local/share/uv/python/cpython-3.12.11-linux-x86_64-gnu/lib/python3.12/pathlib.py", line 373, in __init__
    raise TypeError(
TypeError: argument should be a str or an os.PathLike object where __fspath__ returns a str, not 'CheckpointsSchema'
```

## What problem does this change solve?
Use the proper checkpoint path to check if a dry run should set.

## What issue or task does this change relate to?
<!-- link to Issue Number -->

##  Additional notes ##
Tested the behavior with and without the dry run.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
