### PR TITLE
test: add integration test for temporal downscaler ensemble

### DIFF
--- a/training/src/anemoi/training/config/temporal_downscaler_ensemble.yaml
+++ b/training/src/anemoi/training/config/temporal_downscaler_ensemble.yaml
@@ -1,0 +1,49 @@
+defaults:
+- data: zarr
+- dataloader: native_grid
+- diagnostics: evaluation_ens
+- system: example
+- graph: encoder_decoder_only
+- model: transformer_ens
+- task: temporal_downscaler
+- training: ensemble
+- _self_
+
+config_validation: True
+
+### This file is for local experimentation.
+##  When you commit your changes, assign the new features and keywords
+##  to the correct defaults.
+# For example to change from default GPU count:
+# system:
+#   hardware:
+#     num_gpus_per_node: 1
+
+diagnostics:
+  plot:
+    callbacks: []
+  callbacks: []
+
+system:
+  input:
+    graph: graph_anemoi_new_${data.resolution}.pt
+    dataset: aifs-ea-an-oper-0001-mars-${data.resolution}-1979-2022-6h-v6
+    truncation: ${data.resolution}-o32-linear.mat.npz
+    truncation_inv: o32-${data.resolution}-linear.mat.npz
+    loss_matrices_path: null
+  hardware:
+    accelerator: auto
+    num_gpus_per_ensemble: 1
+    num_gpus_per_node: 1
+    num_nodes: 1
+    num_gpus_per_model: 1
+
+model:
+  num_channels: 128
+
+data:
+  resolution: o96
+
+training:
+  ensemble_size_per_device: 2
+  max_epochs: 1

--- a/training/src/anemoi/training/config/temporal_downscaler_ensemble.yaml
+++ b/training/src/anemoi/training/config/temporal_downscaler_ensemble.yaml
@@ -3,8 +3,8 @@ defaults:
 - dataloader: native_grid
 - diagnostics: evaluation_ens
 - system: example
-- graph: encoder_decoder_only
-- model: transformer_ens
+- graph: multi_scale
+- model: graphtransformer_ens
 - task: temporal_downscaler
 - training: ensemble
 - _self_
@@ -26,10 +26,8 @@ diagnostics:
 
 system:
   input:
-    graph: graph_anemoi_new_${data.resolution}.pt
-    dataset: aifs-ea-an-oper-0001-mars-${data.resolution}-1979-2022-6h-v6
-    truncation: ${data.resolution}-o32-linear.mat.npz
-    truncation_inv: o32-${data.resolution}-linear.mat.npz
+    graph: graph_anemoi_new.pt
+    dataset: aifs-ea-an-oper-0001-mars-o96-1979-2024-1h-v3-with-era51
     loss_matrices_path: null
   hardware:
     accelerator: auto
@@ -41,9 +39,5 @@ system:
 model:
   num_channels: 128
 
-data:
-  resolution: o96
-
 training:
   ensemble_size_per_device: 2
-  max_epochs: 1

--- a/training/tests/integration/config/test_temporal_downscaler_ensemble.yaml
+++ b/training/tests/integration/config/test_temporal_downscaler_ensemble.yaml
@@ -1,0 +1,75 @@
+system:
+  input:
+    dataset: anemoi-integration-tests/training/datasets/aifs-ea-an-oper-0001-mars-o96-2017-2017-6h-v8-testing.zarr
+    loss_matrices_path: "anemoi-integration-tests/training/assets/"
+
+data:
+  frequency: 6h
+
+task:
+  _target_: anemoi.training.tasks.TemporalDownscaler
+  input_timestep: 12h
+  output_timestep: 6h
+  output_right_boundary: True
+
+training:
+  training_loss:
+    datasets:
+      data:
+        loss_matrices: [ "o96_smoothing_o96.npz", null]
+        weights: [1.0, 1.0]
+  validation_metrics:
+    datasets:
+      data:
+        multiscale:
+          loss_matrices: ["o96_smoothing_o96.npz", null]
+          weights: [1.0, 1.0]
+
+
+dataloader:
+  training:
+    datasets:
+      data:
+        end: 2017-01-08 12:00:00
+  validation:
+    datasets:
+      data:
+        start: 2017-01-08 18:00:00
+
+
+diagnostics:
+  plot:
+    parameters: [tp]
+    callbacks:
+      # Add plot callbacks here.
+      - _target_: anemoi.training.diagnostics.callbacks.plot_ens.PlotEnsSample
+        dataset_names: ["data"]
+        sample_idx: ${diagnostics.plot.sample_idx}
+        per_sample : 2
+        parameters: ${diagnostics.plot.parameters}
+        every_n_batches: ${diagnostics.plot.frequency.batch}
+        #Defining the accumulation levels for precipitation related fields and the colormap
+        accumulation_levels_plot: [0, 0.05, 0.1, 0.25, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 7, 100] # in mm
+        members: null  # None for all members, list for specific members
+
+      - _target_: anemoi.training.diagnostics.callbacks.plot_ens.PlotLoss
+        dataset_names: ["data"]
+        parameter_groups:
+          moisture: [tp, cp, tcw]
+          sfc_wind: [10u, 10v]
+        every_n_batches: ${diagnostics.plot.frequency.batch}
+        #! DEACTIVATING UNTIL PYSHTOOLS FIX FOR 3.13
+      # - _target_: anemoi.training.diagnostics.callbacks.plot_ens.PlotSpectrum
+      #   dataset_names: ["data"]
+      #   sample_idx: ${diagnostics.plot.sample_idx}
+      #   parameters: ${diagnostics.plot.parameters}
+      #   every_n_batches: ${diagnostics.plot.frequency.batch}
+      - _target_: anemoi.training.diagnostics.callbacks.plot_ens.PlotHistogram
+        dataset_names: ["data"]
+        sample_idx: ${diagnostics.plot.sample_idx}
+        parameters: ${diagnostics.plot.parameters}
+        every_n_batches: ${diagnostics.plot.frequency.batch}
+        precip_and_related_fields: ["tp", "cp"] # Optional: specify precip fields for special histogram treatment
+      - _target_: anemoi.training.diagnostics.callbacks.plot_ens.GraphTrainableFeaturesPlot
+        dataset_names: ["data"]
+        every_n_epochs: ${diagnostics.plot.frequency.epoch}

