### PR TITLE
feat(training): support datasets with missing dates

### DIFF
--- a/training/src/anemoi/training/data/multidataset.py
+++ b/training/src/anemoi/training/data/multidataset.py
@@ -221,12 +221,14 @@ class MultiDataset(IterableDataset):
                 valid_date_indices_intersection = np.intersect1d(valid_date_indices_intersection, valid_date_indices)
 
             if len(valid_date_indices) == 0:
-                raise ValueError(f"No valid date indices found for dataset '{name}': \n{ds}")
+                msg = f"No valid date indices found for dataset '{name}': \n{ds}"
+                raise ValueError(msg)
 
             LOGGER.info("Dataset '%s' has %d valid indices", name, len(valid_date_indices))
 
         if len(valid_date_indices_intersection) == 0:
-            raise ValueError("No valid date indices found after intersection across all datasets.")
+            msg = "No valid date indices found after intersection across all datasets."
+            raise ValueError(msg)
 
         LOGGER.info("MultiDataset has %d valid indices after intersection.", len(valid_date_indices_intersection))
 


### PR DESCRIPTION
## Description
<!-- What issue or task does this change relate to? -->

This PR solves of the remaining issues after multiple-datasets. 

Now, any of the datasets may contain `missing_dates`. A sample date is considered valid if all datasets are valid at that date.

Additionally, we will raise an error if there are no valid dates. ([anemoi-dataset#511](https://github.com/ecmwf/anemoi-datasets/issues/511))

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
