### PR TITLE
feat(callbacks)!: remove RolloutEvalEns

### DIFF
--- a/training/src/anemoi/training/config/diagnostics/evaluation_ens.yaml
+++ b/training/src/anemoi/training/config/diagnostics/evaluation_ens.yaml
@@ -7,7 +7,7 @@ defaults:
 # another alternative if you don't have any callbacks is to remove it from the
 # defaults list and just use
 callbacks:
-  - _target_: anemoi.training.diagnostics.callbacks.evaluation.RolloutEvalEns
+  - _target_: anemoi.training.diagnostics.callbacks.evaluation.RolloutEval
     rollout:
     - ${task.validation_rollout}
     every_n_batches: 4

--- a/training/src/anemoi/training/diagnostics/callbacks/evaluation.py
+++ b/training/src/anemoi/training/diagnostics/callbacks/evaluation.py
@@ -94,7 +94,7 @@ class RolloutEval(Callback):
         if loss_scales.numel() > 1:
             for scale in range(loss_scales.numel()):
                 pl_module.log(
-                    f"val_r{self.max_rollout}_{loss_name}",
+                    f"val_r{self.max_rollout}_{loss_name}_{scale}",
                     loss_scales[scale],
                     on_epoch=True,
                     on_step=True,
@@ -137,72 +137,6 @@ class RolloutEval(Callback):
             prec = trainer.precision
             dtype = precision_mapping.get(prec)
 
-            context = (
-                torch.autocast(device_type=next(iter(batch.values())).device.type, dtype=dtype)
-                if dtype is not None
-                else nullcontext()
-            )
-
-            with context:
-                self._eval(pl_module, batch)
-
-
-class RolloutEvalEns(RolloutEval):
-    """Evaluates the model performance over a (longer) rollout window.
-
-    Health warning: this callback runs only every ``every_n_batches`` validation batches,
-    so metrics are a sampled view of validation dates. Metrics are logged with
-    distributed synchronization.
-    """
-
-    def _eval(self, pl_module: pl.LightningModule, batch: dict[str, torch.Tensor]) -> None:
-        """Rolls out the model and calculates the validation metrics.
-
-        Parameters
-        ----------
-        pl_module : pl.LightningModule
-            Lightning module object.
-        batch: torch.Tensor
-            Batch tensor (bs, input_steps + forecast_steps, latlon, nvar).
-        """
-        loss = torch.zeros(
-            1,
-            dtype=next(iter(batch.values())).dtype,
-            device=pl_module.device,
-            requires_grad=False,
-        )
-        batch_shape = next(iter(batch.values())).shape
-        assert batch_shape[1] >= self.max_rollout * pl_module.n_step_output + pl_module.n_step_input, (
-            "Batch length not sufficient for requested validation rollout length! "
-            f"Set `task.validation_rollout` to at least {self.max_rollout}"
-        )
-
-        metrics = {}
-        # NOTE: The configured rollout must be lower than or equal to `task.validation_rollout`,
-        # because `_step(..., validation_mode=True)` uses the task setting to determine step count.
-        with torch.no_grad():
-            loss, metrics, _ = pl_module._step(
-                batch=batch,
-                validation_mode=True,
-            )
-            self._log(pl_module, loss, metrics, batch_shape[0])
-
-    def on_validation_batch_end(
-        self,
-        trainer: pl.Trainer,
-        pl_module: pl.LightningModule,
-        outputs: list,
-        batch: torch.Tensor,
-        batch_idx: int,
-    ) -> None:
-        del outputs  # outputs are not used
-        if batch_idx % self.every_n_batches == 0:
-            precision_mapping = {
-                "16-mixed": torch.float16,
-                "bf16-mixed": torch.bfloat16,
-            }
-            prec = trainer.precision
-            dtype = precision_mapping.get(prec)
             context = (
                 torch.autocast(device_type=next(iter(batch.values())).device.type, dtype=dtype)
                 if dtype is not None

--- a/training/tests/unit/diagnostics/test_callbacks.py
+++ b/training/tests/unit/diagnostics/test_callbacks.py
@@ -20,7 +20,6 @@ import yaml
 from anemoi.training.diagnostics.callbacks import _get_progress_bar_callback
 from anemoi.training.diagnostics.callbacks import get_callbacks
 from anemoi.training.diagnostics.callbacks.evaluation import RolloutEval
-from anemoi.training.diagnostics.callbacks.evaluation import RolloutEvalEns
 
 NUM_FIXED_CALLBACKS = 3  # ParentUUIDCallback, CheckVariableOrder, RegisterMigrations
 
@@ -88,40 +87,6 @@ def test_add_plotting_callback(monkeypatch):
     config.diagnostics.plot.callbacks = [{"_target_": "anemoi.training.diagnostics.callbacks.plot.PlotLoss"}]
     callbacks = get_callbacks(config)
     assert len(callbacks) == NUM_FIXED_CALLBACKS + 1
-
-
-def test_rollout_eval_ens_handles_dict_batch():
-    """Test RolloutEvalEns._eval with a dict batch via on_validation_batch_end."""
-    config = omegaconf.OmegaConf.create({})
-    callback = RolloutEvalEns(config, rollout=[1, 2], every_n_batches=1)
-
-    # Mock pl_module
-    pl_module = MagicMock()
-    pl_module.device = torch.device("cpu")
-    pl_module.n_step_input = 1
-    pl_module.n_step_output = 1
-    # _step returns aggregated (loss, metrics, y_preds) over all rollout steps
-    pl_module._step.return_value = (
-        torch.tensor(0.125),
-        {"metric1": torch.tensor(0.25)},
-        None,
-    )
-
-    trainer = MagicMock()
-    trainer.precision = "16-mixed"
-
-    # Mock batch (bs, ms, nens_per_device, latlon, nvar)
-    batch = {"data": torch.randn(2, 4, 4, 10, 5)}
-
-    with patch.object(callback, "_log") as mock_log:
-        callback.on_validation_batch_end(trainer, pl_module, outputs=[], batch=batch, batch_idx=0)
-
-        #  Check for output
-        mock_log.assert_called_once()
-        args = mock_log.call_args[0]
-        assert args[1].item() == pytest.approx(0.125)  # (0.1 + 0.15) / 2
-        assert args[2]["metric1"].item() == pytest.approx(0.25)  # Last metric value
-        assert args[3] == 2  # batch size
 
 
 def test_rollout_eval_handles_dict_batch():

--- a/training/tests/unit/diagnostics/test_callbacks.py
+++ b/training/tests/unit/diagnostics/test_callbacks.py
@@ -89,7 +89,8 @@ def test_add_plotting_callback(monkeypatch):
     assert len(callbacks) == NUM_FIXED_CALLBACKS + 1
 
 
-def test_rollout_eval_handles_dict_batch():
+@pytest.mark.parametrize("n_ensemble", [1, 3])
+def test_rollout_eval_handles_dict_batch(n_ensemble):
     """Test RolloutEval._eval with a dict batch (multi-dataset style)."""
     config = omegaconf.OmegaConf.create({})
     callback = RolloutEval(config, rollout=[1, 2], every_n_batches=1)
@@ -110,7 +111,7 @@ def test_rollout_eval_handles_dict_batch():
     trainer.precision = "16-mixed"  # no autocast
 
     # Mock batch (bs, ms, ens, latlon, nvar)
-    batch = {"data": torch.randn(2, 4, 1, 10, 5)}
+    batch = {"data": torch.randn(2, 4, n_ensemble, 10, 5)}
 
     with patch.object(callback, "_log") as mock_log:
 


### PR DESCRIPTION
## Description
This PR removes the RolloutEvalEns callback, which apart from dead code was verbatim the same as its base class RolloutEval.
If we don't want the breaking change in the configs, we could introduce an alias.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
