### PR TITLE
chore: Release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-    "training": "0.11.0",
-    "graphs": "0.9.1",
-    "models": "0.13.1"
+    "training": "0.12.0",
+    "graphs": "0.9.2",
+    "models": "0.14.0"
 }

--- a/graphs/CHANGELOG.md
+++ b/graphs/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Please add your functional changes to the appropriate section in the PR.
 Keep it human-readable, your future self will thank you!
 
+## [0.9.2](https://github.com/ecmwf/anemoi-core/compare/graphs-0.9.1...graphs-0.9.2) (2026-04-21)
+
+
+### Bug Fixes
+
+* **graphs:** Support passing a graph object directly to GraphExporter ([#1032](https://github.com/ecmwf/anemoi-core/issues/1032)) ([d1f2d92](https://github.com/ecmwf/anemoi-core/commit/d1f2d92861ff049e601dcf25bfe977b1c4f4073c))
+
+
+### Documentation
+
+* **graphs:** Add refinement level 10 ([#1039](https://github.com/ecmwf/anemoi-core/issues/1039)) ([ee1d68b](https://github.com/ecmwf/anemoi-core/commit/ee1d68bec99a108cdea17b2669639ffe54d93a75))
+
 ## [0.9.1](https://github.com/ecmwf/anemoi-core/compare/graphs-0.9.0...graphs-0.9.1) (2026-03-26)
 
 

--- a/models/CHANGELOG.md
+++ b/models/CHANGELOG.md
@@ -8,6 +8,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Please add your functional changes to the appropriate section in the PR.
 Keep it human-readable, your future self will thank you!
 
+## [0.14.0](https://github.com/ecmwf/anemoi-core/compare/models-0.13.1...models-0.14.0) (2026-04-21)
+
+
+### ⚠ BREAKING CHANGES
+
+* **training:** decouple training method & task ([#896](https://github.com/ecmwf/anemoi-core/issues/896))
+
+### Features
+
+* **models:** Point-wise forward/backward mappers ([#990](https://github.com/ecmwf/anemoi-core/issues/990)) ([8f29f92](https://github.com/ecmwf/anemoi-core/commit/8f29f9294739072ac4fa7fdfc9b76864b5a60874))
+* **models:** Remap supports keyword arguments + additional remaps: atanh, asinh, power, affine, displace_boundary_atoms ([#973](https://github.com/ecmwf/anemoi-core/issues/973)) ([c44122d](https://github.com/ecmwf/anemoi-core/commit/c44122d425b9b0a44a5d59184c943835dc507bc3))
+* **training:** Decouple training method & task ([#896](https://github.com/ecmwf/anemoi-core/issues/896)) ([08f6536](https://github.com/ecmwf/anemoi-core/commit/08f6536658c41d9f4e257e6fe65b656696b57150))
+
+
+### Bug Fixes
+
+* Models_conditioning ([#1002](https://github.com/ecmwf/anemoi-core/issues/1002)) ([700e1b9](https://github.com/ecmwf/anemoi-core/commit/700e1b9af9f5ef3781c9cb6da54dbbb593f6524c))
+* **models:** Add clip_negative parameter to inverse_power_transform ([#1031](https://github.com/ecmwf/anemoi-core/issues/1031)) ([1d770be](https://github.com/ecmwf/anemoi-core/commit/1d770beee6245d9048e4db0d3581af8066beb0b4))
+* **models:** Kwargs forwarding for mapper/processor checkpoint wiring ([#1018](https://github.com/ecmwf/anemoi-core/issues/1018)) ([79d636e](https://github.com/ecmwf/anemoi-core/commit/79d636eac73cc156d835c1087dd190f72174e8b2))
+* **models:** Noise schedulers ([#1021](https://github.com/ecmwf/anemoi-core/issues/1021)) ([7dbd5c2](https://github.com/ecmwf/anemoi-core/commit/7dbd5c24fe25bfad538283766f0429e5cff63f77))
+
 ## [0.13.1](https://github.com/ecmwf/anemoi-core/compare/models-0.13.0...models-0.13.1) (2026-03-26)
 
 

--- a/training/CHANGELOG.md
+++ b/training/CHANGELOG.md
@@ -8,6 +8,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Please add your functional changes to the appropriate section in the PR.
 Keep it human-readable, your future self will thank you!
 
+## [0.12.0](https://github.com/ecmwf/anemoi-core/compare/training-0.11.0...training-0.12.0) (2026-04-21)
+
+
+### ⚠ BREAKING CHANGES
+
+* **training:** decouple training method & task ([#896](https://github.com/ecmwf/anemoi-core/issues/896))
+* **training:** make LR scheduler configurable through Hydra and clean up optimization config ([#986](https://github.com/ecmwf/anemoi-core/issues/986)) fx
+
+### Features
+
+* Deprecate LongRolloutPlots ([#1020](https://github.com/ecmwf/anemoi-core/issues/1020)) ([42af828](https://github.com/ecmwf/anemoi-core/commit/42af8286da370b2dbefb9e1e12dc71b30288a558))
+* Make blas backend configurable ([#1042](https://github.com/ecmwf/anemoi-core/issues/1042)) ([7a19bd8](https://github.com/ecmwf/anemoi-core/commit/7a19bd8ebd7ad0427af2afe50057e5b97a7c1008))
+* **models:** Point-wise forward/backward mappers ([#990](https://github.com/ecmwf/anemoi-core/issues/990)) ([8f29f92](https://github.com/ecmwf/anemoi-core/commit/8f29f9294739072ac4fa7fdfc9b76864b5a60874))
+* **training:** Decouple training method & task ([#896](https://github.com/ecmwf/anemoi-core/issues/896)) ([08f6536](https://github.com/ecmwf/anemoi-core/commit/08f6536658c41d9f4e257e6fe65b656696b57150))
+* **training:** Make LR scheduler configurable through Hydra and clean up optimization config ([#986](https://github.com/ecmwf/anemoi-core/issues/986)) fx ([acf58b8](https://github.com/ecmwf/anemoi-core/commit/acf58b8af4b2adaae0c3328b1c255d7687003a8f))
+
+
+### Bug Fixes
+
+* Allow control of multiprocessing context in the DataLoader ([#1000](https://github.com/ecmwf/anemoi-core/issues/1000)) ([70da85d](https://github.com/ecmwf/anemoi-core/commit/70da85ddf777460210b423542745f1718c186072))
+* Don't crash if config.dataloader.multiprocessing is not set ([#1024](https://github.com/ecmwf/anemoi-core/issues/1024)) ([a1f769d](https://github.com/ecmwf/anemoi-core/commit/a1f769d393c583da74694ab826a925e0e43b253c))
+
+
+### Documentation
+
+* **training:** Update optimizer and scheduler documentation ([#1040](https://github.com/ecmwf/anemoi-core/issues/1040)) ([98b14a3](https://github.com/ecmwf/anemoi-core/commit/98b14a31daaff363edc6bea04e375e476f320cc6)), closes [#1038](https://github.com/ecmwf/anemoi-core/issues/1038)
+
 ## [0.11.0](https://github.com/ecmwf/anemoi-core/compare/training-0.10.0...training-0.11.0) (2026-03-26)
 
 


### PR DESCRIPTION
:robot: Automated Release PR

This PR was created by `release-please` to prepare the next release. Once merged:

1. A new version tag will be created
2. A GitHub release will be published
3. The changelog will be updated

Changes to be included in the next release:
---


<details><summary>training: 0.12.0</summary>

## [0.12.0](https://github.com/ecmwf/anemoi-core/compare/training-0.11.0...training-0.12.0) (2026-04-21)


### ⚠ BREAKING CHANGES

* **training:** decouple training method & task ([#896](https://github.com/ecmwf/anemoi-core/issues/896))
* **training:** make LR scheduler configurable through Hydra and clean up optimization config ([#986](https://github.com/ecmwf/anemoi-core/issues/986)) fx

### Features

* Deprecate LongRolloutPlots ([#1020](https://github.com/ecmwf/anemoi-core/issues/1020)) ([42af828](https://github.com/ecmwf/anemoi-core/commit/42af8286da370b2dbefb9e1e12dc71b30288a558))
* Make blas backend configurable ([#1042](https://github.com/ecmwf/anemoi-core/issues/1042)) ([7a19bd8](https://github.com/ecmwf/anemoi-core/commit/7a19bd8ebd7ad0427af2afe50057e5b97a7c1008))
* **models:** Point-wise forward/backward mappers ([#990](https://github.com/ecmwf/anemoi-core/issues/990)) ([8f29f92](https://github.com/ecmwf/anemoi-core/commit/8f29f9294739072ac4fa7fdfc9b76864b5a60874))
* **training:** Decouple training method & task ([#896](https://github.com/ecmwf/anemoi-core/issues/896)) ([08f6536](https://github.com/ecmwf/anemoi-core/commit/08f6536658c41d9f4e257e6fe65b656696b57150))
* **training:** Make LR scheduler configurable through Hydra and clean up optimization config ([#986](https://github.com/ecmwf/anemoi-core/issues/986)) fx ([acf58b8](https://github.com/ecmwf/anemoi-core/commit/acf58b8af4b2adaae0c3328b1c255d7687003a8f))


### Bug Fixes

* Allow control of multiprocessing context in the DataLoader ([#1000](https://github.com/ecmwf/anemoi-core/issues/1000)) ([70da85d](https://github.com/ecmwf/anemoi-core/commit/70da85ddf777460210b423542745f1718c186072))
* Don't crash if config.dataloader.multiprocessing is not set ([#1024](https://github.com/ecmwf/anemoi-core/issues/1024)) ([a1f769d](https://github.com/ecmwf/anemoi-core/commit/a1f769d393c583da74694ab826a925e0e43b253c))


### Documentation

* **training:** Update optimizer and scheduler documentation ([#1040](https://github.com/ecmwf/anemoi-core/issues/1040)) ([98b14a3](https://github.com/ecmwf/anemoi-core/commit/98b14a31daaff363edc6bea04e375e476f320cc6)), closes [#1038](https://github.com/ecmwf/anemoi-core/issues/1038)
</details>

<details><summary>graphs: 0.9.2</summary>

## [0.9.2](https://github.com/ecmwf/anemoi-core/compare/graphs-0.9.1...graphs-0.9.2) (2026-04-21)


### Bug Fixes

* **graphs:** Support passing a graph object directly to GraphExporter ([#1032](https://github.com/ecmwf/anemoi-core/issues/1032)) ([d1f2d92](https://github.com/ecmwf/anemoi-core/commit/d1f2d92861ff049e601dcf25bfe977b1c4f4073c))


### Documentation

* **graphs:** Add refinement level 10 ([#1039](https://github.com/ecmwf/anemoi-core/issues/1039)) ([ee1d68b](https://github.com/ecmwf/anemoi-core/commit/ee1d68bec99a108cdea17b2669639ffe54d93a75))
</details>

<details><summary>models: 0.14.0</summary>

## [0.14.0](https://github.com/ecmwf/anemoi-core/compare/models-0.13.1...models-0.14.0) (2026-04-21)


### ⚠ BREAKING CHANGES

* **training:** decouple training method & task ([#896](https://github.com/ecmwf/anemoi-core/issues/896))

### Features

* **models:** Point-wise forward/backward mappers ([#990](https://github.com/ecmwf/anemoi-core/issues/990)) ([8f29f92](https://github.com/ecmwf/anemoi-core/commit/8f29f9294739072ac4fa7fdfc9b76864b5a60874))
* **models:** Remap supports keyword arguments + additional remaps: atanh, asinh, power, affine, displace_boundary_atoms ([#973](https://github.com/ecmwf/anemoi-core/issues/973)) ([c44122d](https://github.com/ecmwf/anemoi-core/commit/c44122d425b9b0a44a5d59184c943835dc507bc3))
* **training:** Decouple training method & task ([#896](https://github.com/ecmwf/anemoi-core/issues/896)) ([08f6536](https://github.com/ecmwf/anemoi-core/commit/08f6536658c41d9f4e257e6fe65b656696b57150))


### Bug Fixes

* Models_conditioning ([#1002](https://github.com/ecmwf/anemoi-core/issues/1002)) ([700e1b9](https://github.com/ecmwf/anemoi-core/commit/700e1b9af9f5ef3781c9cb6da54dbbb593f6524c))
* **models:** Add clip_negative parameter to inverse_power_transform ([#1031](https://github.com/ecmwf/anemoi-core/issues/1031)) ([1d770be](https://github.com/ecmwf/anemoi-core/commit/1d770beee6245d9048e4db0d3581af8066beb0b4))
* **models:** Kwargs forwarding for mapper/processor checkpoint wiring ([#1018](https://github.com/ecmwf/anemoi-core/issues/1018)) ([79d636e](https://github.com/ecmwf/anemoi-core/commit/79d636eac73cc156d835c1087dd190f72174e8b2))
* **models:** Noise schedulers ([#1021](https://github.com/ecmwf/anemoi-core/issues/1021)) ([7dbd5c2](https://github.com/ecmwf/anemoi-core/commit/7dbd5c24fe25bfad538283766f0429e5cff63f77))
</details>

---
> [!IMPORTANT]
> Please do not change the PR title, manifest file, or any other automatically generated content in this PR unless you understand the implications. Changes here can break the release process.
> 
> :warning: Merging this PR will:
> - Create a new release
> - Trigger deployment pipelines
> - Update package versions

 **Before merging:**
 - Ensure all tests pass
 - Review the changelog carefully
 - Get required approvals

 [Release-please documentation](https://github.com/googleapis/release-please)