--- a/training/tests/integration/config/test_temporal_downscaler_ensemble.yaml
+++ b/training/tests/integration/config/test_temporal_downscaler_ensemble.yaml
@@ -12,19 +12,6 @@ task:
   output_timestep: 6h
   output_right_boundary: True
 
-training:
-  training_loss:
-    datasets:
-      data:
-        loss_matrices: [ "o96_smoothing_o96.npz", null]
-        weights: [1.0, 1.0]
-  validation_metrics:
-    datasets:
-      data:
-        multiscale:
-          loss_matrices: ["o96_smoothing_o96.npz", null]
-          weights: [1.0, 1.0]
-
 
 dataloader:
   training:

--- a/training/tests/integration/conftest.py
+++ b/training/tests/integration/conftest.py
@@ -618,14 +618,13 @@ def temporal_downscaler_ensemble_config(
     get_tmp_path: GetTmpPath,
     get_test_data: GetTestData,
 ) -> tuple[DictConfig, str]:
-    overrides = ["model=graphtransformer_ens", "graph=multi_scale"]
 
     with initialize(
         version_base=None,
         config_path="../../src/anemoi/training/config",
         job_name="test_temporal_downscaler_ensemble",
     ):
-        template = compose(config_name="temporal_downscaler_ensemble", overrides=overrides)
+        template = compose(config_name="temporal_downscaler_ensemble")
 
     use_case_modifications = OmegaConf.load(
         Path.cwd() / "training/tests/integration/config/test_temporal_downscaler_ensemble.yaml",

--- a/training/tests/integration/conftest.py
+++ b/training/tests/integration/conftest.py
@@ -610,3 +610,35 @@ def mlflow_dry_run_config(gnn_config: tuple[DictConfig, str], mlflow_server: str
     cfg["diagnostics"]["log"]["mlflow"]["tracking_uri"] = mlflow_server
     cfg["diagnostics"]["log"]["mlflow"]["offline"] = False
     return cfg, url
+
+
+@pytest.fixture
+def temporal_downscaler_ensemble_config(
+    testing_modifications_with_temp_dir: DictConfig,
+    get_tmp_path: GetTmpPath,
+    get_test_data: GetTestData,
+) -> tuple[DictConfig, str]:
+    overrides = ["model=graphtransformer_ens", "graph=multi_scale"]
+
+    with initialize(
+        version_base=None,
+        config_path="../../src/anemoi/training/config",
+        job_name="test_temporal_downscaler_ensemble",
+    ):
+        template = compose(config_name="temporal_downscaler_ensemble", overrides=overrides)
+
+    use_case_modifications = OmegaConf.load(
+        Path.cwd() / "training/tests/integration/config/test_temporal_downscaler_ensemble.yaml",
+    )
+    assert isinstance(use_case_modifications, DictConfig)
+
+    tmp_dir_dataset, url_dataset = get_tmp_path(use_case_modifications.system.input.dataset)
+    use_case_modifications.system.input.dataset = str(tmp_dir_dataset)
+
+    cfg = OmegaConf.merge(template, testing_modifications_with_temp_dir, use_case_modifications)
+    OmegaConf.resolve(cfg)
+
+    cfg = handle_truncation_matrices(cfg, get_test_data)
+    assert isinstance(cfg, DictConfig)
+
+    return cfg, url_dataset

--- a/training/tests/integration/test_training_cycle.py
+++ b/training/tests/integration/test_training_cycle.py
@@ -393,3 +393,16 @@ def test_training_cycle_multidatasets_diffusion(
     trainer = AnemoiTrainer(cfg)
     trainer.train()
     assert_keys_exist(trainer.metadata, PARTIAL_METADATA_SCHEMA)
+
+
+@skip_if_offline
+@pytest.mark.slow
+def test_training_cycle_temporal_downscaler_ensemble(
+    temporal_downscaler_ensemble_config: tuple[DictConfig, str],
+    get_test_archive: GetTestArchive,
+) -> None:
+    cfg, url = temporal_downscaler_ensemble_config
+    get_test_archive(url)
+    trainer = AnemoiTrainer(cfg)
+    trainer.train()
+    assert_keys_exist(trainer.metadata, PARTIAL_METADATA_SCHEMA)


### PR DESCRIPTION
## Description
This PR adds a config template and an integration test for the temporal downscaler ensemble to ensure continued support of this use case. 

Once we add the custom losses for the temporal downscaler in https://github.com/ecmwf/anemoi-core/issues/1059, we'll update the template and the test.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
