### PR TITLE
fix: single interpolator

### DIFF
--- a/training/src/anemoi/training/train/tasks/interpolator.py
+++ b/training/src/anemoi/training/train/tasks/interpolator.py
@@ -163,6 +163,7 @@ class GraphInterpolator(BaseGraphModule):
                 y[dataset_name] = dataset_batch[
                     :,
                     self.imap[interp_step],
+                    None,
                     :,
                     :,
                     self.data_indices[dataset_name].data.output.full,


### PR DESCRIPTION
## Description
This is a fix related to an issue in the single time-interpolator set-up

## What problem does this change solve?
This solves a bug that the dimensions were wrong in y_pred in the single time interpolator

## What issue or task does this change relate to?
#880


***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
