### PR TITLE
test(training): move benchmark config

### DIFF
--- a/training/docs/user-guide/benchmarking.rst
+++ b/training/docs/user-guide/benchmarking.rst
@@ -853,7 +853,7 @@ The benchmarking tests can also be run locally.
    pytest -s -vvv -v training/tests/integration/ --slow --multigpu -k "test_benchmark_training_cycle"
 
 The server location is read from a file
-"~/.config/anemoi-benchmark.yaml". The expected format is
+"~/.config/anemoi/anemoi-benchmark.yaml". The expected format is
 
 .. code:: yaml
 

--- a/training/tests/integration/test_benchmark.py
+++ b/training/tests/integration/test_benchmark.py
@@ -46,7 +46,7 @@ def test_benchmark_training_cycle(
     AnemoiProfiler(cfg).profile()
 
     # determine store from benchmark config
-    config_path = Path("~/.config/anemoi-benchmark.yaml").expanduser()
+    config_path = Path("~/.config/anemoi/anemoi-benchmark.yaml").expanduser()
     user, hostname, path = parse_benchmark_config(config_path)
     store: str = f"ssh://{user}@{hostname}:{path}"
 


### PR DESCRIPTION
## Description
moves benchmark config file from '~/.config/anemoi-benchmark.yaml' to '~/.config/**anemoi/**anemoi-benchmark.yaml'.

The benchmark config file is optionally read when running the benchmark pytests to determine the remote location to read and write benchmark results too

<!-- readthedocs-preview anemoi-training start -->
----
📚 Documentation preview 📚: https://anemoi-training--802.org.readthedocs.build/en/802/

<!-- readthedocs-preview anemoi-training end -->

<!-- readthedocs-preview anemoi-graphs start -->
----
📚 Documentation preview 📚: https://anemoi-graphs--802.org.readthedocs.build/en/802/

<!-- readthedocs-preview anemoi-graphs end -->

<!-- readthedocs-preview anemoi-models start -->
----
📚 Documentation preview 📚: https://anemoi-models--802.org.readthedocs.build/en/802/

<!-- readthedocs-preview anemoi-models end -->