### PR TITLE
feat(models,training): dictionarify encoder/decoder/residual and extract into Hydra defaults

### DIFF
--- a/models/docs/modules/residual.rst
+++ b/models/docs/modules/residual.rst
@@ -131,3 +131,41 @@ unfiltered fields.
    :members:
    :no-undoc-members:
    :show-inheritance:
+****************
+ Configuration
+****************
+
+The residual connection type is configured under the ``residual`` key in
+the model config. In the training config, residual presets are stored
+under ``model/residual/`` and referenced via Hydra defaults.
+
+Skip connection (default):
+
+.. code:: yaml
+
+   residual:
+     _target_: anemoi.models.layers.residual.SkipConnection
+     step: -1
+
+Graph-based truncated connection:
+
+.. code:: yaml
+
+   residual:
+     _target_: anemoi.models.layers.residual.TruncatedConnection
+     data_nodes: data
+     truncation_nodes: "int"
+     edge_weight_attribute: gauss_weight
+
+File-based truncated connection:
+
+.. code:: yaml
+
+   residual:
+     _target_: anemoi.models.layers.residual.TruncatedConnection
+     truncation_down_file_path: /path/to/n320_to_o96.npz
+     truncation_up_file_path: /path/to/o96_to_n320.npz
+
+For multi-dataset training, different residual connections can be
+specified per dataset. See the training documentation for details on
+per-dataset configuration.

--- a/models/src/anemoi/models/models/base.py
+++ b/models/src/anemoi/models/models/base.py
@@ -212,6 +212,29 @@ class BaseGraphModel(nn.Module):
 
         return dim_sizes[0]
 
+    def _get_nested_configuration(self, config: DotDict, dataset_name: str) -> DotDict:
+        """Extract a nested configuration for a specific dataset if the config is provided in a multi-dataset format.
+        If not provided in a multi-dataset format, return the base config.
+
+        Expects `_target_` key to be present in the final config for instantiation.
+        """
+        assert (
+            dataset_name in self.dataset_names
+        ), f"Dataset name '{dataset_name}' not found in model's dataset names {self.dataset_names}"
+
+        if dataset_name in config and isinstance(config[dataset_name], dict):
+            if "_target_" not in config[dataset_name]:
+                raise ValueError(
+                    f"Dataset-specific configuration for '{dataset_name}' must contain a '_target_' key for instantiation."
+                )
+            return config[dataset_name]
+
+        if "_target_" in config:
+            return config
+        raise ValueError(
+            f"Configuration for dataset '{dataset_name}' is not properly specified. Expected either a multi-dataset config for each dataset or a base config with a '_target_' key."
+        )
+
     @abstractmethod
     def _build_networks(self, model_config: DotDict) -> None:
         """Builds the networks for the model."""
