### PR TITLE
feat(models): runtime env vars to override attention backends

### DIFF
--- a/models/src/anemoi/models/layers/attention.py
+++ b/models/src/anemoi/models/layers/attention.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import logging
 import math
+import os
 from typing import Optional
 
 import einops
@@ -28,6 +29,9 @@ from anemoi.models.distributed.transformer import shard_sequence
 from anemoi.utils.config import DotDict
 
 LOGGER = logging.getLogger(__name__)
+
+# Change attention implementation during inference runtime
+ATTENTION_BACKEND = os.environ.get("ANEMOI_INFERENCE_TRANSFORMER_ATTENTION_BACKEND", "")
 
 
 class MultiHeadSelfAttention(nn.Module):
@@ -148,7 +152,20 @@ class MultiHeadSelfAttention(nn.Module):
             "flash_attention": FlashAttentionWrapper,
             "scaled_dot_product_attention": SDPAAttentionWrapper,
         }
-        assert self.attention_implementation in attn_funcs, f"{self.attention_implementation} not supported. \
+
+        # Check if 'ANEMOI_INFERENCE_TRANSFORMER_ATTENTION_BACKEND' env var has been set
+        if ATTENTION_BACKEND:
+            if ATTENTION_BACKEND == self.attention_implementation:
+                # Attention backend has already been updated, return early
+                return
+            LOGGER.info(
+                "'ANEMOI_INFERENCE_TRANSFORMER_ATTENTION_BACKEND' environment variable has been set. Overwriting attention backend from '%s' to '%s'",
+                self.attention_implementation,
+                ATTENTION_BACKEND,
+            )
+            self.attention_implementation = ATTENTION_BACKEND
+
+        assert self.attention_implementation in attn_funcs, f"backend '{self.attention_implementation}' not supported. \
               Please change model.processor.attention_implementation to one of: {attn_funcs.keys()}"
 
         # initalise the attn func here
@@ -218,6 +235,10 @@ class MultiHeadSelfAttention(nn.Module):
         query = self.lin_q(x)
         key = self.lin_k(x)
         value = self.lin_v(x)
+
+        # Check at runtime if the Attention backend env var has been set, and update attention backend accordingly
+        if ATTENTION_BACKEND:
+            self.set_attention_function()
 
         return self.attention_computation(query, key, value, shapes, batch_size, model_comm_group)
 

--- a/models/src/anemoi/models/layers/attention.py
+++ b/models/src/anemoi/models/layers/attention.py
@@ -117,6 +117,7 @@ class MultiHeadSelfAttention(nn.Module):
             raise ValueError(f"attn_channels ({self.attn_channels}) must be divisible by number of heads ({num_heads})")
 
         self.attention_implementation = attention_implementation
+        self._attention_backend_applied = False
         self.use_alibi_slopes = use_alibi_slopes
 
         self.num_heads = num_heads
@@ -236,9 +237,10 @@ class MultiHeadSelfAttention(nn.Module):
         key = self.lin_k(x)
         value = self.lin_v(x)
 
-        # Check at runtime if the Attention backend env var has been set, and update attention backend accordingly
-        if ATTENTION_BACKEND:
+        # Check once at runtime if the Attention backend env var has been set, and update attention backend accordingly
+        if ATTENTION_BACKEND and not self._attention_backend_applied:
             self.set_attention_function()
+            self._attention_backend_applied = True
 
         return self.attention_computation(query, key, value, shapes, batch_size, model_comm_group)
 

--- a/models/src/anemoi/models/layers/block.py
+++ b/models/src/anemoi/models/layers/block.py
@@ -46,6 +46,8 @@ LOGGER = logging.getLogger(__name__)
 # Number of chunks used in inference (https://github.com/ecmwf/anemoi-core/pull/66)
 NUM_CHUNKS_INFERENCE = int(os.environ.get("ANEMOI_INFERENCE_NUM_CHUNKS", "1"))
 NUM_CHUNKS_INFERENCE_PROCESSOR = int(os.environ.get("ANEMOI_INFERENCE_NUM_CHUNKS_PROCESSOR", NUM_CHUNKS_INFERENCE))
+# Change attention implementation during inference runtime
+ATTENTION_BACKEND = os.environ.get("ANEMOI_INFERENCE_GRAPHTRANSFORMER_ATTENTION_BACKEND", "")
 
 
 class BaseBlock(nn.Module, ABC):
@@ -540,10 +542,26 @@ class GraphTransformerBaseBlock(BaseBlock, ABC):
             self.edge_pre_mlp = nn.Identity()
 
         self.graph_attention_backend = graph_attention_backend
