### PR TITLE
refactor(task): homogenise ens/forecaster implementations

### DIFF
--- a/training/src/anemoi/training/train/tasks/ensforecaster.py
+++ b/training/src/anemoi/training/train/tasks/ensforecaster.py
@@ -147,12 +147,7 @@ class GraphEnsForecaster(BaseRolloutGraphModule):
         # Compute metrics if in validation mode
         metrics_next = {}
         if validation_mode:
-            metrics_next = self._compute_metrics(
-                y_pred_ens,
-                y,
-                step=step,
-                grid_shard_slice=self.grid_shard_slice
-            )
+            metrics_next = self._compute_metrics(y_pred_ens, y, step=step, grid_shard_slice=self.grid_shard_slice)
 
         return loss, metrics_next, y_pred_ens
 


### PR DESCRIPTION
## Description
<!-- What issue or task does this change relate to? -->

This PR homogenise the forecaster.py and ensforecaster.py after the #388 .

- It uses the `self._compute_loss()` instead of the loss directly.
- It keeps the same implementation as the other tasks, where the metrics are computed inside the `self.compute_loss_metrics` function.


***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
