### PR TITLE
feat: add BaseLossWrapper as transparent loss wrapper base class

### DIFF
--- a/training/src/anemoi/training/config/training/training_loss/ensemble_combined.yaml
+++ b/training/src/anemoi/training/config/training/training_loss/ensemble_combined.yaml
@@ -16,10 +16,10 @@ datasets:
           no_autocast: True
           alpha: 0.95
       - _target_: anemoi.training.losses.aggregate.TimeAggregateLossWrapper
+        scalers: ['pressure_level', 'general_variable', 'nan_mask_weights', 'node_weights']
         time_aggregation_types: [mean, max, min, diff]
         loss_fn:
           _target_: anemoi.training.losses.kcrps.AlmostFairKernelCRPS
-          scalers: ['pressure_level', 'general_variable', 'nan_mask_weights', 'node_weights']
           ignore_nans: False
           no_autocast: True
           alpha: 0.95

--- a/training/src/anemoi/training/config/training/training_loss/single_combined.yaml
+++ b/training/src/anemoi/training/config/training/training_loss/single_combined.yaml
@@ -8,8 +8,8 @@ datasets:
         scalers: ['*']
         ignore_nans: False
       - _target_: anemoi.training.losses.aggregate.TimeAggregateLossWrapper
+        scalers: ['pressure_level', 'general_variable', 'node_weights']
         time_aggregation_types: [mean, max, min, diff]
         loss_fn:
           _target_: anemoi.training.losses.MSELoss
-          scalers: ['pressure_level', 'general_variable', 'node_weights']
           ignore_nans: False

--- a/training/src/anemoi/training/losses/aggregate.py
+++ b/training/src/anemoi/training/losses/aggregate.py
@@ -5,15 +5,17 @@ from typing import TYPE_CHECKING
 
 import torch
 
-from anemoi.training.losses.base import BaseLoss
+from anemoi.training.losses.base import BaseLossWrapper
 
 if TYPE_CHECKING:
     from torch.distributed.distributed_c10d import ProcessGroup
 
+    from anemoi.training.losses.base import BaseLoss
+
 LOGGER = logging.getLogger(__name__)
 
 
-class TimeAggregateLossWrapper(BaseLoss):
+class TimeAggregateLossWrapper(BaseLossWrapper):
     """Wraps a base loss and applies it to time-aggregated predictions.
 
     Supported time aggregation types:
@@ -28,9 +30,8 @@ class TimeAggregateLossWrapper(BaseLoss):
         loss_fn: BaseLoss,
         ignore_nans: bool = False,
     ) -> None:
-        super().__init__(ignore_nans=ignore_nans)
+        super().__init__(loss=loss_fn, ignore_nans=ignore_nans)
         self.time_aggregation_types = time_aggregation_types
-        self.loss_fn = loss_fn
 
     def forward(
         self,
@@ -104,6 +105,6 @@ class TimeAggregateLossWrapper(BaseLoss):
                 msg = f"Unknown aggregation type '{agg_op}'. Supported: 'diff', 'mean', 'min', 'max'."
                 raise ValueError(msg)
 
-            loss = loss + self.loss_fn(pred_agg, target_agg, **shared_kwargs)
+            loss = loss + self.loss(pred_agg, target_agg, **shared_kwargs)
 
         return loss

--- a/training/src/anemoi/training/losses/base.py
+++ b/training/src/anemoi/training/losses/base.py
@@ -14,6 +14,7 @@ from abc import ABC
 from abc import abstractmethod
 from collections.abc import Iterator
 from enum import StrEnum
+from typing import Any
 from typing import ClassVar
 
 import torch
@@ -275,6 +276,52 @@ class BaseLoss(nn.Module, ABC):
         torch.Tensor
             Weighted loss
         """