+        self.set_attention_function()
+
+    def set_attention_function(self):
+        # Check if 'ANEMOI_INFERENCE_GRAPHTRANSFORMER_ATTENTION_BACKEND' env var has been set
+        if ATTENTION_BACKEND != "":
+            if ATTENTION_BACKEND == self.graph_attention_backend:
+                # Attention backend has already been updated, return early
+                return
+
+            LOGGER.info(
+                "'ANEMOI_INFERENCE_GRAPHTRANSFORMER_ATTENTION_BACKEND' environment variable has been set. Overwriting attention backend from '%s' to '%s'",
+                self.graph_attention_backend,
+                ATTENTION_BACKEND,
+            )
+            self.graph_attention_backend = ATTENTION_BACKEND
+
         assert self.graph_attention_backend in [
             "triton",
             "pyg",
-        ], f"Backend {self.graph_attention_backend} not supported for GraphTransformerBlock, valid options are 'triton' and 'pyg'"
+        ], f"Backend '{self.graph_attention_backend}' not supported for GraphTransformerBlock, valid options are 'triton' and 'pyg'"
 
         if not is_triton_available():
             LOGGER.warning(
@@ -624,6 +642,10 @@ class GraphTransformerBaseBlock(BaseBlock, ABC):
     ) -> Tensor:
         # self.conv requires size to be a tuple
         conv_size = (size, size) if isinstance(size, int) else size
+
+        # Check at runtime if 'ANEMOI_INFERENCE_GRAPHTRANSFORMER_ATTENTION_BACKEND' env var has been set and update backend if so
+        if ATTENTION_BACKEND != "":
+            self.set_attention_function()
 
         if self.graph_attention_backend == "triton":
             csc, perm, reverse = edge_index_to_csc(edge_index, num_nodes=conv_size, reverse=True)

--- a/models/src/anemoi/models/layers/block.py
+++ b/models/src/anemoi/models/layers/block.py
@@ -542,6 +542,7 @@ class GraphTransformerBaseBlock(BaseBlock, ABC):
             self.edge_pre_mlp = nn.Identity()
 
         self.graph_attention_backend = graph_attention_backend
+        self._attention_backend_applied = False
         self.set_attention_function()
 
     def set_attention_function(self):
@@ -643,9 +644,10 @@ class GraphTransformerBaseBlock(BaseBlock, ABC):
         # self.conv requires size to be a tuple
         conv_size = (size, size) if isinstance(size, int) else size
 
-        # Check at runtime if 'ANEMOI_INFERENCE_GRAPHTRANSFORMER_ATTENTION_BACKEND' env var has been set and update backend if so
-        if ATTENTION_BACKEND != "":
+        # Check once at runtime if 'ANEMOI_INFERENCE_GRAPHTRANSFORMER_ATTENTION_BACKEND' env var has been set and update backend if so
+        if ATTENTION_BACKEND != "" and not self._attention_backend_applied:
             self.set_attention_function()
+            self._attention_backend_applied = True
 
         if self.graph_attention_backend == "triton":
             csc, perm, reverse = edge_index_to_csc(edge_index, num_nodes=conv_size, reverse=True)

--- a/training/docs/user-guide/performance-optimisation.rst
+++ b/training/docs/user-guide/performance-optimisation.rst
@@ -316,6 +316,26 @@ However it requires the 'triton' library to be installed. On AMD systems
 the library is called 'pytorch-triton-rocm'. Triton is not officially
 supported on CPUs.
 
+.. note::
+
+   The attention backend for both the Transformer and GraphTransformer
+   processors can be overridden at runtime using environment variables,
+   without modifying the model config. This is useful when switching
+   backends at inference time.
+
+   .. code:: bash
+
+      # Override the Transformer attention backend
+      export ANEMOI_INFERENCE_TRANSFORMER_ATTENTION_BACKEND='scaled_dot_product_attention'
+
+      # Override the GraphTransformer attention backend
+      export ANEMOI_INFERENCE_GRAPHTRANSFORMER_ATTENTION_BACKEND='pyg'
+
+   The override is applied once on the first forward pass. Valid values
+   are the same as the corresponding config options (e.g.
+   ``flash_attention``, ``scaled_dot_product_attention`` for the
+   Transformer; ``triton``, ``pyg`` for the GraphTransformer).
+
 Compiling
 =========
 


### PR DESCRIPTION
## Summary

- Adds `ANEMOI_INFERENCE_TRANSFORMER_ATTENTION_BACKEND` and `ANEMOI_INFERENCE_GRAPHTRANSFORMER_ATTENTION_BACKEND` environment variables to allow switching attention implementations at inference time without modifying the model config.
- Override is applied once on the first forward pass to avoid per-call overhead.
- Documents the new env vars in the performance optimisation guide.

> [!NOTE]
> Mined from #716 

<!-- readthedocs-preview anemoi-training start -->
----
📚 Documentation preview 📚: https://anemoi-training--1091.org.readthedocs.build/en/1091/

<!-- readthedocs-preview anemoi-training end -->

<!-- readthedocs-preview anemoi-graphs start -->
----
📚 Documentation preview 📚: https://anemoi-graphs--1091.org.readthedocs.build/en/1091/

<!-- readthedocs-preview anemoi-graphs end -->

<!-- readthedocs-preview anemoi-models start -->
----
📚 Documentation preview 📚: https://anemoi-models--1091.org.readthedocs.build/en/1091/

<!-- readthedocs-preview anemoi-models end -->