### PR TITLE
fix(ensemble training): training is broken when ensemble is sharded across gpus

### DIFF
--- a/training/src/anemoi/training/data/dataset.py
+++ b/training/src/anemoi/training/data/dataset.py
@@ -169,7 +169,7 @@ class NativeGridDataset(IterableDataset):
 
         LOGGER.info(
             "NativeGridDataset.set_group_info(): global_rank %d, model_comm_group_id %d, "
-            "model_comm_group_rank %d, model_comm_num_groups %d, reader_group_rank %d",
+            "model_comm_group_rank %d, model_comm_num_groups %d, reader_group_rank %d, "
             "sample_comm_group_id %d, sample_comm_num_groups %d",
             global_rank,
             model_comm_group_id,


### PR DESCRIPTION
Setting num_gpus_per_ensemble > 1 breaks training because the dataset does not use the ensemble group for data partitioning. 

All GPUs in an ensemble subgroup should get the initial conditions of the same date; the ensemble subgroup is a superset of the model comm groups.