### PR TITLE
fix: Reverting change to include dependency of mlflow-export-import to unblock pypi releases

### DIFF
--- a/training/pyproject.toml
+++ b/training/pyproject.toml
@@ -79,9 +79,6 @@ optional-dependencies.docs = [
   "sphinx-argparse",
   "sphinx-rtd-theme",
 ]
-optional-dependencies.mlflowsync = [
-  "mlflow-export-import @ git+https://github.com/mlflow/mlflow-export-import.git@master",
-]
 optional-dependencies.plotting = [
   "distinctipy>=1",
 ]

--- a/training/src/anemoi/training/utils/mlflow_sync.py
+++ b/training/src/anemoi/training/utils/mlflow_sync.py
@@ -73,7 +73,7 @@ try:
 except ImportError:
     msg = (
         "The 'mlflow-export-import' package is not installed."
-        "You can install it doing pip install anemoi-training[mlflowsync]"
+        "Please install it from https://github.com/mlflow/mlflow-export-import"
     )
     raise ImportError(msg) from None
 


### PR DESCRIPTION
## Description
https://github.com/ecmwf/anemoi-core/actions/runs/20342675367 - Current pypi releases are blocked because of https://github.com/ecmwf/anemoi-core/pull/748/changes where 'mlflow-export-import' was added to the pyproject.toml as a dependency. 

Because the package is poorly maintained and don't have releases we used the git+https. According to https://til.dchan.cc/posts/11-29-2022/ and the error, this blocks the release to pypi. 
 


## What problem does this change solve?
(https://github.com/ecmwf/anemoi-core/actions/runs/20342675367)

## What issue or task does this change relate to?
<!-- link to Issue Number -->

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