@@ -229,7 +252,7 @@ class BaseGraphModel(nn.Module):
         self.residual = torch.nn.ModuleDict()
         for dataset_name in self.dataset_names:
             self.residual[dataset_name] = instantiate(
-                residual_config,
+                self._get_nested_configuration(residual_config, dataset_name),
                 graph=self._graph_data,
                 statistics=self.statistics[dataset_name],
                 data_indices=self.data_indices[dataset_name],

--- a/models/src/anemoi/models/models/diffusion_encoder_processor_decoder.py
+++ b/models/src/anemoi/models/models/diffusion_encoder_processor_decoder.py
@@ -77,17 +77,19 @@ class AnemoiDiffusionModelEncProcDec(BaseGraphModel):
         self.encoder_graph_provider = torch.nn.ModuleDict()
         self.encoder = torch.nn.ModuleDict()
         for dataset_name in self.dataset_names:
+            sub_encoder_config = self._get_nested_configuration(model_config.model.encoder, dataset_name)
+
             # Create graph providers
             self.encoder_graph_provider[dataset_name] = create_graph_provider(
                 graph=self._graph_data[(dataset_name, "to", self._graph_name_hidden)],
-                edge_attributes=model_config.model.encoder.get("sub_graph_edge_attributes"),
+                edge_attributes=sub_encoder_config.get("sub_graph_edge_attributes"),
                 src_size=self.node_attributes.num_nodes[dataset_name],
                 dst_size=self.node_attributes.num_nodes[self._graph_name_hidden],
-                trainable_size=model_config.model.encoder.get("trainable_size", 0),
+                trainable_size=sub_encoder_config.get("trainable_size", 0),
             )
 
             self.encoder[dataset_name] = instantiate(
-                model_config.model.encoder,
+                sub_encoder_config,
                 _recursive_=False,  # Avoids instantiation of layer_kernels here
                 in_channels_src=self.input_dim[dataset_name],
                 in_channels_dst=self.node_attributes.attr_ndims[self._graph_name_hidden],
@@ -115,15 +117,17 @@ class AnemoiDiffusionModelEncProcDec(BaseGraphModel):
         self.decoder_graph_provider = torch.nn.ModuleDict()
         self.decoder = torch.nn.ModuleDict()
         for dataset_name in self.dataset_names:
+            sub_decoder_config = self._get_nested_configuration(model_config.model.decoder, dataset_name)
+
             self.decoder_graph_provider[dataset_name] = create_graph_provider(
                 graph=self._graph_data[(self._graph_name_hidden, "to", dataset_name)],
-                edge_attributes=model_config.model.decoder.get("sub_graph_edge_attributes"),
+                edge_attributes=sub_decoder_config.get("sub_graph_edge_attributes"),
                 src_size=self.node_attributes.num_nodes[self._graph_name_hidden],
                 dst_size=self.node_attributes.num_nodes[dataset_name],
-                trainable_size=model_config.model.decoder.get("trainable_size", 0),
+                trainable_size=sub_decoder_config.get("trainable_size", 0),
             )
             self.decoder[dataset_name] = instantiate(
-                model_config.model.decoder,
+                sub_decoder_config,
                 _recursive_=False,  # Avoids instantiation of layer_kernels here
                 in_channels_src=self.num_channels,
                 in_channels_dst=self.input_dim[dataset_name],

--- a/models/src/anemoi/models/models/encoder_processor_decoder.py
+++ b/models/src/anemoi/models/models/encoder_processor_decoder.py
@@ -36,17 +36,19 @@ class AnemoiModelEncProcDec(BaseGraphModel):
         self.encoder_graph_provider = torch.nn.ModuleDict()
         self.encoder = torch.nn.ModuleDict()
         for dataset_name in self.dataset_names:
+            sub_encoder_config = self._get_nested_configuration(model_config.model.encoder, dataset_name)
+
             # Create graph providers
             self.encoder_graph_provider[dataset_name] = create_graph_provider(
                 graph=self._graph_data[(dataset_name, "to", self._graph_name_hidden)],
-                edge_attributes=model_config.model.encoder.get("sub_graph_edge_attributes"),
+                edge_attributes=sub_encoder_config.get("sub_graph_edge_attributes"),
                 src_size=self.node_attributes.num_nodes[dataset_name],
                 dst_size=self.node_attributes.num_nodes[self._graph_name_hidden],
-                trainable_size=model_config.model.encoder.get("trainable_size", 0),
+                trainable_size=sub_encoder_config.get("trainable_size", 0),
             )
 
             self.encoder[dataset_name] = instantiate(
-                model_config.model.encoder,
+                sub_encoder_config,
                 _recursive_=False,  # Avoids instantiation of layer_kernels here
                 in_channels_src=self.input_dim[dataset_name],
                 in_channels_dst=self.input_dim_latent,
@@ -74,16 +76,19 @@ class AnemoiModelEncProcDec(BaseGraphModel):
         self.decoder_graph_provider = torch.nn.ModuleDict()
         self.decoder = torch.nn.ModuleDict()
         for dataset_name in self.dataset_names:
+            sub_decoder_config = self._get_nested_configuration(model_config.model.decoder, dataset_name)
+
+            # Create graph providers
             self.decoder_graph_provider[dataset_name] = create_graph_provider(
                 graph=self._graph_data[(self._graph_name_hidden, "to", dataset_name)],
-                edge_attributes=model_config.model.decoder.get("sub_graph_edge_attributes"),
+                edge_attributes=sub_decoder_config.get("sub_graph_edge_attributes"),
                 src_size=self.node_attributes.num_nodes[self._graph_name_hidden],
                 dst_size=self.node_attributes.num_nodes[dataset_name],
-                trainable_size=model_config.model.decoder.get("trainable_size", 0),
+                trainable_size=sub_decoder_config.get("trainable_size", 0),
             )
 
             self.decoder[dataset_name] = instantiate(
-                model_config.model.decoder,
+                sub_decoder_config,
                 _recursive_=False,  # Avoids instantiation of layer_kernels here
                 in_channels_src=self.num_channels,
                 in_channels_dst=self.target_dim[dataset_name],

--- a/models/src/anemoi/models/models/hierarchical.py
+++ b/models/src/anemoi/models/models/hierarchical.py
@@ -37,16 +37,18 @@ class AnemoiModelEncProcDecHierarchical(AnemoiModelEncProcDec):
         self.encoder_graph_provider = nn.ModuleDict()
         self.encoder = torch.nn.ModuleDict()
         for dataset_name in self.dataset_names:
+            sub_encoder_config = self._get_nested_configuration(model_config.model.encoder, dataset_name)
+
             self.encoder_graph_provider[dataset_name] = create_graph_provider(
                 graph=self._graph_data[(dataset_name, "to", self._graph_name_hidden[0])],
-                edge_attributes=model_config.model.encoder.get("sub_graph_edge_attributes"),
+                edge_attributes=sub_encoder_config.get("sub_graph_edge_attributes"),
                 src_size=self.node_attributes.num_nodes[dataset_name],
                 dst_size=self.node_attributes.num_nodes[self._graph_name_hidden[0]],
-                trainable_size=model_config.model.encoder.get("trainable_size", 0),
+                trainable_size=sub_encoder_config.get("trainable_size", 0),
             )
 
             self.encoder[dataset_name] = instantiate(
-                model_config.model.encoder,
+                sub_encoder_config,
                 _recursive_=False,  # Avoids instantiation of layer_kernels here
                 in_channels_src=self.input_dim[dataset_name],
                 in_channels_dst=self.input_dim_latent,
@@ -123,16 +125,18 @@ class AnemoiModelEncProcDecHierarchical(AnemoiModelEncProcDec):
             src_nodes_name = self._graph_name_hidden[i]
             dst_nodes_name = self._graph_name_hidden[i + 1]
 
+            sub_downscale_config = self._get_nested_configuration(model_config.model.encoder, src_nodes_name)
+
             self.downscale_graph_providers[src_nodes_name] = create_graph_provider(
                 graph=self._graph_data[(src_nodes_name, "to", dst_nodes_name)],
-                edge_attributes=model_config.model.encoder.get("sub_graph_edge_attributes"),
+                edge_attributes=sub_downscale_config.get("sub_graph_edge_attributes"),
                 src_size=self.node_attributes.num_nodes[src_nodes_name],
                 dst_size=self.node_attributes.num_nodes[dst_nodes_name],
-                trainable_size=model_config.model.encoder.get("trainable_size", 0),
+                trainable_size=sub_downscale_config.get("trainable_size", 0),
             )
 
             self.downscale[src_nodes_name] = instantiate(
-                model_config.model.encoder,
+                sub_downscale_config,
                 _recursive_=False,  # Avoids instantiation of layer_kernels here
                 in_channels_src=self.hidden_dims[src_nodes_name],
                 in_channels_dst=self.node_attributes.attr_ndims[dst_nodes_name],
@@ -147,16 +151,18 @@ class AnemoiModelEncProcDecHierarchical(AnemoiModelEncProcDec):
             src_nodes_name = self._graph_name_hidden[i]
             dst_nodes_name = self._graph_name_hidden[i - 1]
 
+            sub_upscale_config = self._get_nested_configuration(model_config.model.decoder, src_nodes_name)
+
             self.upscale_graph_providers[src_nodes_name] = create_graph_provider(
                 graph=self._graph_data[(src_nodes_name, "to", dst_nodes_name)],
-                edge_attributes=model_config.model.decoder.get("sub_graph_edge_attributes"),
+                edge_attributes=sub_upscale_config.get("sub_graph_edge_attributes"),
                 src_size=self.node_attributes.num_nodes[src_nodes_name],
                 dst_size=self.node_attributes.num_nodes[dst_nodes_name],
-                trainable_size=model_config.model.decoder.get("trainable_size", 0),
+                trainable_size=sub_upscale_config.get("trainable_size", 0),
             )
 
             self.upscale[src_nodes_name] = instantiate(
-                model_config.model.decoder,
+                sub_upscale_config,
                 _recursive_=False,  # Avoids instantiation of layer_kernels here
                 in_channels_src=self.hidden_dims[src_nodes_name],
                 in_channels_dst=self.hidden_dims[dst_nodes_name],
@@ -169,16 +175,18 @@ class AnemoiModelEncProcDecHierarchical(AnemoiModelEncProcDec):
         self.decoder_graph_provider = nn.ModuleDict()
         self.decoder = torch.nn.ModuleDict()
         for dataset_name in self.dataset_names:
+            sub_decoder_config = self._get_nested_configuration(model_config.model.decoder, dataset_name)
+
             self.decoder_graph_provider[dataset_name] = create_graph_provider(
                 graph=self._graph_data[(self._graph_name_hidden[0], "to", dataset_name)],
-                edge_attributes=model_config.model.decoder.get("sub_graph_edge_attributes"),
+                edge_attributes=sub_decoder_config.get("sub_graph_edge_attributes"),
                 src_size=self.node_attributes.num_nodes[self._graph_name_hidden[0]],
                 dst_size=self.node_attributes.num_nodes[dataset_name],
-                trainable_size=model_config.model.decoder.get("trainable_size", 0),
+                trainable_size=sub_decoder_config.get("trainable_size", 0),
             )
 
             self.decoder[dataset_name] = instantiate(
-                model_config.model.decoder,
+                sub_decoder_config,
                 _recursive_=False,  # Avoids instantiation of layer_kernels here
                 in_channels_src=self.hidden_dims[self._graph_name_hidden[0]],
                 in_channels_dst=self.input_dim[dataset_name],

--- a/models/src/anemoi/models/models/hierarchical_autoencoder.py
+++ b/models/src/anemoi/models/models/hierarchical_autoencoder.py
@@ -95,15 +95,17 @@ class AnemoiModelHierarchicalAutoEncoder(AnemoiModelAutoEncoder):
         self.encoder_graph_provider = nn.ModuleDict()
         self.encoder = torch.nn.ModuleDict()
         for dataset_name in self.dataset_names:
+            sub_encoder_config = self._get_nested_configuration(model_config.model.encoder, dataset_name)
+
             self.encoder_graph_provider[dataset_name] = create_graph_provider(
                 graph=self._graph_data[(dataset_name, "to", self._graph_name_hidden[0])],
-                edge_attributes=model_config.model.encoder.get("sub_graph_edge_attributes"),
+                edge_attributes=sub_encoder_config.get("sub_graph_edge_attributes"),
                 src_size=self.node_attributes.num_nodes[dataset_name],
                 dst_size=self.node_attributes.num_nodes[self._graph_name_hidden[0]],
-                trainable_size=model_config.model.encoder.get("trainable_size", 0),
+                trainable_size=sub_encoder_config.get("trainable_size", 0),
             )
             self.encoder[dataset_name] = instantiate(
-                model_config.model.encoder,
+                sub_encoder_config,
                 _recursive_=False,  # Avoids instantiation of layer_kernels here
                 in_channels_src=self.input_dim[dataset_name],
                 in_channels_dst=self.input_dim_latent,
@@ -131,7 +133,7 @@ class AnemoiModelHierarchicalAutoEncoder(AnemoiModelAutoEncoder):
                 )
 
                 self.down_level_processor[nodes_names] = instantiate(
-                    model_config.model.processor,
+                    model_config.model.processor.processor,
                     _recursive_=False,  # Avoids instantiation of layer_kernels here
                     num_channels=self.hidden_dims[nodes_names],
                     edge_dim=self.down_level_processor_graph_providers[nodes_names].edge_dim,
@@ -148,7 +150,7 @@ class AnemoiModelHierarchicalAutoEncoder(AnemoiModelAutoEncoder):
                 )
 
                 self.up_level_processor[nodes_names] = instantiate(
-                    model_config.model.processor,
+                    model_config.model.processor.processor,
                     _recursive_=False,  # Avoids instantiation of layer_kernels here
                     num_channels=self.hidden_dims[nodes_names],
                     edge_dim=self.up_level_processor_graph_providers[nodes_names].edge_dim,
@@ -163,16 +165,18 @@ class AnemoiModelHierarchicalAutoEncoder(AnemoiModelAutoEncoder):
             src_nodes_name = self._graph_name_hidden[i]
             dst_nodes_name = self._graph_name_hidden[i + 1]
 
+            sub_downscale_config = self._get_nested_configuration(model_config.model.encoder, src_nodes_name)
+
             self.downscale_graph_providers[src_nodes_name] = create_graph_provider(
                 graph=self._graph_data[(src_nodes_name, "to", dst_nodes_name)],
-                edge_attributes=model_config.model.encoder.get("sub_graph_edge_attributes"),
+                edge_attributes=sub_downscale_config.get("sub_graph_edge_attributes"),
                 src_size=self.node_attributes.num_nodes[src_nodes_name],
                 dst_size=self.node_attributes.num_nodes[dst_nodes_name],
-                trainable_size=model_config.model.encoder.get("trainable_size", 0),
+                trainable_size=sub_downscale_config.get("trainable_size", 0),
             )
 
             self.downscale[src_nodes_name] = instantiate(
-                model_config.model.encoder,
+                sub_downscale_config,
                 _recursive_=False,  # Avoids instantiation of layer_kernels here
                 in_channels_src=self.hidden_dims[src_nodes_name],
                 in_channels_dst=self.node_attributes.attr_ndims[dst_nodes_name],
@@ -188,16 +192,18 @@ class AnemoiModelHierarchicalAutoEncoder(AnemoiModelAutoEncoder):
             src_nodes_name = self._graph_name_hidden[i]
             dst_nodes_name = self._graph_name_hidden[i - 1]
 
+            sub_upscale_config = self._get_nested_configuration(model_config.model.decoder, src_nodes_name)
+
             self.upscale_graph_providers[src_nodes_name] = create_graph_provider(
                 graph=self._graph_data[(src_nodes_name, "to", dst_nodes_name)],
-                edge_attributes=model_config.model.decoder.get("sub_graph_edge_attributes"),
+                edge_attributes=sub_upscale_config.get("sub_graph_edge_attributes"),
                 src_size=self.node_attributes.num_nodes[src_nodes_name],
                 dst_size=self.node_attributes.num_nodes[dst_nodes_name],
-                trainable_size=model_config.model.decoder.get("trainable_size", 0),
+                trainable_size=sub_upscale_config.get("trainable_size", 0),
             )
 
             self.upscale[src_nodes_name] = instantiate(
-                model_config.model.decoder,
+                sub_upscale_config,
                 _recursive_=False,  # Avoids instantiation of layer_kernels here
                 in_channels_src=self.hidden_dims[src_nodes_name],
                 in_channels_dst=self.hidden_dims[dst_nodes_name],
@@ -210,16 +216,18 @@ class AnemoiModelHierarchicalAutoEncoder(AnemoiModelAutoEncoder):
         self.decoder_graph_provider = nn.ModuleDict()
         self.decoder = torch.nn.ModuleDict()
         for dataset_name in self.dataset_names:
+            sub_decoder_config = self._get_nested_configuration(model_config.model.decoder, dataset_name)
+
             self.decoder_graph_provider[dataset_name] = create_graph_provider(
                 graph=self._graph_data[(self._graph_name_hidden[0], "to", dataset_name)],
-                edge_attributes=model_config.model.decoder.get("sub_graph_edge_attributes"),
+                edge_attributes=sub_decoder_config.get("sub_graph_edge_attributes"),
                 src_size=self.node_attributes.num_nodes[self._graph_name_hidden[0]],
                 dst_size=self.node_attributes.num_nodes[dataset_name],
-                trainable_size=model_config.model.decoder.get("trainable_size", 0),
+                trainable_size=sub_decoder_config.get("trainable_size", 0),
             )
 
             self.decoder[dataset_name] = instantiate(
-                model_config.model.decoder,
+                sub_decoder_config,
                 _recursive_=False,  # Avoids instantiation of layer_kernels here
                 in_channels_src=self.hidden_dims[self._graph_name_hidden[0]],
                 in_channels_dst=self.target_dim[dataset_name],

--- a/models/src/anemoi/models/schemas/decoder.py
+++ b/models/src/anemoi/models/schemas/decoder.py
@@ -7,6 +7,7 @@
 # nor does it submit to any jurisdiction.
 #
 
+from typing import Annotated
 from typing import Any
 from typing import Literal
 from typing import Union
@@ -81,3 +82,9 @@ class PointWiseBackwardMapperSchema(PointWiseMapperComponent):
     "Point-wise decoder object from anemoi.models.layers.mapper."
     initialise_data_extractor_zero: bool = Field(default=False)
     "Initialise the data extractor with zeros. Default to False."
+
+
+DecoderSchema = Annotated[
+    GNNDecoderSchema | GraphTransformerDecoderSchema | TransformerDecoderSchema | PointWiseBackwardMapperSchema,
+    Field(discriminator="target_"),
+]

--- a/models/src/anemoi/models/schemas/encoder.py
+++ b/models/src/anemoi/models/schemas/encoder.py
@@ -7,6 +7,7 @@
 # nor does it submit to any jurisdiction.
 #
 
+from typing import Annotated
 from typing import Any
 from typing import Literal
 from typing import Union
@@ -75,3 +76,9 @@ class TransformerEncoderSchema(TransformerModelComponent):
 class PointWiseForwardMapperSchema(PointWiseMapperComponent):
     target_: Literal["anemoi.models.layers.mapper.PointWiseForwardMapper"] = Field(..., alias="_target_")
     "Point-wise encoder object from anemoi.models.layers.mapper."
+
+
+EncoderSchema = Annotated[
+    GNNEncoderSchema | GraphTransformerEncoderSchema | TransformerEncoderSchema | PointWiseForwardMapperSchema,
+    Field(discriminator="target_"),
+]

--- a/models/src/anemoi/models/schemas/models.py
+++ b/models/src/anemoi/models/schemas/models.py
@@ -26,19 +26,9 @@ from pydantic import model_validator
 
 from anemoi.utils.schemas import BaseModel
 
-from .decoder import GNNDecoderSchema  # noqa: TC001
-from .decoder import GraphTransformerDecoderSchema  # noqa: TC001
-from .decoder import PointWiseBackwardMapperSchema  # noqa: TC001
-from .decoder import TransformerDecoderSchema  # noqa: TC001
-from .encoder import GNNEncoderSchema  # noqa: TC001
-from .encoder import GraphTransformerEncoderSchema  # noqa: TC001
-from .encoder import PointWiseForwardMapperSchema  # noqa: TC001
-from .encoder import TransformerEncoderSchema  # noqa: TC001
-from .processor import GNNProcessorSchema  # noqa: TC001
-from .processor import GraphTransformerProcessorSchema  # noqa: TC001
-from .processor import NoOpProcessorSchema  # noqa: TC001
-from .processor import PointWiseMLPProcessorSchema  # noqa: TC001
-from .processor import TransformerProcessorSchema  # noqa: TC001
+from .decoder import DecoderSchema
+from .encoder import EncoderSchema
+from .processor import ProcessorSchema
 from .residual import ResidualConnectionSchema
 
 LOGGER = logging.getLogger(__name__)
@@ -218,38 +208,16 @@ class BaseModelSchema(PydanticBaseModel):
     "Output mask"
     latent_skip: bool = True
     "Add skip connection in latent space before/after processor."
-    processor: Union[
-        NoOpProcessorSchema,
-        GNNProcessorSchema,
-        GraphTransformerProcessorSchema,
-        TransformerProcessorSchema,
-        PointWiseMLPProcessorSchema,
-    ] = Field(
+    processor: ProcessorSchema = Field(
         ...,
         discriminator="target_",
     )
     "GNN processor schema."
-    encoder: Union[
-        GNNEncoderSchema, GraphTransformerEncoderSchema, TransformerEncoderSchema, PointWiseForwardMapperSchema
-    ] = Field(
-        ...,
-        discriminator="target_",
-    )
+    encoder: Union[EncoderSchema, dict[str, EncoderSchema]]
     "GNN encoder schema."
-    decoder: Union[
-        GNNDecoderSchema,
-        GraphTransformerDecoderSchema,
-        TransformerDecoderSchema,
-        PointWiseBackwardMapperSchema,
-    ] = Field(
-        ...,
-        discriminator="target_",
-    )
-    "GNN decoder schema.",
-    residual: ResidualConnectionSchema = Field(
-        ...,
-        discriminator="target_",
-    )
+    decoder: Union[DecoderSchema, dict[str, DecoderSchema]]
+    "GNN decoder schema."
+    residual: Union[ResidualConnectionSchema, dict[str, ResidualConnectionSchema]]
     "Residual connection schema."
     compile: Optional[list[dict[str, Any]]] = Field(None)
     "Modules to be compiled"

--- a/models/src/anemoi/models/schemas/processor.py
+++ b/models/src/anemoi/models/schemas/processor.py
@@ -7,6 +7,7 @@
 # nor does it submit to any jurisdiction.
 #
 
+from typing import Annotated
 from typing import Any
 from typing import Literal
 from typing import Union
@@ -112,3 +113,13 @@ class PointWiseMLPProcessorSchema(PointWiseModelComponent):
     "Ratio of the hidden dimension to the processor channel dimension."
     dropout_p: NonNegativeFloat = Field(default=0.0, example=0.0)
     "Dropout probability, default 0.0"
+
+
+ProcessorSchema = Annotated[
+    NoOpProcessorSchema
+    | GNNProcessorSchema
+    | GraphTransformerProcessorSchema
+    | TransformerProcessorSchema
+    | PointWiseMLPProcessorSchema,
+    Field(discriminator="target_"),
+]

--- a/training/docs/user-guide/configuring.rst
+++ b/training/docs/user-guide/configuring.rst
@@ -58,6 +58,33 @@ the config groups.:
 
 This will override the default model config with the transformer model.
 
+Model configs themselves use nested defaults for the encoder, decoder,
+and residual connection. For example, ``model/transformer.yaml``
+begins with:
+
+.. code:: yaml
+
+   defaults:
+     - encoder: gt16
+     - decoder: gt16
+     - residual: skip
+
+These reference config files under ``model/encoder/``,
+``model/decoder/``, and ``model/residual/`` respectively. You can
+override them individually:
+
+.. code:: yaml
+
+   model:
+     defaults:
+       - encoder: pointwise
+       - decoder: pointwise
+       - residual: truncated
+
+For multi-dataset training, per-dataset components can be specified
+using Hydra's package directive (see :ref:`per-dataset-components` in
+the Models page).
+
 You can also override individual settings. For example, to change the
 learning rate from the default value of 0.625e-4 to 1e-3, you can add
 the following to the config you're using:

--- a/training/docs/user-guide/models.rst
+++ b/training/docs/user-guide/models.rst
@@ -106,9 +106,61 @@ as there is no message passing or interaction between nodes.
 *******************
 
 The encoders and decoders can be chosen to be GNNs, GraphTransformers,
-or Transformers. This choice is independent of the processor, but
-currently the encoders and decoders must be the same model type otherwise
-the code will break.
+Transformers, or Point-wise MLPs. This choice is independent of the
+processor.
+
+Encoder and decoder configurations are defined as separate Hydra config
+groups under ``model/encoder/`` and ``model/decoder/``. Each model
+config file references them via Hydra defaults:
+
+.. code:: yaml
+
+   # training/config/model/transformer.yaml
+   defaults:
+     - encoder: gt16
+     - decoder: gt16
+     - residual: skip
+
+Available encoder presets include ``gnn``, ``gt16``, ``gt16_qknorm``,
+``pointwise``, and ``transformer``. Decoder presets mirror these with
+the addition of ``gt16_qknorm_zeroinit`` for diffusion models.
+
+.. _per-dataset-components:
+
+Per-dataset Encoders and Decoders
+=================================
+
+When training with multiple datasets, each dataset can use a different
+encoder, decoder, or residual connection. This is configured by nesting
+the component config under the dataset name:
+
+.. code:: yaml
+
+   defaults:
+     - encoder@encoder.data: gt16
+     - decoder@decoder.data: gt16
+     - residual: skip
+
+Here ``encoder@encoder.data`` tells Hydra to place the ``gt16`` encoder
+config at the path ``encoder.data`` within the model config, where
+``data`` is the dataset name. The model will then use that specific
+encoder for the ``data`` dataset.
+
+This can be extended to multiple datasets:
+
+.. code:: yaml
+
+   defaults:
+     - encoder@encoder.dataset_a: gt16
+     - encoder@encoder.dataset_b: pointwise
+     - decoder@decoder.dataset_a: gt16
+     - decoder@decoder.dataset_b: pointwise
+     - residual@residual.dataset_a: skip
+     - residual@residual.dataset_b: truncated
+
+When a single (non-nested) config is provided, it is shared across all
+datasets -- this is the default behaviour and matches the previous
+configuration style.
 
 *******************
  Switchable Layers

--- a/training/src/anemoi/training/commands/config.py
+++ b/training/src/anemoi/training/commands/config.py
@@ -15,6 +15,7 @@ import logging
 import os
 import re
 import shutil
+import subprocess
 import tempfile
 from collections.abc import Generator
 from pathlib import Path
@@ -60,6 +61,8 @@ class ConfigGenerator(Command):
         validate = subparsers.add_parser("validate", help=help_msg, description=help_msg)
 
         validate.add_argument("--config-name", help="Name of the primary config file")
+        validate.add_argument("--open", help="Open config files in an editor", action="store_true")
+        validate.add_argument("--viewer", help="Viewer to use for opening config files", default="vim")
         validate.add_argument("--overwrite", "-f", action="store_true")
         validate.add_argument(
             "--mask_env_vars",
@@ -103,7 +106,15 @@ class ConfigGenerator(Command):
                     the config_validation flag to false."
                 "So this command will validate the config regardless of the flag.",
             )
-            self.validate_config(args.config_name, args.mask_env_vars)
+            validated_config = self.validate_config(args.config_name, args.mask_env_vars)
+            if args.open:
+                with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False) as tmp_file:
+                    tmp_file_path = Path(tmp_file.name)
+                    dumped_config = validated_config.model_dump(by_alias=True)
+                    with tmp_file_path.open("w") as f:
+                        f.write(OmegaConf.to_yaml(dumped_config))
+                    assert args.viewer in ["vim", "nano", "code"], "Viewer must be one of 'vim', 'nano', or 'code'"
+                    subprocess.run([args.viewer, str(tmp_file_path)], check=False)  # noqa: S603
             LOGGER.info("Config files validated.")
             return
 
@@ -191,14 +202,14 @@ class ConfigGenerator(Command):
 
         return OmegaConf.create(updated_cfg)
 
-    def validate_config(self, config_name: Path | str, mask_env_vars: bool) -> None:
+    def validate_config(self, config_name: Path | str, mask_env_vars: bool) -> BaseSchema:
         """Validates the configuration files in the given directory."""
         with initialize(version_base=None, config_path=""):
             cfg = compose(config_name=config_name)
             if mask_env_vars:
                 cfg = self._mask_slurm_env_variables(cfg)
             OmegaConf.resolve(cfg)
-            BaseSchema(**cfg)
+            return BaseSchema(**cfg)
 
     def dump_config(self, config_path: Path, name: str, output: Path) -> None:
         """Dump config files in one YAML file."""

--- a/training/src/anemoi/training/config/model/decoder/gnn.yaml
+++ b/training/src/anemoi/training/config/model/decoder/gnn.yaml
@@ -1,0 +1,8 @@
+_target_: anemoi.models.layers.mapper.GNNBackwardMapper
+trainable_size: ${model.trainable_parameters.hidden2data}
+sub_graph_edge_attributes: ${model.attributes.edges}
+num_chunks: 1
+mlp_extra_layers: 0
+cpu_offload: ${model.cpu_offload}
+gradient_checkpointing: True
+layer_kernels: ${model.layer_kernels}

--- a/training/src/anemoi/training/config/model/decoder/gt16.yaml
+++ b/training/src/anemoi/training/config/model/decoder/gt16.yaml
@@ -1,0 +1,14 @@
+_target_: anemoi.models.layers.mapper.GraphTransformerBackwardMapper
+trainable_size: ${model.trainable_parameters.hidden2data}
+sub_graph_edge_attributes: ${model.attributes.edges}
+num_chunks: 4
+mlp_hidden_ratio: 4 # GraphTransformer or Transformer only
+num_heads: 16 # GraphTransformer or Transformer only
+initialise_data_extractor_zero: False
+qk_norm: False
+cpu_offload: ${model.cpu_offload}
+gradient_checkpointing: True
+layer_kernels: ${model.layer_kernels}
+shard_strategy: "edges"
+graph_attention_backend: "triton"  # Options: "triton", "pyg"
+edge_pre_mlp: False

--- a/training/src/anemoi/training/config/model/decoder/gt16_qknorm.yaml
+++ b/training/src/anemoi/training/config/model/decoder/gt16_qknorm.yaml
@@ -1,0 +1,13 @@
+_target_: anemoi.models.layers.mapper.GraphTransformerBackwardMapper
+trainable_size: ${model.trainable_parameters.hidden2data}
+sub_graph_edge_attributes: ${model.attributes.edges}
+num_chunks: 4
+mlp_hidden_ratio: 4 # GraphTransformer or Transformer only
+num_heads: 16 # GraphTransformer or Transformer only
+initialise_data_extractor_zero: False
+qk_norm: True
+cpu_offload: ${model.cpu_offload}
+gradient_checkpointing: True
+layer_kernels: ${model.layer_kernels}
+shard_strategy: "edges"
+graph_attention_backend: "triton"  # Options: "triton", "pyg"

--- a/training/src/anemoi/training/config/model/decoder/gt16_qknorm_zeroinit.yaml
+++ b/training/src/anemoi/training/config/model/decoder/gt16_qknorm_zeroinit.yaml
@@ -1,0 +1,13 @@
+_target_: anemoi.models.layers.mapper.GraphTransformerBackwardMapper
+trainable_size: ${model.trainable_parameters.hidden2data}
+sub_graph_edge_attributes: ${model.attributes.edges}
+num_chunks: 4
+mlp_hidden_ratio: 4 # GraphTransformer or Transformer only
+num_heads: 16 # GraphTransformer or Transformer only
+initialise_data_extractor_zero: True
+qk_norm: True
+cpu_offload: ${model.cpu_offload}
+gradient_checkpointing: True
+layer_kernels: ${model.layer_kernels}
+shard_strategy: "edges"
+graph_attention_backend: "triton"  # Options: "triton", "pyg"

--- a/training/src/anemoi/training/config/model/decoder/pointwise.yaml
+++ b/training/src/anemoi/training/config/model/decoder/pointwise.yaml
@@ -1,0 +1,5 @@
+_target_: anemoi.models.layers.mapper.PointWiseBackwardMapper
+initialise_data_extractor_zero: False
+cpu_offload: ${model.cpu_offload}
+gradient_checkpointing: True
+layer_kernels: ${model.layer_kernels}

--- a/training/src/anemoi/training/config/model/decoder/transformer.yaml
+++ b/training/src/anemoi/training/config/model/decoder/transformer.yaml
@@ -1,0 +1,16 @@
+_target_: anemoi.models.layers.mapper.TransformerBackwardMapper
+_convert_: all
+cpu_offload: ${model.cpu_offload}
+gradient_checkpointing: True
+num_chunks: 2
+mlp_hidden_ratio: 4 # GraphTransformer or Transformer only
+num_heads: 16 # GraphTransformer or Transformer only
+window_size: -1
+dropout_p: 0.0
+attention_implementation: flash_attention # Possible values: scaled_dot_product_attention, flash_attention
+softcap: 0.0 # Transformer only
+use_alibi_slopes: False # Transformer only
+qk_norm: False
+use_rotary_embeddings: False
+layer_kernels: ${model.layer_kernels}
+shard_strategy: "edges"

--- a/training/src/anemoi/training/config/model/encoder/gnn.yaml
+++ b/training/src/anemoi/training/config/model/encoder/gnn.yaml
@@ -1,0 +1,8 @@
+_target_: anemoi.models.layers.mapper.GNNForwardMapper
+trainable_size: ${model.trainable_parameters.data2hidden}
+sub_graph_edge_attributes: ${model.attributes.edges}
+num_chunks: 1
+mlp_extra_layers: 0
+cpu_offload: ${model.cpu_offload}
+gradient_checkpointing: True
+layer_kernels: ${model.layer_kernels}

--- a/training/src/anemoi/training/config/model/encoder/gt16.yaml
+++ b/training/src/anemoi/training/config/model/encoder/gt16.yaml
@@ -1,0 +1,13 @@
+_target_: anemoi.models.layers.mapper.GraphTransformerForwardMapper
+trainable_size: ${model.trainable_parameters.data2hidden}
+sub_graph_edge_attributes: ${model.attributes.edges}
+num_chunks: 4
+mlp_hidden_ratio: 4 # GraphTransformer or Transformer only
+num_heads: 16 # GraphTransformer or Transformer only
+qk_norm: False
+cpu_offload: ${model.cpu_offload}
+gradient_checkpointing: True
+layer_kernels: ${model.layer_kernels}
+shard_strategy: "edges"
+graph_attention_backend: "triton"  # Options: "triton", "pyg"
+edge_pre_mlp: False

--- a/training/src/anemoi/training/config/model/encoder/gt16_qknorm.yaml
+++ b/training/src/anemoi/training/config/model/encoder/gt16_qknorm.yaml
@@ -1,0 +1,12 @@
+_target_: anemoi.models.layers.mapper.GraphTransformerForwardMapper
+trainable_size: ${model.trainable_parameters.data2hidden}
+sub_graph_edge_attributes: ${model.attributes.edges}
+num_chunks: 4
+mlp_hidden_ratio: 4 # GraphTransformer or Transformer only
+num_heads: 16 # GraphTransformer or Transformer only
+qk_norm: True
+cpu_offload: ${model.cpu_offload}
+gradient_checkpointing: True
+layer_kernels: ${model.layer_kernels}
+shard_strategy: "edges"
+graph_attention_backend: "triton"  # Options: "triton", "pyg"

--- a/training/src/anemoi/training/config/model/encoder/pointwise.yaml
+++ b/training/src/anemoi/training/config/model/encoder/pointwise.yaml
@@ -1,0 +1,4 @@
+_target_: anemoi.models.layers.mapper.PointWiseForwardMapper
+cpu_offload: ${model.cpu_offload}
+gradient_checkpointing: True
+layer_kernels: ${model.layer_kernels}

--- a/training/src/anemoi/training/config/model/encoder/transformer.yaml
+++ b/training/src/anemoi/training/config/model/encoder/transformer.yaml
@@ -1,0 +1,16 @@
+_target_: anemoi.models.layers.mapper.TransformerForwardMapper
+_convert_: all
+cpu_offload: ${model.cpu_offload}
+gradient_checkpointing: True
+num_chunks: 2
+mlp_hidden_ratio: 4 # GraphTransformer or Transformer only
+num_heads: 16 # GraphTransformer or Transformer only
+window_size: -1
+dropout_p: 0.0
+attention_implementation: flash_attention  # Possible values: scaled_dot_product_attention, flash_attention
+softcap: 0.0 # Transformer only
+use_alibi_slopes: False # Transformer only
+qk_norm: False
+use_rotary_embeddings: False
+layer_kernels: ${model.layer_kernels}
+shard_strategy: "edges"

--- a/training/src/anemoi/training/config/model/gnn.yaml
+++ b/training/src/anemoi/training/config/model/gnn.yaml
@@ -1,3 +1,9 @@
+defaults:
+  # See graphtransformer.yaml for full documentation on nesting per dataset.
+  - encoder: gnn
+  - decoder: gnn
+  - residual: skip
+
 num_channels: 512
 cpu_offload: False
 
@@ -29,29 +35,6 @@ processor:
   gradient_checkpointing: True
   layer_kernels: ${model.layer_kernels}
 
-encoder:
-  _target_: anemoi.models.layers.mapper.GNNForwardMapper
-  trainable_size: ${model.trainable_parameters.data2hidden}
-  sub_graph_edge_attributes: ${model.attributes.edges}
-  num_chunks: 1
-  mlp_extra_layers: 0
-  cpu_offload: ${model.cpu_offload}
-  gradient_checkpointing: True
-  layer_kernels: ${model.layer_kernels}
-
-decoder:
-  _target_: anemoi.models.layers.mapper.GNNBackwardMapper
-  trainable_size: ${model.trainable_parameters.hidden2data}
-  sub_graph_edge_attributes: ${model.attributes.edges}
-  num_chunks: 1
-  mlp_extra_layers: 0
-  cpu_offload: ${model.cpu_offload}
-  gradient_checkpointing: True
-  layer_kernels: ${model.layer_kernels}
-
-residual:
-  _target_: anemoi.models.layers.residual.SkipConnection # options: SkipConnection, TruncatedConnection
-  step: -1 # use the latest step as skip connection
 
 output_mask:
   _target_: anemoi.training.utils.masks.NoOutputMask

--- a/training/src/anemoi/training/config/model/graphtransformer.yaml
+++ b/training/src/anemoi/training/config/model/graphtransformer.yaml
@@ -10,8 +10,8 @@ defaults:
   #
   # For multiple datasets with different encoder/decoder/residual configs,
   # use the @<path> syntax to nest configs per dataset:
-  #   - encoder@encoder.data: gt16
-  #   - encoder@encoder.other: gnn
+  # - encoder@encoder.data: gt16
+  # - encoder@encoder.other: gnn
   # This produces a dictionary-style config:
   #   encoder:
   #     data:

--- a/training/src/anemoi/training/config/model/graphtransformer.yaml
+++ b/training/src/anemoi/training/config/model/graphtransformer.yaml
@@ -1,3 +1,29 @@
+defaults:
+  # Encoder, decoder, and residual configs are loaded from the subdirectories.
+  # Each default populates the corresponding top-level key (e.g. encoder: gt16
+  # loads encoder/gt16.yaml into the `encoder` key).
+  #
+  # For a single dataset, this gives a flat config:
+  #   encoder:
+  #     _target_: anemoi.models.layers.mapper.GraphTransformerForwardMapper
+  #     ...
+  #
+  # For multiple datasets with different encoder/decoder/residual configs,
+  # use the @<path> syntax to nest configs per dataset:
+  #   - encoder@encoder.data: gt16
+  #   - encoder@encoder.other: gnn
+  # This produces a dictionary-style config:
+  #   encoder:
+  #     data:
+  #       _target_: anemoi.models.layers.mapper.GraphTransformerForwardMapper
+  #       ...
+  #     other:
+  #       _target_: anemoi.models.layers.mapper.GNNForwardMapper
+  #       ...
+  - encoder: gt16
+  - decoder: gt16
+  - residual: skip
+
 num_channels: 1024
 cpu_offload: False
 
@@ -38,41 +64,6 @@ processor:
   graph_attention_backend: "triton"  # Options: "triton", "pyg"
   edge_pre_mlp: False
 
-encoder:
-  _target_: anemoi.models.layers.mapper.GraphTransformerForwardMapper
-  trainable_size: ${model.trainable_parameters.data2hidden}
-  sub_graph_edge_attributes: ${model.attributes.edges}
-  num_chunks: 4
-  mlp_hidden_ratio: 4 # GraphTransformer or Transformer only
-  num_heads: 16 # GraphTransformer or Transformer only
-  qk_norm: False
-  cpu_offload: ${model.cpu_offload}
-  gradient_checkpointing: True
-  layer_kernels: ${model.layer_kernels}
-  shard_strategy: "edges"
-  graph_attention_backend: "triton"  # Options: "triton", "pyg"
-  edge_pre_mlp: False
-
-decoder:
-  _target_: anemoi.models.layers.mapper.GraphTransformerBackwardMapper
-  trainable_size: ${model.trainable_parameters.hidden2data}
-  sub_graph_edge_attributes: ${model.attributes.edges}
-  num_chunks: 4
-  mlp_hidden_ratio: 4 # GraphTransformer or Transformer only
-  num_heads: 16 # GraphTransformer or Transformer only
-  initialise_data_extractor_zero: False
-  qk_norm: False
-  cpu_offload: ${model.cpu_offload}
-  gradient_checkpointing: True
-  layer_kernels: ${model.layer_kernels}
-  shard_strategy: "edges"
-  graph_attention_backend: "triton"  # Options: "triton", "pyg"
-  edge_pre_mlp: False
-
-
-residual:
-  _target_: anemoi.models.layers.residual.SkipConnection # options: SkipConnection, TruncatedConnection
-  step: -1 # use the latest step as skip connection
 
 output_mask:
   _target_: anemoi.training.utils.masks.NoOutputMask

--- a/training/src/anemoi/training/config/model/graphtransformer_diffusion.yaml
+++ b/training/src/anemoi/training/config/model/graphtransformer_diffusion.yaml
@@ -1,4 +1,5 @@
 defaults:
+  # See graphtransformer.yaml for full documentation on nesting per dataset.
   - encoder: gt16_qknorm
   - decoder: gt16_qknorm
   - residual: skip

--- a/training/src/anemoi/training/config/model/graphtransformer_diffusion.yaml
+++ b/training/src/anemoi/training/config/model/graphtransformer_diffusion.yaml
@@ -1,3 +1,8 @@
+defaults:
+  - encoder: gt16_qknorm
+  - decoder: gt16_qknorm
+  - residual: skip
+
 num_channels: 1024
 cpu_offload: False
 
@@ -66,39 +71,6 @@ processor:
   layer_kernels: ${model.layer_kernels}
   graph_attention_backend: "triton"  # Options: "triton", "pyg"
 
-encoder:
-  _target_: anemoi.models.layers.mapper.GraphTransformerForwardMapper
-  trainable_size: ${model.trainable_parameters.data2hidden}
-  sub_graph_edge_attributes: ${model.attributes.edges}
-  num_chunks: 4
-  mlp_hidden_ratio: 4 # GraphTransformer or Transformer only
-  num_heads: 16 # GraphTransformer or Transformer only
-  qk_norm: True
-  cpu_offload: ${model.cpu_offload}
-  gradient_checkpointing: True
-  layer_kernels: ${model.layer_kernels}
-  shard_strategy: "edges"
-  graph_attention_backend: "triton"  # Options: "triton", "pyg"
-
-
-decoder:
-  _target_: anemoi.models.layers.mapper.GraphTransformerBackwardMapper
-  trainable_size: ${model.trainable_parameters.hidden2data}
-  sub_graph_edge_attributes: ${model.attributes.edges}
-  num_chunks: 4
-  mlp_hidden_ratio: 4 # GraphTransformer or Transformer only
-  num_heads: 16 # GraphTransformer or Transformer only
-  initialise_data_extractor_zero: False
-  qk_norm: True
-  cpu_offload: ${model.cpu_offload}
-  gradient_checkpointing: True
-  layer_kernels: ${model.layer_kernels}
-  shard_strategy: "edges"
-  graph_attention_backend: "triton"  # Options: "triton", "pyg"
-
-residual:
-  _target_: anemoi.models.layers.residual.SkipConnection # options: SkipConnection, TruncatedConnection
-  step: -1 # use the latest step as skip connection
 
 output_mask:
   _target_: anemoi.training.utils.masks.NoOutputMask

--- a/training/src/anemoi/training/config/model/graphtransformer_diffusiontend.yaml
+++ b/training/src/anemoi/training/config/model/graphtransformer_diffusiontend.yaml
@@ -1,4 +1,5 @@
 defaults:
+  # See graphtransformer.yaml for full documentation on nesting per dataset.
   - encoder: gt16_qknorm
   - decoder: gt16_qknorm
   - residual: skip

--- a/training/src/anemoi/training/config/model/graphtransformer_diffusiontend.yaml
+++ b/training/src/anemoi/training/config/model/graphtransformer_diffusiontend.yaml
@@ -1,3 +1,8 @@
+defaults:
+  - encoder: gt16_qknorm
+  - decoder: gt16_qknorm
+  - residual: skip
+
 num_channels: 1024
 condition_on_residual: False
 cpu_offload: False
@@ -67,39 +72,6 @@ processor:
   layer_kernels: ${model.layer_kernels}
   graph_attention_backend: "triton"  # Options: "triton", "pyg"
 
-encoder:
-  _target_: anemoi.models.layers.mapper.GraphTransformerForwardMapper
-  trainable_size: ${model.trainable_parameters.data2hidden}
-  sub_graph_edge_attributes: ${model.attributes.edges}
-  num_chunks: 4
-  mlp_hidden_ratio: 4 # GraphTransformer or Transformer only
-  num_heads: 16 # GraphTransformer or Transformer only
-  qk_norm: True
-  cpu_offload: ${model.cpu_offload}
-  gradient_checkpointing: True
-  layer_kernels: ${model.layer_kernels}
-  shard_strategy: "edges"
-  graph_attention_backend: "triton"  # Options: "triton", "pyg"
-
-
-decoder:
-  _target_: anemoi.models.layers.mapper.GraphTransformerBackwardMapper
-  trainable_size: ${model.trainable_parameters.hidden2data}
-  sub_graph_edge_attributes: ${model.attributes.edges}
-  num_chunks: 4
-  mlp_hidden_ratio: 4 # GraphTransformer or Transformer only
-  num_heads: 16 # GraphTransformer or Transformer only
-  initialise_data_extractor_zero: False
-  qk_norm: True
-  cpu_offload: ${model.cpu_offload}
-  gradient_checkpointing: True
-  layer_kernels: ${model.layer_kernels}
-  shard_strategy: "edges"
-  graph_attention_backend: "triton"  # Options: "triton", "pyg"
-
-residual:
-  _target_: anemoi.models.layers.residual.SkipConnection # options: SkipConnection, TruncatedConnection
-  step: -1 # use the latest step as skip connection
 
 output_mask:
   _target_: anemoi.training.utils.masks.NoOutputMask

--- a/training/src/anemoi/training/config/model/graphtransformer_ens.yaml
+++ b/training/src/anemoi/training/config/model/graphtransformer_ens.yaml
@@ -1,4 +1,5 @@
 defaults:
+  # See graphtransformer.yaml for full documentation on nesting per dataset.
   - encoder: gt16
   - decoder: gt16
   - residual: skip

--- a/training/src/anemoi/training/config/model/graphtransformer_ens.yaml
+++ b/training/src/anemoi/training/config/model/graphtransformer_ens.yaml
@@ -1,3 +1,8 @@
+defaults:
+  - encoder: gt16
+  - decoder: gt16
+  - residual: skip
+
 num_channels: 1024
 condition_on_residual: False
 output_mask:
@@ -70,45 +75,6 @@ processor:
       _target_: anemoi.models.layers.normalization.AutocastLayerNorm
       bias: False
 
-encoder:
-  _target_: anemoi.models.layers.mapper.GraphTransformerForwardMapper
-  trainable_size: ${model.trainable_parameters.data2hidden}
-  sub_graph_edge_attributes: ${model.attributes.edges}
-  num_chunks: 4
-  mlp_hidden_ratio: 4 # GraphTransformer or Transformer only
-  num_heads: 16 # GraphTransformer or Transformer only
-  qk_norm: False
-  cpu_offload: ${model.cpu_offload}
-  gradient_checkpointing: True
-  layer_kernels: ${model.layer_kernels}
-  shard_strategy: "edges"
-  graph_attention_backend: "triton"  # Options: "triton", "pyg"
-  edge_pre_mlp: False
-
-
-decoder:
-  _target_: anemoi.models.layers.mapper.GraphTransformerBackwardMapper
-  trainable_size: ${model.trainable_parameters.hidden2data}
-  sub_graph_edge_attributes: ${model.attributes.edges}
-  num_chunks: 4
-  mlp_hidden_ratio: 4 # GraphTransformer or Transformer only
-  num_heads: 16 # GraphTransformer or Transformer only
-  initialise_data_extractor_zero: False
-  qk_norm: False
-  cpu_offload: ${model.cpu_offload}
-  gradient_checkpointing: True
-  layer_kernels: ${model.layer_kernels}
-  shard_strategy: "edges"
-  graph_attention_backend: "triton"  # Options: "triton", "pyg"
-  edge_pre_mlp: False
-
-
-residual:
-  _target_: anemoi.models.layers.residual.SkipConnection # options: SkipConnection, TruncatedConnection
-  step: -1 # use the latest step as skip connection
-#  _target_: anemoi.models.layers.residual.TruncatedConnection
-#  truncation_up_file_path: ${system.input.truncation}
-#  truncation_down_file_path:  ${system.input.truncation_inv}
 
 trainable_parameters:
   data: 8

--- a/training/src/anemoi/training/config/model/point_wise.yaml
+++ b/training/src/anemoi/training/config/model/point_wise.yaml
@@ -1,4 +1,5 @@
 defaults:
+  # See graphtransformer.yaml for full documentation on nesting per dataset.
   - encoder: pointwise
   - decoder: pointwise
   - residual: skip

--- a/training/src/anemoi/training/config/model/point_wise.yaml
+++ b/training/src/anemoi/training/config/model/point_wise.yaml
@@ -1,3 +1,8 @@
+defaults:
+  - encoder: pointwise
+  - decoder: pointwise
+  - residual: skip
+
 num_channels: 1024
 cpu_offload: False
 
@@ -32,22 +37,6 @@ processor:
   gradient_checkpointing: True
   layer_kernels: ${model.layer_kernels}
 
-encoder:
-  _target_: anemoi.models.layers.mapper.PointWiseForwardMapper
-  cpu_offload: ${model.cpu_offload}
-  gradient_checkpointing: True
-  layer_kernels: ${model.layer_kernels}
-
-decoder:
-  _target_: anemoi.models.layers.mapper.PointWiseBackwardMapper
-  initialise_data_extractor_zero: False
-  cpu_offload: ${model.cpu_offload}
-  gradient_checkpointing: True
-  layer_kernels: ${model.layer_kernels}
-
-residual:
-  _target_: anemoi.models.layers.residual.SkipConnection # options: SkipConnection, TruncatedConnection
-  step: -1 # use the latest step as skip connection
 
 output_mask:
   _target_: anemoi.training.utils.masks.NoOutputMask

--- a/training/src/anemoi/training/config/model/residual/scalar_ornstein.yaml
+++ b/training/src/anemoi/training/config/model/residual/scalar_ornstein.yaml
@@ -1,0 +1,4 @@
+_target_: anemoi.models.layers.residual.ScalarOrnsteinConnection
+theta_init: 0.0
+theta_buff: 0.0
+theta_train: true

--- a/training/src/anemoi/training/config/model/residual/skip.yaml
+++ b/training/src/anemoi/training/config/model/residual/skip.yaml
@@ -1,0 +1,2 @@
+_target_: anemoi.models.layers.residual.SkipConnection # options: SkipConnection, TruncatedConnection
+step: -1 # use the latest step as skip connection

--- a/training/src/anemoi/training/config/model/residual/spectral_ornstein.yaml
+++ b/training/src/anemoi/training/config/model/residual/spectral_ornstein.yaml
@@ -1,0 +1,10 @@
+_target_: anemoi.models.layers.residual.SpectralOrnsteinConnection
+lmax: 2
+grid: legendre-gauss
+theta_init: 0.0
+theta_buff: 0.0
+zmean_term: true
+regressors: null
+truncate: false
+anti_aliasing: true
+skip_truncate_variables: null

--- a/training/src/anemoi/training/config/model/residual/truncated.yaml
+++ b/training/src/anemoi/training/config/model/residual/truncated.yaml
@@ -1,0 +1,2 @@
+_target_: anemoi.models.layers.residual.TruncatedConnection
+# TODO: Add defaults here

--- a/training/src/anemoi/training/config/model/transformer.yaml
+++ b/training/src/anemoi/training/config/model/transformer.yaml
@@ -1,4 +1,5 @@
 defaults:
+  # See graphtransformer.yaml for full documentation on nesting per dataset.
   - encoder: gt16
   - decoder: gt16
   - residual: skip

--- a/training/src/anemoi/training/config/model/transformer.yaml
+++ b/training/src/anemoi/training/config/model/transformer.yaml
@@ -1,3 +1,8 @@
+defaults:
+  - encoder: gt16
+  - decoder: gt16
+  - residual: skip
+
 num_channels: 1024
 cpu_offload: False
 
@@ -39,39 +44,6 @@ processor:
   gradient_checkpointing: True
   use_rotary_embeddings: False
   layer_kernels: ${model.layer_kernels}
-
-encoder:
-  _target_: anemoi.models.layers.mapper.GraphTransformerForwardMapper
-  trainable_size: ${model.trainable_parameters.data2hidden}
-  sub_graph_edge_attributes: ${model.attributes.edges}
-  num_chunks: 4
-  mlp_hidden_ratio: 4 # GraphTransformer or Transformer only
-  num_heads: 16 # GraphTransformer or Transformer only
-  qk_norm: False
-  cpu_offload: ${model.cpu_offload}
-  gradient_checkpointing: True
-  layer_kernels: ${model.layer_kernels}
-  shard_strategy: "edges"
-  graph_attention_backend: "triton" # Options: "triton", "pyg"
-
-decoder:
-  _target_: anemoi.models.layers.mapper.GraphTransformerBackwardMapper
-  trainable_size: ${model.trainable_parameters.hidden2data}
-  sub_graph_edge_attributes: ${model.attributes.edges}
-  num_chunks: 4
-  mlp_hidden_ratio: 4 # GraphTransformer or Transformer only
-  num_heads: 16 # GraphTransformer or Transformer only
-  initialise_data_extractor_zero: False
-  qk_norm: False
-  cpu_offload: ${model.cpu_offload}
-  gradient_checkpointing: True
-  layer_kernels: ${model.layer_kernels}
-  shard_strategy: "edges"
-  graph_attention_backend: "triton" # Options: "triton", "pyg"
-
-residual:
-  _target_: anemoi.models.layers.residual.SkipConnection # options: SkipConnection, TruncatedConnection
-  step: -1 # use the latest step as skip connection
 
 output_mask:
   _target_: anemoi.training.utils.masks.NoOutputMask

--- a/training/src/anemoi/training/config/model/transformer_diffusion.yaml
+++ b/training/src/anemoi/training/config/model/transformer_diffusion.yaml
@@ -1,3 +1,8 @@
+defaults:
+  - encoder: gt16_qknorm
+  - decoder: gt16_qknorm_zeroinit
+  - residual: skip
+
 num_channels: 1024
 cpu_offload: False
 
@@ -69,39 +74,6 @@ processor:
   use_rotary_embeddings: False
   layer_kernels: ${model.layer_kernels}
 
-encoder:
-  _target_: anemoi.models.layers.mapper.GraphTransformerForwardMapper
-  trainable_size: ${model.trainable_parameters.data2hidden}
-  sub_graph_edge_attributes: ${model.attributes.edges}
-  num_chunks: 4
-  mlp_hidden_ratio: 4 # GraphTransformer or Transformer only
-  num_heads: 16 # GraphTransformer or Transformer only
-  qk_norm: True
-  cpu_offload: ${model.cpu_offload}
-  gradient_checkpointing: True
-  layer_kernels: ${model.layer_kernels}
-  shard_strategy: "edges"
-  graph_attention_backend: "triton"  # Options: "triton", "pyg"
-
-
-decoder:
-  _target_: anemoi.models.layers.mapper.GraphTransformerBackwardMapper
-  trainable_size: ${model.trainable_parameters.hidden2data}
-  sub_graph_edge_attributes: ${model.attributes.edges}
-  num_chunks: 4
-  mlp_hidden_ratio: 4 # GraphTransformer or Transformer only
-  num_heads: 16 # GraphTransformer or Transformer only
-  initialise_data_extractor_zero: True
-  qk_norm: True
-  cpu_offload: ${model.cpu_offload}
-  gradient_checkpointing: True
-  layer_kernels: ${model.layer_kernels}
-  shard_strategy: "edges"
-  graph_attention_backend: "triton"  # Options: "triton", "pyg"
-
-residual:
-  _target_: anemoi.models.layers.residual.SkipConnection # options: SkipConnection, TruncatedConnection
-  step: -1 # use the latest step as skip connection
 
 output_mask:
   _target_: anemoi.training.utils.masks.NoOutputMask

--- a/training/src/anemoi/training/config/model/transformer_diffusion.yaml
+++ b/training/src/anemoi/training/config/model/transformer_diffusion.yaml
@@ -1,4 +1,5 @@
 defaults:
+  # See graphtransformer.yaml for full documentation on nesting per dataset.
   - encoder: gt16_qknorm
   - decoder: gt16_qknorm_zeroinit
   - residual: skip

--- a/training/src/anemoi/training/config/model/transformer_diffusiontend.yaml
+++ b/training/src/anemoi/training/config/model/transformer_diffusiontend.yaml
@@ -1,4 +1,5 @@
 defaults:
+  # See graphtransformer.yaml for full documentation on nesting per dataset.
   - encoder: gt16_qknorm
   - decoder: gt16_qknorm_zeroinit
   - residual: skip

--- a/training/src/anemoi/training/config/model/transformer_diffusiontend.yaml
+++ b/training/src/anemoi/training/config/model/transformer_diffusiontend.yaml
@@ -1,3 +1,8 @@
+defaults:
+  - encoder: gt16_qknorm
+  - decoder: gt16_qknorm_zeroinit
+  - residual: skip
+
 num_channels: 1024
 condition_on_residual: False
 cpu_offload: False
@@ -70,38 +75,6 @@ processor:
   use_rotary_embeddings: False
   layer_kernels: ${model.layer_kernels}
 
-encoder:
-  _target_: anemoi.models.layers.mapper.GraphTransformerForwardMapper
-  trainable_size: ${model.trainable_parameters.data2hidden}
-  sub_graph_edge_attributes: ${model.attributes.edges}
-  num_chunks: 4
-  mlp_hidden_ratio: 4 # GraphTransformer or Transformer only
-  num_heads: 16 # GraphTransformer or Transformer only
-  qk_norm: True
-  cpu_offload: ${model.cpu_offload}
-  gradient_checkpointing: True
-  layer_kernels: ${model.layer_kernels}
-  shard_strategy: "edges"
-  graph_attention_backend: "triton"  # Options: "triton", "pyg"
-
-decoder:
-  _target_: anemoi.models.layers.mapper.GraphTransformerBackwardMapper
-  trainable_size: ${model.trainable_parameters.hidden2data}
-  sub_graph_edge_attributes: ${model.attributes.edges}
-  num_chunks: 4
-  mlp_hidden_ratio: 4 # GraphTransformer or Transformer only
-  num_heads: 16 # GraphTransformer or Transformer only
-  initialise_data_extractor_zero: True
-  qk_norm: True
-  cpu_offload: ${model.cpu_offload}
-  gradient_checkpointing: True
-  layer_kernels: ${model.layer_kernels}
-  shard_strategy: "edges"
-  graph_attention_backend: "triton"  # Options: "triton", "pyg"
-
-residual:
-  _target_: anemoi.models.layers.residual.SkipConnection # options: SkipConnection, TruncatedConnection
-  step: -1 # use the latest step as skip connection
 
 output_mask:
   _target_: anemoi.training.utils.masks.NoOutputMask

--- a/training/src/anemoi/training/config/model/transformer_ens.yaml
+++ b/training/src/anemoi/training/config/model/transformer_ens.yaml
@@ -1,3 +1,8 @@
+defaults:
+  - encoder: gt16
+  - decoder: gt16
+  - residual: skip
+
 num_channels: 1024
 condition_on_residual: False
 cpu_offload: False
@@ -63,41 +68,6 @@ processor:
     Activation:
       _target_: torch.nn.GELU
 
-encoder:
-  _target_: anemoi.models.layers.mapper.GraphTransformerForwardMapper
-  trainable_size: ${model.trainable_parameters.data2hidden}
-  sub_graph_edge_attributes: ${model.attributes.edges}
-  num_chunks: 4
-  mlp_hidden_ratio: 4 # GraphTransformer or Transformer only
-  num_heads: 16 # GraphTransformer or Transformer only
-  qk_norm: False
-  cpu_offload: ${model.cpu_offload}
-  gradient_checkpointing: True
-  layer_kernels: ${model.layer_kernels}
-  shard_strategy: "edges"
-  graph_attention_backend: "triton"  # Options: "triton", "pyg"
-
-decoder:
-  _target_: anemoi.models.layers.mapper.GraphTransformerBackwardMapper
-  trainable_size: ${model.trainable_parameters.hidden2data}
-  sub_graph_edge_attributes: ${model.attributes.edges}
-  num_chunks: 4
-  mlp_hidden_ratio: 4 # GraphTransformer or Transformer only
-  num_heads: 16 # GraphTransformer or Transformer only
-  initialise_data_extractor_zero: False
-  qk_norm: False
-  cpu_offload: ${model.cpu_offload}
-  gradient_checkpointing: True
-  layer_kernels: ${model.layer_kernels}
-  shard_strategy: "edges"
-  graph_attention_backend: "triton"  # Options: "triton", "pyg"
-
-residual:
-  _target_: anemoi.models.layers.residual.SkipConnection # options: SkipConnection, TruncatedConnection
-  step: -1 # use the latest step as skip connection
-#  _target_: anemoi.models.layers.residual.TruncatedConnection
-#  truncation_up_file_path: ${system.input.truncation}
-#  truncation_down_file_path:  ${system.input.truncation_inv}
 
 output_mask:
   _target_: anemoi.training.utils.masks.NoOutputMask

--- a/training/src/anemoi/training/config/model/transformer_ens.yaml
+++ b/training/src/anemoi/training/config/model/transformer_ens.yaml
@@ -1,4 +1,5 @@
 defaults:
+  # See graphtransformer.yaml for full documentation on nesting per dataset.
   - encoder: gt16
   - decoder: gt16
   - residual: skip

--- a/training/src/anemoi/training/config/model/transformer_transformermapper.yaml
+++ b/training/src/anemoi/training/config/model/transformer_transformermapper.yaml
@@ -1,3 +1,8 @@
+defaults:
+  - encoder: transformer
+  - decoder: transformer
+  - residual: skip
+
 num_channels: 1024
 cpu_offload: False
 
@@ -41,45 +46,6 @@ processor:
   use_rotary_embeddings: False
   layer_kernels: ${model.layer_kernels}
 
-encoder:
-  _target_: anemoi.models.layers.mapper.TransformerForwardMapper
-  _convert_: all
-  cpu_offload: ${model.cpu_offload}
-  gradient_checkpointing: True
-  num_chunks: 2
-  mlp_hidden_ratio: 4 # GraphTransformer or Transformer only
-  num_heads: 16 # GraphTransformer or Transformer only
-  window_size: -1
-  dropout_p: 0.0
-  attention_implementation: flash_attention  # Possible values: scaled_dot_product_attention, flash_attention
-  softcap: 0.0 # Transformer only
-  use_alibi_slopes: False # Transformer only
-  qk_norm: False
-  use_rotary_embeddings: False
-  layer_kernels: ${model.layer_kernels}
-  shard_strategy: "edges"
-
-decoder:
-  _target_: anemoi.models.layers.mapper.TransformerBackwardMapper
-  _convert_: all
-  cpu_offload: ${model.cpu_offload}
-  gradient_checkpointing: True
-  num_chunks: 2
-  mlp_hidden_ratio: 4 # GraphTransformer or Transformer only
-  num_heads: 16 # GraphTransformer or Transformer only
-  window_size: -1
-  dropout_p: 0.0
-  attention_implementation: flash_attention # Possible values: scaled_dot_product_attention, flash_attention
-  softcap: 0.0 # Transformer only
-  use_alibi_slopes: False # Transformer only
-  qk_norm: False
-  use_rotary_embeddings: False
-  layer_kernels: ${model.layer_kernels}
-  shard_strategy: "edges"
-
-residual:
-  _target_: anemoi.models.layers.residual.SkipConnection # options: SkipConnection, TruncatedConnection
-  step: -1 # use the latest step as skip connection
 
 output_mask:
   _target_: anemoi.training.utils.masks.NoOutputMask

--- a/training/src/anemoi/training/config/model/transformer_transformermapper.yaml
+++ b/training/src/anemoi/training/config/model/transformer_transformermapper.yaml
@@ -1,4 +1,5 @@
 defaults:
+  # See graphtransformer.yaml for full documentation on nesting per dataset.
   - encoder: transformer
   - decoder: transformer
   - residual: skip

--- a/training/src/anemoi/training/schemas/base_schema.py
+++ b/training/src/anemoi/training/schemas/base_schema.py
@@ -192,9 +192,8 @@ class UnvalidatedBaseSchema(SchemaCommonMixin, PydanticBaseModel):
     """Flag to disable validation of the configuration"""
 
 
-def convert_to_omegaconf(config: BaseSchema) -> dict:
-    config = config.model_dump(by_alias=True)
-    return OmegaConf.create(config)
+def convert_to_omegaconf(config: BaseSchema | UnvalidatedBaseSchema) -> DictConfig:
+    return OmegaConf.create(config.model_dump(by_alias=True))
 
 
 def validate_schema(config: DictConfig) -> BaseSchema:

--- a/training/src/anemoi/training/schemas/base_schema.py
+++ b/training/src/anemoi/training/schemas/base_schema.py
@@ -154,10 +154,14 @@ class BaseSchema(SchemaCommonMixin, BaseModel):
     @model_validator(mode="after")
     def check_bounding_not_used_with_data_extractor_zero(self) -> Self:
         """Check that bounding is not used with zero data extractor."""
-        if (
-            isinstance(self.model.decoder, GraphTransformerDecoderSchema)
-            and self.model.decoder.initialise_data_extractor_zero
+        decoder_schema = (
+            [self.model.decoder] if not isinstance(self.model.decoder, dict) else self.model.decoder.values()
+        )
+        if any(
+            isinstance(decoder, GraphTransformerDecoderSchema)
+            and decoder.initialise_data_extractor_zero
             and self.model.bounding
+            for decoder in decoder_schema
         ):
             error = "bounding_conflict_with_data_extractor_zero"
             msg = (

--- a/training/src/anemoi/training/train/train.py
+++ b/training/src/anemoi/training/train/train.py
@@ -69,16 +69,16 @@ class AnemoiTrainer(ABC):
 
         if config.config_validation:
             OmegaConf.resolve(config)
-            self.config = BaseSchema(**config)
+            resolved_config = BaseSchema(**config)
 
             LOGGER.info("Config validated.")
         else:
-            config = OmegaConf.to_object(config)
-            self.config = UnvalidatedBaseSchema(**DictConfig(config))
+            resolved_config = OmegaConf.to_object(config)
+            resolved_config = UnvalidatedBaseSchema(**DictConfig(resolved_config))
 
             LOGGER.info("Skipping config validation.")
 
-        self.config = convert_to_omegaconf(self.config)
+        self.config = convert_to_omegaconf(resolved_config)
 
         # Optionally override the torch default BLAS backend.
         _blas_backend = self.config.training.get("preferred_blas_backend", None)
@@ -261,6 +261,17 @@ class AnemoiTrainer(ABC):
     @cached_property
     def model(self) -> pl.LightningModule:
         """Provide the model instance."""
+        encoder_config = (
+            [self.config.model.encoder]
+            if "_target_" in self.config.model.encoder
+            else list(self.config.model.encoder.values())
+        )
+        decoder_config = (
+            [self.config.model.decoder]
+            if "_target_" in self.config.model.decoder
+            else list(self.config.model.decoder.values())
+        )
+
         assert (
             not (
                 "layer_kernels" in self.config.model.processor
@@ -268,12 +279,18 @@ class AnemoiTrainer(ABC):
                 and ".Transformer" in self.config.model.processor.target_
             )
             and not (
-                "GLU" in self.config.model.encoder.layer_kernels["Activation"]["_target_"]
-                and ".Transformer" in self.config.model.encoder.target_
+                any(
+                    "GLU" in encoder_config.layer_kernels["Activation"]["_target_"]
+                    and ".Transformer" in encoder_config.target_
+                    for encoder_config in encoder_config
+                )
             )
             and not (
-                "GLU" in self.config.model.decoder.layer_kernels["Activation"]["_target_"]
-                and ".Transformer" in self.config.model.decoder.target_
+                any(
+                    "GLU" in decoder_config.layer_kernels["Activation"]["_target_"]
+                    and ".Transformer" in decoder_config.target_
+                    for decoder_config in decoder_config
+                )
             )
         ), "GLU activation function is not supported in Transformer models, due to fixed dimensions. "
         "Please use a different activation function."

--- a/training/src/anemoi/training/train/train.py
+++ b/training/src/anemoi/training/train/train.py
@@ -280,16 +280,14 @@ class AnemoiTrainer(ABC):
             )
             and not (
                 any(
-                    "GLU" in encoder_config.layer_kernels["Activation"]["_target_"]
-                    and ".Transformer" in encoder_config.target_
-                    for encoder_config in encoder_config
+                    "GLU" in enc_conf.layer_kernels["Activation"]["_target_"] and ".Transformer" in enc_conf.target_
+                    for enc_conf in encoder_config
                 )
             )
             and not (
                 any(
-                    "GLU" in decoder_config.layer_kernels["Activation"]["_target_"]
-                    and ".Transformer" in decoder_config.target_
-                    for decoder_config in decoder_config
+                    "GLU" in dec_conf.layer_kernels["Activation"]["_target_"] and ".Transformer" in dec_conf.target_
+                    for dec_conf in decoder_config
                 )
             )
         ), "GLU activation function is not supported in Transformer models, due to fixed dimensions. "

--- a/training/tests/integration/aicon/test_cicd_aicon_04_icon-dream_medium.py
+++ b/training/tests/integration/aicon/test_cicd_aicon_04_icon-dream_medium.py
@@ -136,7 +136,10 @@ def test_aicon_metadata(aicon_config_with_grid: DictConfig) -> None:
     assert torch.is_tensor(trainer.graph_data[dataset_name].x), "data coordinates not present"
 
     # Assert heterogeneity of num_chunks setting.
-    assert aicon_config_with_grid.model.encoder.num_chunks != aicon_config_with_grid.model.decoder.num_chunks
+    assert (
+        aicon_config_with_grid.model.encoder[dataset_name].num_chunks
+        != aicon_config_with_grid.model.decoder[dataset_name].num_chunks
+    )
 
     # Monitor path and setting of num_chunks
     assert (


### PR DESCRIPTION
## Summary

> [!WARNING]
> Still to be tested and models run

This PR makes encoder, decoder, and residual configs dictionary-based (keyed by dataset name) in the model code, and extracts the duplicated config blocks into reusable Hydra defaults.

### Dictionarify encoder/decoder/residual (models)

- Encoder, decoder, and residual are now stored as `torch.nn.ModuleDict` keyed by dataset name, allowing per-dataset configuration
- Adds `_get_nested_configuration()` to `BaseGraphModel` which resolves either a flat config (single `_target_`) or a nested dict of per-dataset configs
- Updates all model classes (`AnemoiModelEncProcDec`, diffusion, ensemble, hierarchical, autoencoder) to use the new nested lookup
- Moves encoder/decoder/processor schemas into their own modules
- Updates the GLU/Transformer assertion in `train.py` to iterate over potentially multiple encoder/decoder configs

### Extract configs into Hydra defaults (training)

- Extracts duplicated encoder, decoder, and residual blocks from all model YAML files into reusable configs under `model/encoder/`, `model/decoder/`, and `model/residual/`
- All 11 model configs now reference these via Hydra `defaults:` list instead of inlining the full block
- Where configs differ, separate named defaults preserve the exact resolved config

### Validation command

- Adds `--open` and `--viewer` flags to `anemoi-training config validate` to open the resolved config in an editor

## New default configs

**Encoder:** gnn, gt16, gt16_qknorm, transformer, pointwise
**Decoder:** gnn, gt16, gt16_qknorm, gt16_qknorm_zeroinit, transformer, pointwise
**Residual:** skip, truncated

## Model config mapping

| Model config | Encoder | Decoder | Residual |
|---|---|---|---|
| graphtransformer | gt16 | gt16 | skip |
| gnn | gnn | gnn | skip |
| transformer | gt16 | gt16 | skip |
| graphtransformer_ens | gt16 | gt16 | skip |
| transformer_ens | gt16 | gt16 | skip |
| graphtransformer_diffusion | gt16_qknorm | gt16_qknorm | skip |
| graphtransformer_diffusiontend | gt16_qknorm | gt16_qknorm | skip |
| transformer_diffusion | gt16_qknorm | gt16_qknorm_zeroinit | skip |
| transformer_diffusiontend | gt16_qknorm | gt16_qknorm_zeroinit | skip |
| transformer_transformermapper | transformer | transformer | skip |
| point_wise | pointwise | pointwise | skip |

<!-- readthedocs-preview anemoi-training start -->
----
📚 Documentation preview 📚: https://anemoi-training--1085.org.readthedocs.build/en/1085/

<!-- readthedocs-preview anemoi-training end -->

<!-- readthedocs-preview anemoi-graphs start -->
----
📚 Documentation preview 📚: https://anemoi-graphs--1085.org.readthedocs.build/en/1085/

<!-- readthedocs-preview anemoi-graphs end -->

<!-- readthedocs-preview anemoi-models start -->
----
📚 Documentation preview 📚: https://anemoi-models--1085.org.readthedocs.build/en/1085/

<!-- readthedocs-preview anemoi-models end -->