### PR TITLE
fix: update weight averaging config to not have duplicated commented out code. 

### DIFF
--- a/training/src/anemoi/training/config/training/autoencoder.yaml
+++ b/training/src/anemoi/training/config/training/autoencoder.yaml
@@ -2,6 +2,7 @@
 defaults:
   - scalers: global
   - optimization: default
+  - weight_averaging: null
 
 # resume or fork a training from a checkpoint last.ckpt or specified in system.input.warm_start
 run_id: null
@@ -40,15 +41,6 @@ num_sanity_val_steps: 6
 gradient_clip:
   val: 32.
   algorithm: value
-
-# weight averaging only supported in Lightning 2.6+
-weight_averaging: null
-# For EMA:
-#  _target_: pytorch_lightning.callbacks.EMAWeightAveraging
-#  decay: 0.999
-# For SWA:
-#  _target_: pytorch_lightning.callbacks.StochasticWeightAveraging
-#  swa_lrs: 1.e-4
 
 # =====================================================================
 # Optimizer configuration

--- a/training/src/anemoi/training/config/training/default.yaml
+++ b/training/src/anemoi/training/config/training/default.yaml
@@ -2,6 +2,7 @@
 defaults:
   - scalers: global
   - optimization: default
+  - weight_averaging: null
 
 # resume or fork a training from a checkpoint last.ckpt or specified in system.input.warm_start
 run_id: null
@@ -40,16 +41,6 @@ num_sanity_val_steps: 6
 gradient_clip:
   val: 32.
   algorithm: value
-
-# weight averaging only supported in Lightning 2.6+
-weight_averaging: null
-# For EMA:
-#  _target_: pytorch_lightning.callbacks.EMAWeightAveraging
-#  decay: 0.999
-# For SWA:
-#  _target_: pytorch_lightning.callbacks.StochasticWeightAveraging
-#  swa_lrs: 1.e-4
-
 
 # select model
 model_task: anemoi.training.train.tasks.GraphForecaster

--- a/training/src/anemoi/training/config/training/diffusion.yaml
+++ b/training/src/anemoi/training/config/training/diffusion.yaml
@@ -2,6 +2,7 @@
 defaults:
   - scalers: global
   - optimization: default
+  - weight_averaging: null
 
 # resume or fork a training from a checkpoint last.ckpt or specified in system.input.warm_start
 run_id: null
@@ -38,15 +39,6 @@ num_sanity_val_steps: 6
 gradient_clip:
   val: 1.
   algorithm: norm
-
-# weight averaging only supported in Lightning 2.6+
-weight_averaging: null
-# For EMA:
-#  _target_: pytorch_lightning.callbacks.EMAWeightAveraging
-#  decay: 0.999
-# For SWA:
-#  _target_: pytorch_lightning.callbacks.StochasticWeightAveraging
-#  swa_lrs: 1.e-4
 
 optimization:
   optimizer:

--- a/training/src/anemoi/training/config/training/ensemble.yaml
+++ b/training/src/anemoi/training/config/training/ensemble.yaml
@@ -2,6 +2,7 @@
 defaults:
   - scalers: global
   - optimization: default
+  - weight_averaging: null
 
 # resume or fork a training from a checkpoint last.ckpt or specified in system.input.warm_start
 run_id: null
@@ -38,16 +39,6 @@ num_sanity_val_steps: 6
 gradient_clip:
   val: 32.
   algorithm: value
-
-# weight averaging only supported in Lightning 2.6+
-weight_averaging: null
-# For EMA:
-#  _target_: pytorch_lightning.callbacks.EMAWeightAveraging
-#  decay: 0.999
-# For SWA:
-#  _target_: pytorch_lightning.callbacks.StochasticWeightAveraging
-#  swa_lrs: 1.e-4
-
 
 # select model
 model_task: anemoi.training.train.tasks.GraphEnsForecaster

--- a/training/src/anemoi/training/config/training/lam.yaml
+++ b/training/src/anemoi/training/config/training/lam.yaml
@@ -2,6 +2,7 @@
 defaults:
   - scalers: lam
   - optimization: default
