### PR TITLE
fix(models): remove dataset dependency from input_dim_latent

### DIFF
--- a/models/src/anemoi/models/models/base.py
+++ b/models/src/anemoi/models/models/base.py
@@ -102,7 +102,7 @@ class BaseGraphModel(nn.Module):
         self._internal_output_idx = {}
         self._decoding_forcing_input_idx = {}
         self.input_dim = {}
-        self.input_dim_latent = {}
+        self.input_dim_latent = self._calculate_input_dim_latent()
         self.target_dim = {}
         self.output_dim = {}
 
@@ -121,15 +121,16 @@ class BaseGraphModel(nn.Module):
             self.num_output_channels[dataset_name] = len(dataset_indices.model.output)
 
             self.input_dim[dataset_name] = self._calculate_input_dim(dataset_name)
-            self.input_dim_latent[dataset_name] = self._calculate_input_dim_latent(dataset_name)
             self.target_dim[dataset_name] = self._calculate_target_dim(dataset_name)
             self.output_dim[dataset_name] = self._calculate_output_dim(dataset_name)
 
     def _calculate_input_dim(self, dataset_name: str) -> int:
         return self.n_step_input * self.num_input_channels[dataset_name] + self.node_attributes.attr_ndims[dataset_name]
 
-    def _calculate_input_dim_latent(self, dataset_name: str) -> int:
-        return self.node_attributes.attr_ndims[dataset_name]
+    def _calculate_input_dim_latent(self) -> int:
+        """Calculate the latent input dimension."""
+        nodes_name = self._graph_name_hidden if isinstance(self._graph_name_hidden, str) else self._graph_name_hidden[0]
+        return self.node_attributes.attr_ndims[nodes_name]
 
     def _assert_hidden_nodes_name(self, hidden_nodes_name: str) -> None:
         if isinstance(hidden_nodes_name, str):

--- a/models/src/anemoi/models/models/encoder_processor_decoder.py
+++ b/models/src/anemoi/models/models/encoder_processor_decoder.py
@@ -49,7 +49,7 @@ class AnemoiModelEncProcDec(BaseGraphModel):
                 model_config.model.encoder,
                 _recursive_=False,  # Avoids instantiation of layer_kernels here
                 in_channels_src=self.input_dim[dataset_name],
-                in_channels_dst=self.input_dim_latent[dataset_name],
+                in_channels_dst=self.input_dim_latent,
                 hidden_dim=self.num_channels,
                 edge_dim=self.encoder_graph_provider[dataset_name].edge_dim,
             )

--- a/models/src/anemoi/models/models/hierarchical.py
+++ b/models/src/anemoi/models/models/hierarchical.py
@@ -26,9 +26,6 @@ LOGGER = logging.getLogger(__name__)
 class AnemoiModelEncProcDecHierarchical(AnemoiModelEncProcDec):
     """Message passing hierarchical graph neural network."""
 
-    def _calculate_input_dim_latent(self, dataset_name: str) -> int:
-        return self.node_attributes.attr_ndims[self._graph_name_hidden[0]]
-
     def _build_networks(self, model_config):
         """Builds the model components."""
         # note that this is called by the super class init
@@ -52,7 +49,7 @@ class AnemoiModelEncProcDecHierarchical(AnemoiModelEncProcDec):
                 model_config.model.encoder,
                 _recursive_=False,  # Avoids instantiation of layer_kernels here
                 in_channels_src=self.input_dim[dataset_name],
-                in_channels_dst=self.input_dim_latent[dataset_name],
+                in_channels_dst=self.input_dim_latent,
                 hidden_dim=self.hidden_dims[self._graph_name_hidden[0]],
                 edge_dim=self.encoder_graph_provider[dataset_name].edge_dim,
             )

--- a/models/src/anemoi/models/models/hierarchical_autoencoder.py
+++ b/models/src/anemoi/models/models/hierarchical_autoencoder.py
@@ -82,9 +82,6 @@ class AnemoiModelHierarchicalAutoEncoder(AnemoiModelAutoEncoder):
         # Multi-dataset: create ModuleDict with ModuleList per dataset
         self.boundings = build_boundings(model_config, self.data_indices, self.statistics)
 
-    def _calculate_input_dim_latent(self, dataset_name: str) -> int:
-        return self.node_attributes.attr_ndims[self._graph_name_hidden[0]]
-
     def _build_networks(self, model_config):
 
         # note that this is called by the super class init
@@ -107,7 +104,7 @@ class AnemoiModelHierarchicalAutoEncoder(AnemoiModelAutoEncoder):
                 model_config.model.encoder,
                 _recursive_=False,  # Avoids instantiation of layer_kernels here
                 in_channels_src=self.input_dim[dataset_name],
-                in_channels_dst=self.input_dim_latent[dataset_name],
+                in_channels_dst=self.input_dim_latent,
                 hidden_dim=self.hidden_dims[self._graph_name_hidden[0]],
                 edge_dim=self.encoder_graph_provider[dataset_name].edge_dim,
             )


### PR DESCRIPTION
## Description
<!-- What issue or task does this change relate to? -->

This PR removes the dependency of the `input_dim_latent` on the `dataset_name`. Currently, a mismatch error could be raised if a different number of trainable parameters were specified for data and hidden nodes.


***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
