### PR TITLE
fix: improve handling of axis limits buffer for plotting callbacks

### DIFF
--- a/training/src/anemoi/training/diagnostics/plots.py
+++ b/training/src/anemoi/training/diagnostics/plots.py
@@ -841,13 +841,14 @@ def single_plot(
             ax=ax,
         )
 
+    ymin, ymax, xmin, xmax = lat.min(), lat.max(), lon.min(), lon.max()
+    dy, dx = ymax - ymin, xmax - xmin
+    ybuffer, xbuffer = dy * 0.05, dx * 0.05
     if transform is not None:
-        ax.set_extent([lon.min() - 0.1, lon.max() + 0.1, lat.min() - 0.1, lat.max() + 0.1], crs=transform)
+        ax.set_extent([xmin - xbuffer, xmax + xbuffer, ymin - ybuffer, ymax + ybuffer], crs=transform)
     else:
-        xmin, xmax = max(lon.min(), -np.pi), min(lon.max(), np.pi)
-        ymin, ymax = max(lat.min(), -np.pi / 2), min(lat.max(), np.pi / 2)
-        ax.set_xlim((xmin - 0.1, xmax + 0.1))
-        ax.set_ylim((ymin - 0.1, ymax + 0.1))
+        ax.set_xlim((xmin - xbuffer, xmax + xbuffer))
+        ax.set_ylim((ymin - ybuffer, ymax + ybuffer))
 
     # Add map features (always equirectangular coastlines/borders)
     map_features.plot(ax)


### PR DESCRIPTION
Closes #930 by improving how a buffer zone is added for the plotting limits. The buffer zone is no longer fixed but computed based on the extend of the focus area itself.

This is what plots look like (they are very ugly but this is a separate issue to be addressed) for  
```yaml
focus_area:
  latlon_bbox: [45.5, 5.8, 47.9, 10.6]
```
<img width="2400" height="2700" alt="image" src="https://github.com/user-attachments/assets/7706da38-261e-4942-8e10-3ed30bcf7d48" />

---

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
