### PR TITLE
fix: add missing parameters for logging hyperparameters in MlflowSchema

### DIFF
--- a/training/src/anemoi/training/config/diagnostics/log/mlflow.yaml
+++ b/training/src/anemoi/training/config/diagnostics/log/mlflow.yaml
@@ -9,6 +9,8 @@ mlflow:
   system: False
   terminal: True
   run_name: null # If set to null, the run name will be the a random UUID
+  prefix: '' # Prefix for metric keys logged to MLflow
+  log_hyperparams: True
   on_resume_create_child: True
   expand_hyperparams: # Which keys in hyperparams to expand
     - config

--- a/training/src/anemoi/training/schemas/diagnostics.py
+++ b/training/src/anemoi/training/schemas/diagnostics.py
@@ -374,6 +374,10 @@ class MlflowSchema(BaseModel):
     "Log terminal logs to MLflow."
     run_name: str | None
     "Name of run."
+    prefix: str = ""
+    "Prefix for metric keys logged to MLflow."
+    log_hyperparams: bool = True
+    "Whether to log hyperparameters."
     on_resume_create_child: bool
     "Whether to create a child run when resuming a run."
     expand_hyperparams: list[str] = Field(default_factory=lambda: ["config"])

--- a/training/tests/unit/diagnostics/mlflow/test_azureml_mlflow_logger.py
+++ b/training/tests/unit/diagnostics/mlflow/test_azureml_mlflow_logger.py
@@ -1,6 +1,6 @@
+import inspect
 from pathlib import Path
 
-import inspect
 import mlflow
 import pytest
 from mlflow import MlflowClient
@@ -88,7 +88,6 @@ def test_azure_mlflow_schema_covers_logger_init_params() -> None:
     run_id and fork_run_id are excluded because they are injected at runtime
     by get_mlflow_logger, not read from the config schema.
     """
-
     # Parameters injected at runtime rather than sourced from config
     runtime_params = {"self", "run_id", "fork_run_id"}
 

--- a/training/tests/unit/diagnostics/mlflow/test_azureml_mlflow_logger.py
+++ b/training/tests/unit/diagnostics/mlflow/test_azureml_mlflow_logger.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import inspect
 import mlflow
 import pytest
 from mlflow import MlflowClient
@@ -79,3 +80,20 @@ def test_azure_mlflow_schema() -> None:
     schema = AzureMlflowSchema(**config)
 
     assert schema.target_ == "anemoi.training.diagnostics.mlflow.azureml.AnemoiAzureMLflowLogger"
+
+
+def test_azure_mlflow_schema_covers_logger_init_params() -> None:
+    """Assert every AnemoiAzureMLflowLogger __init__ param has a field in AzureMlflowSchema.
+
+    run_id and fork_run_id are excluded because they are injected at runtime
+    by get_mlflow_logger, not read from the config schema.
+    """
+
+    # Parameters injected at runtime rather than sourced from config
+    runtime_params = {"self", "run_id", "fork_run_id"}
+
+    logger_params = set(inspect.signature(AnemoiAzureMLflowLogger.__init__).parameters) - runtime_params
+    schema_fields = set(AzureMlflowSchema.model_fields)
+
+    missing = logger_params - schema_fields
+    assert not missing, f"AzureMlflowSchema is missing fields for logger params: {missing}"

--- a/training/tests/unit/diagnostics/mlflow/test_mlflow_logger.py
+++ b/training/tests/unit/diagnostics/mlflow/test_mlflow_logger.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import inspect
 import omegaconf
 import pytest
 import yaml
@@ -171,3 +172,20 @@ def test_mlflow_schema_backward_compatibility() -> None:
 
     assert schema.target_ == "anemoi.training.diagnostics.mlflow.logger.AnemoiMLflowLogger"
     assert schema.save_dir is None
+
+
+def test_mlflow_schema_covers_logger_init_params() -> None:
+    """Assert every BaseAnemoiMLflowLogger __init__ param has a field in MlflowSchema.
+
+    run_id and fork_run_id are excluded because they are injected at runtime
+    by get_mlflow_logger, not read from the config schema.
+    """
+
+    # Parameters injected at runtime rather than sourced from config
+    runtime_params = {"self", "run_id", "fork_run_id"}
+
+    logger_params = set(inspect.signature(AnemoiMLflowLogger.__init__).parameters) - runtime_params
+    schema_fields = set(MlflowSchema.model_fields)
+
+    missing = logger_params - schema_fields
+    assert not missing, f"MlflowSchema is missing fields for logger params: {missing}"

--- a/training/tests/unit/diagnostics/mlflow/test_mlflow_logger.py
+++ b/training/tests/unit/diagnostics/mlflow/test_mlflow_logger.py
@@ -1,6 +1,6 @@
+import inspect
 from pathlib import Path
 
-import inspect
 import omegaconf
 import pytest
 import yaml
@@ -180,7 +180,6 @@ def test_mlflow_schema_covers_logger_init_params() -> None:
     run_id and fork_run_id are excluded because they are injected at runtime
     by get_mlflow_logger, not read from the config schema.
     """
-
     # Parameters injected at runtime rather than sourced from config
     runtime_params = {"self", "run_id", "fork_run_id"}
 


### PR DESCRIPTION
## Description
Fix bug #1083: The Pydantic schema: `MlflowSchema` is missing two parameters: `log_hyperparams` and `prefix`. These are available and work at runtime, but because they are missing from the schema, config validation incorrectly fails indicating that they are illegal extra inputs.

## What problem does this change solve?
Bug fix for #1083

## What issue or task does this change relate to?
#1083

##  Additional notes ##
I have added tests for both implementations of the `BaseAnemoiMLflowLogger`, i.e. for `AnemoiMLflowLogger` and for `AnemoiAzureMLflowLogger` to assert that the constructor parameters all match the schema so that we will catch any other future missing parameters.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
