### PR TITLE
feat(graphs): Add option to disable node scaling by degree

### DIFF
--- a/graphs/src/anemoi/graphs/plotting/interactive_3d.html.jinja
+++ b/graphs/src/anemoi/graphs/plotting/interactive_3d.html.jinja
@@ -183,6 +183,13 @@ nor does it submit to any jurisdiction. #}
                     <input id="scaleFactor" type="number" min="0.5" max="3.0" step="0.1" value="1.0" />
                 </div>
             </div>
+
+            <div class="control-row">
+                <span>Scale nodes by degree</span>
+                <div class="control-right">
+                    <input id="scaleByDegree" type="checkbox" checked />
+                </div>
+            </div>
         </div>
 
         <div class="controls">
@@ -397,8 +404,9 @@ nor does it submit to any jurisdiction. #}
         let totalNodeCount = 0;
 
         const BASE_SCALE = 1.0;
+        const scaleByDegreeCheckbox = document.getElementById('scaleByDegree');
         function computeNodeScale(d) {
-            if (maxDegree === minDegree) return 1.0 * BASE_SCALE;
+            if (!scaleByDegreeCheckbox.checked || maxDegree === minDegree) return 1.0 * BASE_SCALE;
             const n = (d - minDegree) / ((maxDegree / 4) - minDegree);
             return (1 + n * 4) * BASE_SCALE;
         }
@@ -900,6 +908,8 @@ nor does it submit to any jurisdiction. #}
             baseScaleFactorRef.value = Number(e.target.value);
             updateNodeScales();
         };
+
+        scaleByDegreeCheckbox.onchange = () => { updateNodeScales(); };
 
         // Resize
         window.addEventListener('resize', () => {


### PR DESCRIPTION
# Add option to disable node scaling by degree
                                                                    
In the 3D graph visualization, nodes are scaled proportionally to
their number of incoming connections. For dense graphs this helps 
identify high-degree nodes, but it can obscure the spatial
distribution of the node set itself. For example near the poles.                              
                                                      
This PR adds a "Scale nodes by degree" checkbox (checked by       
default) to the Global Controls panel. When unchecked, all nodes
are rendered at uniform size regardless of their degree. The      
change takes effect immediately without reloading.  

Changes:                                                          
- interactive_3d.html.jinja: new checkbox in the controls panel;
computeNodeScale returns uniform scale when the checkbox is off;  
onchange listener triggers an immediate re-render.  


<img width="315" height="300" alt="image" src="https://github.com/user-attachments/assets/20488cbc-4890-4bd9-8ca8-1f9be507ec75" />

<img width="272" height="148" alt="image" src="https://github.com/user-attachments/assets/13183cbf-1772-4c2b-8502-64ca2e0fd5af" />

<img width="314" height="301" alt="image" src="https://github.com/user-attachments/assets/5604ff58-1329-41c5-bf58-1d8852cbceca" />