### PR TITLE
chore: Release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-    "training": "0.12.0",
-    "graphs": "0.9.2",
-    "models": "0.14.0"
+    "training": "0.12.1",
+    "graphs": "0.9.3",
+    "models": "0.14.1"
 }

--- a/graphs/CHANGELOG.md
+++ b/graphs/CHANGELOG.md
@@ -8,6 +8,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Please add your functional changes to the appropriate section in the PR.
 Keep it human-readable, your future self will thank you!
 
+## [0.9.3](https://github.com/ecmwf/anemoi-core/compare/graphs-0.9.2...graphs-0.9.3) (2026-04-23)
+
+
+### Features
+
+* **graphs:** Option to exclude self edges in KNN graphs ([#1065](https://github.com/ecmwf/anemoi-core/issues/1065)) ([04c881d](https://github.com/ecmwf/anemoi-core/commit/04c881dd293a0d90d05079ea1ce13a7b4ce602f5))
+
+
+### Bug Fixes
+
+* **graphs,aicon:** Icon mesh vertex mask ([#975](https://github.com/ecmwf/anemoi-core/issues/975)) ([e19b259](https://github.com/ecmwf/anemoi-core/commit/e19b25995535e451df97439f8f349dafa8d9e9d4))
+
+
+### Documentation
+
+* **graphs:** Correct a diagram on how multiscale edges work ([#1051](https://github.com/ecmwf/anemoi-core/issues/1051)) ([48c180c](https://github.com/ecmwf/anemoi-core/commit/48c180ce455708941a86a4a4273754c3f6f93102))
+
 ## [0.9.2](https://github.com/ecmwf/anemoi-core/compare/graphs-0.9.1...graphs-0.9.2) (2026-04-21)
 
 

--- a/models/CHANGELOG.md
+++ b/models/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Please add your functional changes to the appropriate section in the PR.
 Keep it human-readable, your future self will thank you!
 
+## [0.14.1](https://github.com/ecmwf/anemoi-core/compare/models-0.14.0...models-0.14.1) (2026-04-23)
+
+
+### Bug Fixes
+
+* No learnable parameters for non-model nodes ([#1050](https://github.com/ecmwf/anemoi-core/issues/1050)) ([9c4be94](https://github.com/ecmwf/anemoi-core/commit/9c4be94263e657487597952341a0cda645eb0a36))
+
 ## [0.14.0](https://github.com/ecmwf/anemoi-core/compare/models-0.13.1...models-0.14.0) (2026-04-21)
 
 

--- a/training/CHANGELOG.md
+++ b/training/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Please add your functional changes to the appropriate section in the PR.
 Keep it human-readable, your future self will thank you!
 
+## [0.12.1](https://github.com/ecmwf/anemoi-core/compare/training-0.12.0...training-0.12.1) (2026-04-23)
+
+
+### Bug Fixes
+
+* Apply spatial mask to coordinates when using focus_area with boolean mask ([#1062](https://github.com/ecmwf/anemoi-core/issues/1062)) ([4ccf5a7](https://github.com/ecmwf/anemoi-core/commit/4ccf5a7cf81339e00b51830538ba05a0f66938d6))
+* Fix anemoi TimeLimit callback ([#1064](https://github.com/ecmwf/anemoi-core/issues/1064)) ([09fd87f](https://github.com/ecmwf/anemoi-core/commit/09fd87f9be6bce73b2e160d480fcf0316dcfae47))
+* Improve handling of axis limits buffer for plotting callbacks ([#1063](https://github.com/ecmwf/anemoi-core/issues/1063)) ([1f052ec](https://github.com/ecmwf/anemoi-core/commit/1f052ecb98db3e3f4e4d37c4bb7ef56ecfb01394))
+
 ## [0.12.0](https://github.com/ecmwf/anemoi-core/compare/training-0.11.0...training-0.12.0) (2026-04-21)
 
 


### PR DESCRIPTION
:robot: Automated Release PR

This PR was created by `release-please` to prepare the next release. Once merged:

1. A new version tag will be created
2. A GitHub release will be published
3. The changelog will be updated

Changes to be included in the next release:
---


<details><summary>training: 0.12.1</summary>

## [0.12.1](https://github.com/ecmwf/anemoi-core/compare/training-0.12.0...training-0.12.1) (2026-04-23)


### Bug Fixes

* Apply spatial mask to coordinates when using focus_area with boolean mask ([#1062](https://github.com/ecmwf/anemoi-core/issues/1062)) ([4ccf5a7](https://github.com/ecmwf/anemoi-core/commit/4ccf5a7cf81339e00b51830538ba05a0f66938d6))
* Fix anemoi TimeLimit callback ([#1064](https://github.com/ecmwf/anemoi-core/issues/1064)) ([09fd87f](https://github.com/ecmwf/anemoi-core/commit/09fd87f9be6bce73b2e160d480fcf0316dcfae47))
* Improve handling of axis limits buffer for plotting callbacks ([#1063](https://github.com/ecmwf/anemoi-core/issues/1063)) ([1f052ec](https://github.com/ecmwf/anemoi-core/commit/1f052ecb98db3e3f4e4d37c4bb7ef56ecfb01394))
</details>

<details><summary>graphs: 0.9.3</summary>

## [0.9.3](https://github.com/ecmwf/anemoi-core/compare/graphs-0.9.2...graphs-0.9.3) (2026-04-23)


### Features

* **graphs:** Option to exclude self edges in KNN graphs ([#1065](https://github.com/ecmwf/anemoi-core/issues/1065)) ([04c881d](https://github.com/ecmwf/anemoi-core/commit/04c881dd293a0d90d05079ea1ce13a7b4ce602f5))


### Bug Fixes

* **graphs,aicon:** Icon mesh vertex mask ([#975](https://github.com/ecmwf/anemoi-core/issues/975)) ([e19b259](https://github.com/ecmwf/anemoi-core/commit/e19b25995535e451df97439f8f349dafa8d9e9d4))


### Documentation

* **graphs:** Correct a diagram on how multiscale edges work ([#1051](https://github.com/ecmwf/anemoi-core/issues/1051)) ([48c180c](https://github.com/ecmwf/anemoi-core/commit/48c180ce455708941a86a4a4273754c3f6f93102))
</details>

<details><summary>models: 0.14.1</summary>

## [0.14.1](https://github.com/ecmwf/anemoi-core/compare/models-0.14.0...models-0.14.1) (2026-04-23)


### Bug Fixes

* No learnable parameters for non-model nodes ([#1050](https://github.com/ecmwf/anemoi-core/issues/1050)) ([9c4be94](https://github.com/ecmwf/anemoi-core/commit/9c4be94263e657487597952341a0cda645eb0a36))
</details>

---
> [!IMPORTANT]
> Please do not change the PR title, manifest file, or any other automatically generated content in this PR unless you understand the implications. Changes here can break the release process.
> 
> :warning: Merging this PR will:
> - Create a new release
> - Trigger deployment pipelines
> - Update package versions

 **Before merging:**
 - Ensure all tests pass
 - Review the changelog carefully
 - Get required approvals

 [Release-please documentation](https://github.com/googleapis/release-please)