### PR TITLE
fix(graphs): fix node selection in interactive 3D graph viewer

### DIFF
--- a/graphs/src/anemoi/graphs/plotting/interactive_3d.html.jinja
+++ b/graphs/src/anemoi/graphs/plotting/interactive_3d.html.jinja
@@ -706,8 +706,9 @@ nor does it submit to any jurisdiction. #}
                 selectedNode = nodeName;
                 connectedNodes = new Set();
 
-                // Compute adjacency on the fly
-                EDGE_SETS.forEach(es => {
+                // Compute adjacency on the fly, only for visible edge sets
+                EDGE_SETS.forEach((es, i) => {
+                    if (!edgeSetMeshes[i].visible) return;
                     es.edges.forEach(([a, b]) => {
                         if (a === nodeName) connectedNodes.add(b);
                         else if (b === nodeName) connectedNodes.add(a);


### PR DESCRIPTION
#  Filter node selection highlights to visible edge sets                                        
                                                                                               
  When clicking a node in the 3D graph viewer, the previous behaviour highlighted all connected
   nodes across every edge set, regardless of which edge sets were toggled on in the Edges     
  panel. This made it impossible to isolate connections for a specific edge set — for example,
  selecting only data_to_hidden would still highlight nodes connected via hidden_to_hidden or  
  any other edge set.                                 

  The fix skips hidden edge sets when computing the connected-node set on click. Now the       
  highlighted neighbours reflect only the edge sets currently visible in the UI.
                                                                                               
  Changes:                                            
  - interactive_3d.html.jinja: selectNode now checks edgeSetMeshes[i].visible before including
  an edge set's connections.                                                                   
   

Before: 
<img width="1404" height="857" alt="2026-05-04_09-57" src="https://github.com/user-attachments/assets/271c7a93-3f6c-436b-9d04-7b3679ca7ce9" />

After: 
<img width="1186" height="952" alt="2026-05-04_10-02" src="https://github.com/user-attachments/assets/98dfc58b-8703-49d8-be36-cbf0931b8c14" />