+
+
+class BaseLossWrapper(BaseLoss):
+    """Transparent wrapper around a single inner loss.
+
+    By default, all scaler and metadata methods are delegated to the
+    wrapped loss so that the wrapper behaves as if it *were* the inner
+    loss from the perspective of ``CombinedLoss`` and the scaler
+    machinery.  Subclasses only need to override ``forward``.
+    """
+
+    def __init__(self, loss: BaseLoss, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        if not isinstance(loss, BaseLoss):
+            msg = f"Invalid loss type provided: {type(loss)}. Expected BaseLoss."
+            raise TypeError(msg)
+        self.loss = loss
+        # Share the inner loss's scaler so that scaler additions/updates
+        # applied to this wrapper are visible to the actual loss computation.
+        self.scaler = self.loss.scaler
+        self.supports_sharding = getattr(self.loss, "supports_sharding", True)
+
+    # -- scaler delegation --------------------------------------------------
+
+    @functools.wraps(ScaleTensor.add_scaler)
+    def add_scaler(self, dimension: int | tuple[int], scaler: torch.Tensor, *, name: str | None = None) -> None:
+        self.loss.add_scaler(dimension=dimension, scaler=scaler, name=name)
+
+    @functools.wraps(ScaleTensor.update_scaler)
+    def update_scaler(self, name: str, scaler: torch.Tensor, *, override: bool = False) -> None:
+        self.loss.update_scaler(name=name, scaler=scaler, override=override)
+
+    @functools.wraps(ScaleTensor.has_scaler_for_dim)
+    def has_scaler_for_dim(self, dim: TensorDim) -> bool:
+        return self.loss.has_scaler_for_dim(dim=dim)
+
+    # -- metadata delegation ------------------------------------------------
+
+    @property
+    def needs_shard_layout_info(self) -> bool:
+        """Delegate to the wrapped loss."""
+        return getattr(self.loss, "needs_shard_layout_info", False)
+
+    def iter_leaf_losses(self) -> Iterator["BaseLoss"]:
+        """Yield leaf losses from the wrapped loss."""
+        yield from self.loss.iter_leaf_losses()
 
 
 class FunctionalLoss(BaseLoss):

--- a/training/src/anemoi/training/losses/loss.py
+++ b/training/src/anemoi/training/losses/loss.py
@@ -145,7 +145,16 @@ def get_loss_function(
     if "_target_" in loss_config and loss_config["_target_"] in WRAPPED_LOSSES:
         inner_loss_config = loss_config.pop("loss_fn")
         inner_loss = get_loss_function(OmegaConf.create(inner_loss_config), scalers, data_indices)
-        return instantiate(loss_config, loss_fn=inner_loss)
+        wrapper = instantiate(loss_config, loss_fn=inner_loss)
+        # Apply any scalers specified on the wrapper itself (delegated to the inner loss).
+        if scalers_to_include and scalers:
+            resolved = (
+                [s for s in scalers if f"!{s}" not in scalers_to_include]
+                if "*" in scalers_to_include
+                else list(scalers_to_include)
+            )
+            _apply_scalers(wrapper, resolved, scalers, data_indices)
+        return wrapper
 
     if scalers is None:
         scalers = {}

--- a/training/src/anemoi/training/losses/multiscale.py
+++ b/training/src/anemoi/training/losses/multiscale.py
@@ -21,11 +21,12 @@ from anemoi.models.distributed.shapes import apply_shard_shapes
 from anemoi.models.layers.graph_provider import ProjectionGraphProvider
 from anemoi.models.layers.sparse_projector import SparseProjector
 from anemoi.training.losses.base import BaseLoss
+from anemoi.training.losses.base import BaseLossWrapper
 
 LOGGER = logging.getLogger(__name__)
 
 
-class MultiscaleLossWrapper(BaseLoss):
+class MultiscaleLossWrapper(BaseLossWrapper):
 
     name: str = "MultiscaleLossWrapper"
 
@@ -59,7 +60,7 @@ class MultiscaleLossWrapper(BaseLoss):
         autocast : bool
             Whether to use automatic mixed precision for the projections
         """
-        super().__init__()
+        super().__init__(loss=per_scale_loss)
 
         self.smoothing_matrices = self._load_smoothing_matrices(loss_matrices_path, loss_matrices)
         self.num_scales = len(self.smoothing_matrices)
@@ -67,8 +68,6 @@ class MultiscaleLossWrapper(BaseLoss):
             len(weights) == self.num_scales
         ), f"Number of weights ({len(weights)}) must match number of scales ({self.num_scales})"
         self.weights = weights
-        self.loss = per_scale_loss
-        self.scaler = self.loss.scaler
         self.keep_batch_sharded = keep_batch_sharded
         self.supports_sharding = True
         self.mloss = None
@@ -83,20 +82,6 @@ class MultiscaleLossWrapper(BaseLoss):
         grid-sharded during loss computation.
         """
         return self.keep_batch_sharded
-
-    def update_scaler(self, name: str, scaler: torch.Tensor, *, override: bool = False) -> None:
-        """Update the scaler values for the internal loss.
-
-        Parameters
-        ----------
-        name : str
-            Name of the scaler to update
-        scaler : torch.Tensor
-            New scaler values
-        override : bool, optional
-            Whether to override existing scaler values, by default False
-        """
-        self.loss.update_scaler(name=name, scaler=scaler, override=override)
 
     def _load_smoothing_matrices(
         self,

--- a/training/src/anemoi/training/losses/utils.py
+++ b/training/src/anemoi/training/losses/utils.py
@@ -13,9 +13,8 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from anemoi.training.losses.aggregate import TimeAggregateLossWrapper
+from anemoi.training.losses.base import BaseLossWrapper
 from anemoi.training.losses.combined import CombinedLoss
-from anemoi.training.losses.multiscale import MultiscaleLossWrapper
 from anemoi.training.losses.variable_mapper import LossVariableMapper
 from anemoi.training.utils.enums import TensorDim
 
@@ -62,16 +61,12 @@ def print_variable_scaling(loss: BaseLoss, data_indices: IndexCollection) -> dic
             variable_scaling[f"{base_key}{suffix}"] = print_variable_scaling(sub_loss, data_indices)
         return variable_scaling
 
-    if isinstance(loss, MultiscaleLossWrapper):
-        return print_variable_scaling(loss.loss, data_indices)
-
-    if isinstance(loss, TimeAggregateLossWrapper):
-        return print_variable_scaling(loss.loss_fn, data_indices)
-
     if isinstance(loss, LossVariableMapper):
         subset_vars = enumerate(loss.predicted_variables)
         # LossVariableMapper forwards scalers to its inner loss, so get scaling from there
         scaler_source = loss.loss.scaler
+    elif isinstance(loss, BaseLossWrapper):
+        return print_variable_scaling(loss.loss, data_indices)
     else:
         subset_vars = enumerate(data_indices.model.output.name_to_index.keys())
         scaler_source = loss.scaler

--- a/training/src/anemoi/training/losses/variable_mapper.py
+++ b/training/src/anemoi/training/losses/variable_mapper.py
@@ -17,6 +17,7 @@ from torch.distributed.distributed_c10d import ProcessGroup
 
 from anemoi.models.data_indices.collection import IndexCollection
 from anemoi.training.losses.base import BaseLoss
+from anemoi.training.losses.base import BaseLossWrapper
 from anemoi.training.losses.scaler_tensor import ScaleTensor
 from anemoi.training.utils.enums import TensorDim
 from anemoi.training.utils.index_space import IndexSpace
@@ -24,7 +25,7 @@ from anemoi.training.utils.index_space import IndexSpace
 LOGGER = logging.getLogger(__name__)
 
 
-class LossVariableMapper(BaseLoss):
+class LossVariableMapper(BaseLossWrapper):
     """Loss wrapper to filter variables to compute the loss on."""
 
     def __init__(
@@ -52,18 +53,9 @@ class LossVariableMapper(BaseLoss):
                 target_variables,
             ), "predicted and target variables must have the same length for loss computation"
 
-        super().__init__()
+        super().__init__(loss=loss)
 
         self._loss_scaler_specification = {}
-        if not isinstance(loss, BaseLoss):
-            msg = f"Invalid loss type provided: {type(loss)}. Expected BaseLoss."
-            raise TypeError(msg)
-        self.loss = loss
-        if hasattr(self.loss, "scaler"):
-            # Share the inner loss scaler so scaler membership and updates remain visible
-            # to training/task utilities that inspect `loss.scaler`.
-            self.scaler = self.loss.scaler
-        self.supports_sharding = getattr(self.loss, "supports_sharding", False)
         self.predicted_variables = list(predicted_variables) if predicted_variables is not None else None
         self.target_variables = list(target_variables) if target_variables is not None else None
         self.data_indices: IndexCollection | None = None
@@ -71,11 +63,6 @@ class LossVariableMapper(BaseLoss):
         self.target_indices_by_layout: dict[IndexSpace, list[int]] = {}
         if data_indices is not None:
             self.set_data_indices(data_indices)
-
-    @property
-    def needs_shard_layout_info(self) -> bool:
-        """Whether the wrapped loss requires explicit shard-layout metadata."""
-        return getattr(self.loss, "needs_shard_layout_info", False)
 
     def _get_predicted_indices_for_scaler_variable_axis(self, variable_size: int) -> list[int] | None:
         if variable_size == 1:
@@ -155,14 +142,10 @@ class LossVariableMapper(BaseLoss):
     @functools.wraps(ScaleTensor.update_scaler)
     def update_scaler(self, name: str, scaler: torch.Tensor, *, override: bool = False) -> None:
         # Keep update behavior consistent with add_scaler for VARIABLE-axis scalers.
-        if hasattr(self.loss, "scaler") and name in self.loss.scaler.tensors:
+        if name in self.loss.scaler.tensors:
             dimension = self.loss.scaler.tensors[name][0]
             scaler = self._filter_variable_axis_scaler(dimension, scaler)
         self.loss.update_scaler(name=name, scaler=scaler, override=override)
-
-    @functools.wraps(ScaleTensor.has_scaler_for_dim)
-    def has_scaler_for_dim(self, dim: TensorDim) -> bool:
-        return self.loss.has_scaler_for_dim(dim=dim)
 
     @staticmethod
     def _to_layout(layout: IndexSpace | str, *, layout_name: str) -> IndexSpace:

--- a/training/src/anemoi/training/schemas/training.py
+++ b/training/src/anemoi/training/schemas/training.py
@@ -291,6 +291,23 @@ class MultiScaleLossSchema(BaseModel):
     keep_batch_sharded: bool
     loss_matrices_path: str | None = None
     loss_matrices: list[str | None]
+    scalers: list[str] | None = None
+    "Scalers to apply to the wrapped loss (delegated to inner per_scale_loss)."
+
+    @field_validator("per_scale_loss", mode="before")
+    @classmethod
+    def add_empty_scalers_to_inner(cls, v: Any) -> Any:
+        """Inject empty scalers for inner loss; scalers flow through the wrapper."""
+        if isinstance(v, dict) and "scalers" not in v:
+            v["scalers"] = []
+        else:
+            from omegaconf import DictConfig
+            from omegaconf.omegaconf import open_dict
+
+            if isinstance(v, DictConfig) and "scalers" not in v:
+                with open_dict(v):
+                    v["scalers"] = []
+        return v
 
     @field_validator("weights")
     @classmethod
@@ -308,6 +325,23 @@ class TimeAggregateLossWrapperSchema(BaseModel):
     "Time aggregation operations to apply over the time dimension before computing the loss."
     loss_fn: BaseLossSchema | AlmostFairKernelCRPSSchema | KernelCRPSSchema
     "Inner loss function applied to each time-aggregated output."
+    scalers: list[str] | None = None
+    "Scalers to apply to the wrapped loss (delegated to inner loss_fn)."
+
+    @field_validator("loss_fn", mode="before")
+    @classmethod
+    def add_empty_scalers_to_inner(cls, v: Any) -> Any:
+        """Inject empty scalers for inner loss; scalers flow through the wrapper."""
+        if isinstance(v, dict) and "scalers" not in v:
+            v["scalers"] = []
+        else:
+            from omegaconf import DictConfig
+            from omegaconf.omegaconf import open_dict
+
+            if isinstance(v, DictConfig) and "scalers" not in v:
+                with open_dict(v):
+                    v["scalers"] = []
+        return v
 
 
 class HuberLossSchema(BaseLossSchema):
@@ -348,10 +382,6 @@ class CombinedLossSchema(BaseLossSchema):
         from omegaconf.omegaconf import open_dict
 
         for loss in losses:
-            # TimeAggregateLossWrapper and MultiscaleLossWrapper don't have top-level scalers
-            target = loss.get("_target_", "") if isinstance(loss, (dict, DictConfig)) else ""
-            if "TimeAggregateLossWrapper" in target or "MultiscaleLossWrapper" in target:
-                continue
             if "scalers" not in loss:
                 if isinstance(loss, DictConfig):
                     with open_dict(loss):

--- a/training/tests/unit/losses/test_aggregate_loss.py
+++ b/training/tests/unit/losses/test_aggregate_loss.py
@@ -61,10 +61,10 @@ def test_is_base_loss() -> None:
     assert isinstance(wrapper, BaseLoss)
 
 
-def test_stores_loss_fn_and_agg_types() -> None:
+def test_stores_loss_and_agg_types() -> None:
     inner = _make_loss()
     wrapper = TimeAggregateLossWrapper(["mean", "diff"], inner)
-    assert wrapper.loss_fn is inner
+    assert wrapper.loss is inner
     assert wrapper.time_aggregation_types == ["mean", "diff"]
 
 


### PR DESCRIPTION
## Description
Make the aggregate loss wrapper "transparent", i.e. share scalers with the inner loss and delegate metadata and scaler handling methods.

Add a BaseLossWrapper to make the transparent loss wrapping the default for nested wrappers.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