+  - weight_averaging: null
 
 # resume or fork a training from a checkpoint last.ckpt or specified in system.input.warm_start
 run_id: null
@@ -37,15 +38,6 @@ num_sanity_val_steps: 6
 gradient_clip:
   val: 32.
   algorithm: value
-
-# weight averaging only supported in Lightning 2.6+
-weight_averaging: null
-# For EMA:
-#  _target_: pytorch_lightning.callbacks.EMAWeightAveraging
-#  decay: 0.999
-# For SWA:
-#  _target_: pytorch_lightning.callbacks.StochasticWeightAveraging
-#  swa_lrs: 1.e-4
 
 # Optimizer settings
 

--- a/training/src/anemoi/training/config/training/multi.yaml
+++ b/training/src/anemoi/training/config/training/multi.yaml
@@ -2,6 +2,7 @@
 defaults:
   - scalers: multi
   - optimization: default
+  - weight_averaging: null
 
 # resume or fork a training from a checkpoint last.ckpt or specified in hardware.files.warm_start
 run_id: null
@@ -38,15 +39,6 @@ num_sanity_val_steps: 6
 gradient_clip:
   val: 32.
   algorithm: value
-
-# weight averaging only supported in Lightning 2.6+
-weight_averaging: null
-# For EMA:
-#  _target_: pytorch_lightning.callbacks.EMAWeightAveraging
-#  decay: 0.999
-# For SWA:
-#  _target_: pytorch_lightning.callbacks.StochasticWeightAveraging
-#  swa_lrs: 1.e-4
 
 # =====================================================================
 # Optimizer configuration

--- a/training/src/anemoi/training/config/training/stretched.yaml
+++ b/training/src/anemoi/training/config/training/stretched.yaml
@@ -2,6 +2,7 @@
 defaults:
   - scalers: stretched
   - optimization: default
+  - weight_averaging: null
 
 # resume or fork a training from a checkpoint last.ckpt or specified in system.input.warm_start
 run_id: null
@@ -39,15 +40,6 @@ num_sanity_val_steps: 6
 gradient_clip:
   val: 32.
   algorithm: value
-
-# weight averaging only supported in Lightning 2.6+
-weight_averaging: null
-# For EMA:
-#  _target_: pytorch_lightning.callbacks.EMAWeightAveraging
-#  decay: 0.999
-# For SWA:
-#  _target_: pytorch_lightning.callbacks.StochasticWeightAveraging
-#  swa_lrs: 1.e-4
 
 # Optimizer settings
 

--- a/training/src/anemoi/training/config/training/weight_averaging/ema.yaml
+++ b/training/src/anemoi/training/config/training/weight_averaging/ema.yaml
@@ -1,2 +1,3 @@
 _target_: pytorch_lightning.callbacks.EMAWeightAveraging
 decay: 0.999
+update_starting_at_step: ${training.lr.warmup}

--- a/training/src/anemoi/training/config/training/weight_averaging/ema.yaml
+++ b/training/src/anemoi/training/config/training/weight_averaging/ema.yaml
@@ -1,0 +1,2 @@
+_target_: pytorch_lightning.callbacks.EMAWeightAveraging
+decay: 0.999

--- a/training/src/anemoi/training/config/training/weight_averaging/swa.yaml
+++ b/training/src/anemoi/training/config/training/weight_averaging/swa.yaml
@@ -1,0 +1,2 @@
+_target_: pytorch_lightning.callbacks.StochasticWeightAveraging
+swa_lrs: 1.e-4


### PR DESCRIPTION
Hi Jacob, here is what I meant in the ATS :) 

 - Add training/weight_averaging/ema.yaml and swa.yaml
  - Add - weight_averaging: null to defaults in all training configs                             
  - Remove inline weight_averaging: null and commented-out example configs                      
  - Can now be selected via CLI:
  training/weight_averaging=ema or                   
  training/weight_averaging=swa                

