### PR TITLE
fix(deps): Workaround for failing uv dependency resolution

### DIFF
--- a/training/pyproject.toml
+++ b/training/pyproject.toml
@@ -48,6 +48,7 @@ dependencies = [
   "hydra-core>=1.3",
   "matplotlib>=3.7.1",
   "mlflow-skinny>=2.11.1",
+  "numba",
   "numpy",
   "nvidia-ml-py>=13.580.82",
   "pydantic>=2.9",


### PR DESCRIPTION
## Description
Adding `numba` to the direct dependencies of anemoi-training seems to give uv the kick it needed to resolve all dependencies.

## What issue or task does this change relate to?
fixes #815 

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
