### PR TITLE
feat: Add support for shared nested configs and optional enc/dec prefixes

### DIFF
--- a/models/docs/usage/create_model.rst
+++ b/models/docs/usage/create_model.rst
@@ -58,6 +58,108 @@ First, let's take the model configuration ``transformer.yaml``:
      - edge_dirs
      nodes: []
 
+.. _multi-dataset-enc-dec:
+
+Multi-Dataset Encoder/Decoder Configuration
+============================================
+
+When training with multiple datasets, each dataset can have its own
+encoder and decoder configuration. This is done by nesting configs
+under dataset-name keys using Hydra's ``@`` package directive.
+
+**Single dataset** (flat config, the default):
+
+.. code:: yaml
+
+   defaults:
+     - encoder: gt16
+     - decoder: gt16
+
+This produces a flat config with ``_target_`` at the top level:
+
+.. code:: yaml
+
+   encoder:
+     _target_: anemoi.models.layers.mapper.GraphTransformerForwardMapper
+     ...
+
+**Multiple datasets** with different encoders/decoders:
+
+.. code:: yaml
+
+   defaults:
+     - encoder@encoder.data: gt16
+     - encoder@encoder.other: gnn
+     - decoder@decoder.data: gt16
+     - decoder@decoder.other: gnn
+
+This produces a dictionary-style config:
+
+.. code:: yaml
+
+   encoder:
+     data:
+       _target_: anemoi.models.layers.mapper.GraphTransformerForwardMapper
+       ...
+     other:
+       _target_: anemoi.models.layers.mapper.GNNForwardMapper
+       ...
+
+The model resolves the correct encoder/decoder for each dataset at
+build time using ``_get_nested_configuration``.
+
+Optional Encoders/Decoders
+--------------------------
+
+In multi-dataset setups, some datasets may not always be present at
+inference time. Prefix the dataset key with ``~`` to mark its
+encoder/decoder as optional:
+
+.. code:: yaml
+
+   defaults:
+     - encoder@encoder.data: gt16
+     - encoder@encoder.~other: gnn
+
+This produces:
+
+.. code:: yaml
+
+   encoder:
+     data:
+       _target_: anemoi.models.layers.mapper.GraphTransformerForwardMapper
+       ...
+     ~other:
+       _target_: anemoi.models.layers.mapper.GNNForwardMapper
+       ...
+
+At forward time, the model validates that all **required** (non-``~``)
+datasets are present in the input batch. Optional datasets may be
+absent without raising an error.
+
+Shared Encoders/Decoders
+------------------------
+
+.. note::
+
+   Shared encoders/decoders are not yet fully supported. The
+   configuration syntax is defined but will raise
+   ``NotImplementedError`` at build time until forward pass support is
+   added.
+
+Multiple datasets can share a single encoder/decoder instance by
+joining their names with ``&``:
+
+.. code:: yaml
+
+   encoder:
+     dataset1&dataset2:
+       _target_: anemoi.models.layers.mapper.GraphTransformerForwardMapper
+       ...
+
+When enabled, the model will instantiate the encoder once and reuse it
+for both datasets.
+
 Typically the model is instantiated in :doc:`Anemoi Training
 <anemoi-training:index>` or :doc:`Anemoi Inference
 <anemoi-inference:index>`. For this example we will load the model

--- a/models/docs/usage/create_model.rst
+++ b/models/docs/usage/create_model.rst
@@ -137,17 +137,34 @@ At forward time, the model validates that all **required** (non-``~``)
 datasets are present in the input batch. Optional datasets may be
 absent without raising an error.
 
-Shared Encoders/Decoders
+Shared Configuration (``,``)
+-----------------------------
+
+Multiple datasets can share the same configuration by joining their
+names with ``,``. Each dataset gets its own independently instantiated
+encoder/decoder, but they share the same config:
+
+.. code:: yaml
+
+   encoder:
+     dataset1,dataset2:
+       _target_: anemoi.models.layers.mapper.GraphTransformerForwardMapper
+       ...
+
+This is equivalent to writing the same config under each dataset key
+individually. Each dataset receives a separate module instance built
+from the shared config.
+
+Shared Instance (``&``)
 ------------------------
 
 .. note::
 
-   Shared encoders/decoders are not yet fully supported. The
-   configuration syntax is defined but will raise
-   ``NotImplementedError`` at build time until forward pass support is
-   added.
+   Shared instances are not yet fully supported. The configuration
+   syntax is defined but will raise ``NotImplementedError`` at build
+   time until forward pass support is added.
 
-Multiple datasets can share a single encoder/decoder instance by
+Multiple datasets can share a single encoder/decoder **instance** by
 joining their names with ``&``:
 
 .. code:: yaml
@@ -157,8 +174,8 @@ joining their names with ``&``:
        _target_: anemoi.models.layers.mapper.GraphTransformerForwardMapper
        ...
 
-When enabled, the model will instantiate the encoder once and reuse it
-for both datasets.
+Unlike ``,``, this instantiates the encoder **once** and reuses the
+same module for both datasets.
 
 Typically the model is instantiated in :doc:`Anemoi Training
 <anemoi-training:index>` or :doc:`Anemoi Inference

--- a/models/src/anemoi/models/migrations/scripts/1777984565_add_enc_dec_flags.py
+++ b/models/src/anemoi/models/migrations/scripts/1777984565_add_enc_dec_flags.py
@@ -1,0 +1,49 @@
+# (C) Copyright 2025 Anemoi contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+from anemoi.models.migrations import CkptType
+from anemoi.models.migrations import MigrationMetadata
+
+# DO NOT CHANGE -->
+metadata = MigrationMetadata(
+    versions={
+        "migration": "1.0.0",
+        "anemoi-models": "%NEXT_ANEMOI_MODELS_VERSION%",
+    },
+)
+# <-- END DO NOT CHANGE
+
+
+def migrate(ckpt: CkptType) -> CkptType:
+    """Migrate the checkpoint.
+
+    Parameters
+    ----------
+    ckpt : CkptType
+        The checkpoint dict.
+
+    Returns
+    -------
+    CkptType
+        The migrated checkpoint dict.
+    """
+
+    all_dataset_names = set()
+    for key in ckpt["state_dict"].keys():
+        if key.startswith("model.model.encoder."):
+            dataset_name = key.split(".")[3]  # model.model.encoder.{dataset_name}.rest.of.key
+            all_dataset_names.add(dataset_name)
+
+    ckpt["state_dict"]["model.model.encoder_flags"] = {
+        dataset_name: {"optional": False} for dataset_name in all_dataset_names
+    }
+    ckpt["state_dict"]["model.model.decoder_flags"] = {
+        dataset_name: {"optional": False} for dataset_name in all_dataset_names
+    }
+    return ckpt

--- a/models/src/anemoi/models/models/autoencoder.py
+++ b/models/src/anemoi/models/models/autoencoder.py
@@ -104,12 +104,12 @@ class AnemoiModelAutoEncoder(AnemoiModelEncProcDec):
 
     def forward(
         self,
-        x: Tensor,
+        x: dict[str, Tensor],
         *,
         model_comm_group: Optional[ProcessGroup] = None,
         grid_shard_shapes: dict[str, Optional[list]] | None = None,
         **kwargs,
-    ) -> Tensor:
+    ) -> dict[str, Tensor]:
         """Forward pass of the model.
 
         Parameters
@@ -123,11 +123,17 @@ class AnemoiModelAutoEncoder(AnemoiModelEncProcDec):
 
         Returns
         -------
-        Tensor
+        dict[str, Tensor]
             Output of the model, with the same shape as the input (sharded if input is sharded)
         """
 
         dataset_names = list(x.keys())
+        self._validate_required(
+            dataset_names, required=list(d[0] for d in self.encoder_flags.items() if not d[1].get("optional", False))
+        )
+        self._validate_required(
+            dataset_names, required=list(d[0] for d in self.decoder_flags.items() if not d[1].get("optional", False))
+        )
 
         # Extract and validate batch & ensemble sizes across datasets
         batch_size = self._get_consistent_dim(x, 0)

--- a/models/src/anemoi/models/models/base.py
+++ b/models/src/anemoi/models/models/base.py
@@ -368,7 +368,13 @@ class BaseGraphModel(nn.Module):
                 )
             # if key in self.residual:
             #     continue # Residual already built for this dataset (e.g., shared residual), skip to avoid overwriting
-            self.residual[dataset_name] = instantiate(config, graph=self._graph_data)
+            self.residual[dataset_name] = instantiate(
+                config,
+                graph=self._graph_data,
+                statistics=self.statistics[dataset_name],
+                data_indices=self.data_indices[dataset_name],
+                dataset_name=dataset_name,
+            )
 
     @abstractmethod
     def forward(

--- a/models/src/anemoi/models/models/base.py
+++ b/models/src/anemoi/models/models/base.py
@@ -238,6 +238,9 @@ class BaseGraphModel(nn.Module):
         """Extract a nested configuration for a specific dataset if the config is provided in a multi-dataset format.
         If not provided in a multi-dataset format, return the base config.
 
+        Use `&` for objects shared across datasets (e.g., "dataset1&dataset2") and the dataset name as the key for dataset-specific configs.
+        Use `,` for configs shared across datasets.
+
         The key can be used to maintain the association, particuarly for the shared use case.
         For `dict`'s built with this, use `self._get_from_dict_with_and` to retrieve the correct value based on the dataset name.
 
@@ -260,6 +263,13 @@ class BaseGraphModel(nn.Module):
         3) Multi-dataset config with '&' in keys (e.g., "dataset1&dataset2"):
             ```
             dataset1&dataset2:
+                _target_: SomeClass
+                param1: value1
+                param2: value2
+            ```
+        4) Multi-dataset config with ',' in keys (e.g., "dataset1,dataset2"):
+            ```
+            dataset1,dataset2:
                 _target_: SomeClass
                 param1: value1
                 param2: value2
@@ -334,6 +344,13 @@ class BaseGraphModel(nn.Module):
                 )
                 _assert_is_valid_nested_config(config[key])
                 return key, config[key], prefix_flags
+
+        # Check for multi-dataset config with ',' in keys, e.g., "dataset1,dataset2"
+        for key in (k for k in config.keys() if "," in k):
+            _, prefix_flags = equals_with_mapping(key, dataset_name)
+            if any(equals_with_mapping(part, dataset_name)[0] for part in key.split(",")):
+                _assert_is_valid_nested_config(config[key])
+                return dataset_name, config[key], prefix_flags
 
         raise ValueError(
             f"Could not find a valid configuration for dataset '{dataset_name}'. Expected either a direct config with '_target_' or a nested config under key '{dataset_name}' or keys containing '{dataset_name}' separated by '&'. Got config: {config}"

--- a/models/src/anemoi/models/models/base.py
+++ b/models/src/anemoi/models/models/base.py
@@ -33,6 +33,11 @@ from anemoi.utils.config import DotDict
 LOGGER = logging.getLogger(__name__)
 T = TypeVar("T")
 
+PREFIX_TO_MEANING = {
+    "~": "optional",
+    # "!": "required", # Default is required, so no need for a prefix to indicate this, but can be added if desired for clarity
+}
+
 
 class BaseGraphModel(nn.Module):
     """Message passing graph neural network."""
@@ -227,7 +232,9 @@ class BaseGraphModel(nn.Module):
                 return container[k]
         raise KeyError(f"Key '{key}' not found in container with keys {list(container.keys())}")
 
-    def _get_nested_configuration(self, config: DotDict, dataset_name: str) -> tuple[str, DotDict]:
+    def _get_nested_configuration(
+        self, config: DotDict, dataset_name: str, *, prefix_mapping: dict[str, T] | None = None
+    ) -> tuple[str, DotDict, dict[T, bool]]:
         """Extract a nested configuration for a specific dataset if the config is provided in a multi-dataset format.
         If not provided in a multi-dataset format, return the base config.
 
@@ -264,11 +271,21 @@ class BaseGraphModel(nn.Module):
             The configuration dictionary, potentially containing nested configurations for multiple datasets.
         dataset_name : str
             The name of the dataset for which to extract the configuration.
+        prefix_mapping : dict[str, T], optional
+            Optional mapping to translate prefixes in the nested config name to semantic meaning
+            based on the dictionary values, returned the 3rd element as a dict of booleans of
+            if present in the key.
+
+            Only works for multi-dataset configs, either with individual dataset keys or shared keys with '&'.
+                For example, with `{"~": "optional"}`, a config key of "~dataset1" would indicate that the
+                configuration is optional for dataset1, and the returned dictionary would contain
+                {"optional": True} for that dataset.
 
         Returns
         -------
-        tuple[str, DotDict]
-            A tuple containing the key found for the config, and the corresponding configuration dictionary.
+        tuple[str, DotDict, dict[T, bool]]
+            A tuple containing the key found for the config, the corresponding configuration dictionary,
+            and a dictionary of booleans indicating the presence of each prefix in the key.
 
         Raises
         ------
@@ -283,7 +300,17 @@ class BaseGraphModel(nn.Module):
 
         # Early return for direct instantiation
         if "_target_" in config:
-            return dataset_name, config
+            return dataset_name, config, {}
+
+        def equals_with_mapping(key: str, target_key: str) -> tuple[bool, dict[T, bool]]:
+            """Check if the key matches the target key after removing any prefixes defined in the prefix_mapping."""
+            prefix_flags = {v: False for v in (prefix_mapping.values() if prefix_mapping else [])}
+            if prefix_mapping:
+                for prefix, meaning in prefix_mapping.items():
+                    if key.startswith(prefix):
+                        key = key[len(prefix) :]
+                        prefix_flags[meaning] = True
+            return key == target_key, prefix_flags
 
         def _assert_is_valid_nested_config(nested_config: Any) -> None:
             if not isinstance(nested_config, dict) or "_target_" not in nested_config:
@@ -292,22 +319,31 @@ class BaseGraphModel(nn.Module):
                 )
 
         # Check for nested config under key matching the dataset name
-        if dataset_name in config:
-            _assert_is_valid_nested_config(config[dataset_name])
-            return dataset_name, config[dataset_name]
+        for key in config.keys():
+            equal, prefix_flags = equals_with_mapping(key, dataset_name)
+            if equal:
+                _assert_is_valid_nested_config(config[key])
+                return key, config[key], prefix_flags
 
         # Check for multi-dataset config with '&' in keys, e.g., "dataset1&dataset2"
         for key in (k for k in config.keys() if "&" in k):
-            if dataset_name in key.split("&"):
+            _, prefix_flags = equals_with_mapping(key, dataset_name)
+            if any(equals_with_mapping(part, dataset_name)[0] for part in key.split("&")):
                 raise NotImplementedError(  # Temporary: Disallow shared blocks until supported in the forward pass
                     f"Shared configurations for multiple datasets (e.g., with keys like 'dataset1&dataset2') are not yet implemented. Found key '{key}' for dataset '{dataset_name}'."
                 )
                 _assert_is_valid_nested_config(config[key])
-                return key, config[key]
+                return key, config[key], prefix_flags
 
         raise ValueError(
             f"Could not find a valid configuration for dataset '{dataset_name}'. Expected either a direct config with '_target_' or a nested config under key '{dataset_name}' or keys containing '{dataset_name}' separated by '&'. Got config: {config}"
         )
+
+    def _validate_required(self, keys: list[str], required: list[str]) -> None:
+        """Helper function to validate that all required keys are present in the list of keys."""
+        missing = set(required) - set(keys)
+        if missing:
+            raise ValueError(f"Missing required keys: {missing}. Found keys: {keys}")
 
     @abstractmethod
     def _build_networks(self, model_config: DotDict) -> None:
@@ -325,7 +361,7 @@ class BaseGraphModel(nn.Module):
     def _build_residual(self, residual_config: DotDict) -> None:
         self.residual = torch.nn.ModuleDict()
         for dataset_name in self.dataset_names:
-            key, config = self._get_nested_configuration(residual_config, dataset_name)
+            key, config, _ = self._get_nested_configuration(residual_config, dataset_name)
             if "&" in key:
                 raise NotImplementedError(
                     f"Shared residual configurations for multiple datasets (e.g., with keys like 'dataset1&dataset2') are not yet implemented. Found key '{key}' for dataset '{dataset_name}'."

--- a/models/src/anemoi/models/models/base.py
+++ b/models/src/anemoi/models/models/base.py
@@ -10,7 +10,9 @@
 
 import logging
 from abc import abstractmethod
+from typing import Any
 from typing import Optional
+from typing import TypeVar
 
 import torch
 from hydra.utils import instantiate
@@ -29,6 +31,7 @@ from anemoi.models.utils.config import broadcast_config_keys
 from anemoi.utils.config import DotDict
 
 LOGGER = logging.getLogger(__name__)
+T = TypeVar("T")
 
 
 class BaseGraphModel(nn.Module):
@@ -212,27 +215,98 @@ class BaseGraphModel(nn.Module):
 
         return dim_sizes[0]
 
-    def _get_nested_configuration(self, config: DotDict, dataset_name: str) -> DotDict:
+    def _get_from_dict_with_and(self, container: dict[str, T] | nn.ModuleDict, key: str) -> T | nn.Module:
+        """Helper function to get a value from a dictionary where keys can be in the format 'dataset1&dataset2'.
+
+        Will first look for the exact key, then look for keys containing '&' and check if the key is part of the split keys.
+        """
+        if key in container:
+            return container[key]
+        for k in container.keys():
+            if "&" in k and key in k.split("&"):
+                return container[k]
+        raise KeyError(f"Key '{key}' not found in container with keys {list(container.keys())}")
+
+    def _get_nested_configuration(self, config: DotDict, dataset_name: str) -> tuple[str, DotDict]:
         """Extract a nested configuration for a specific dataset if the config is provided in a multi-dataset format.
         If not provided in a multi-dataset format, return the base config.
 
-        Expects `_target_` key to be present in the final config for instantiation.
+        The key can be used to maintain the association, particuarly for the shared use case.
+        For `dict`'s built with this, use `self._get_from_dict_with_and` to retrieve the correct value based on the dataset name.
+
+        Examples
+        --------
+        Examples of valid config formats for a dataset named 'dataset1':
+        1) Direct config with '_target_':
+            ```
+            _target_: SomeClass
+            param1: value1
+            param2: value2
+            ```
+        2) Nested config under key matching the dataset name:
+            ```
+            dataset1:
+                _target_: SomeClass
+                param1: value1
+                param2: value2
+            ```
+        3) Multi-dataset config with '&' in keys (e.g., "dataset1&dataset2"):
+            ```
+            dataset1&dataset2:
+                _target_: SomeClass
+                param1: value1
+                param2: value2
+            ```
+
+        Parameters
+        ----------
+        config : DotDict
+            The configuration dictionary, potentially containing nested configurations for multiple datasets.
+        dataset_name : str
+            The name of the dataset for which to extract the configuration.
+
+        Returns
+        -------
+        tuple[str, DotDict]
+            A tuple containing the key found for the config, and the corresponding configuration dictionary.
+
+        Raises
+        ------
+        ValueError
+            If the dataset-specific configuration is not a dictionary with a '_target_' key.
+        ValueError
+            If no valid configuration is found for the specified dataset.
         """
         assert (
             dataset_name in self.dataset_names
         ), f"Dataset name '{dataset_name}' not found in model's dataset names {self.dataset_names}"
 
-        if dataset_name in config and isinstance(config[dataset_name], dict):
-            if "_target_" not in config[dataset_name]:
-                raise ValueError(
-                    f"Dataset-specific configuration for '{dataset_name}' must contain a '_target_' key for instantiation."
-                )
-            return config[dataset_name]
-
+        # Early return for direct instantiation
         if "_target_" in config:
-            return config
+            return dataset_name, config
+
+        def _assert_is_valid_nested_config(nested_config: Any) -> None:
+            if not isinstance(nested_config, dict) or "_target_" not in nested_config:
+                raise ValueError(
+                    f"Dataset-specific configuration for '{dataset_name}' must be a dict with '_target_' key, got {type(nested_config)}: {nested_config}."
+                )
+
+        # Check for nested config under key matching the dataset name
+        if dataset_name in config:
+            _assert_is_valid_nested_config(config[dataset_name])
+            return dataset_name, config[dataset_name]
+
+        # Check for multi-dataset config with '&' in keys, e.g., "dataset1&dataset2"
+        for key in (k for k in config.keys() if "&" in k):
+            if dataset_name in key.split("&"):
+                raise NotImplementedError(  # Temporary: Disallow shared blocks until supported in the forward pass
+                    f"Shared configurations for multiple datasets (e.g., with keys like 'dataset1&dataset2') are not yet implemented. Found key '{key}' for dataset '{dataset_name}'."
+                )
+                _assert_is_valid_nested_config(config[key])
+                return key, config[key]
+
         raise ValueError(
-            f"Configuration for dataset '{dataset_name}' is not properly specified. Expected either a multi-dataset config for each dataset or a base config with a '_target_' key."
+            f"Could not find a valid configuration for dataset '{dataset_name}'. Expected either a direct config with '_target_' or a nested config under key '{dataset_name}' or keys containing '{dataset_name}' separated by '&'. Got config: {config}"
         )
 
     @abstractmethod
@@ -251,13 +325,14 @@ class BaseGraphModel(nn.Module):
     def _build_residual(self, residual_config: DotDict) -> None:
         self.residual = torch.nn.ModuleDict()
         for dataset_name in self.dataset_names:
-            self.residual[dataset_name] = instantiate(
-                self._get_nested_configuration(residual_config, dataset_name),
-                graph=self._graph_data,
-                statistics=self.statistics[dataset_name],
-                data_indices=self.data_indices[dataset_name],
-                dataset_name=dataset_name,
-            )
+            key, config = self._get_nested_configuration(residual_config, dataset_name)
+            if "&" in key:
+                raise NotImplementedError(
+                    f"Shared residual configurations for multiple datasets (e.g., with keys like 'dataset1&dataset2') are not yet implemented. Found key '{key}' for dataset '{dataset_name}'."
+                )
+            # if key in self.residual:
+            #     continue # Residual already built for this dataset (e.g., shared residual), skip to avoid overwriting
+            self.residual[dataset_name] = instantiate(config, graph=self._graph_data)
 
     @abstractmethod
     def forward(

--- a/models/src/anemoi/models/models/base.py
+++ b/models/src/anemoi/models/models/base.py
@@ -300,7 +300,7 @@ class BaseGraphModel(nn.Module):
 
         # Early return for direct instantiation
         if "_target_" in config:
-            return dataset_name, config, {}
+            return dataset_name, config, {v: False for v in (prefix_mapping.values() if prefix_mapping else [])}
 
         def equals_with_mapping(key: str, target_key: str) -> tuple[bool, dict[T, bool]]:
             """Check if the key matches the target key after removing any prefixes defined in the prefix_mapping."""

--- a/models/src/anemoi/models/models/diffusion_encoder_processor_decoder.py
+++ b/models/src/anemoi/models/models/diffusion_encoder_processor_decoder.py
@@ -77,7 +77,7 @@ class AnemoiDiffusionModelEncProcDec(BaseGraphModel):
         self.encoder_graph_provider = torch.nn.ModuleDict()
         self.encoder = torch.nn.ModuleDict()
         for dataset_name in self.dataset_names:
-            sub_encoder_config = self._get_nested_configuration(model_config.model.encoder, dataset_name)
+            key, sub_encoder_config = self._get_nested_configuration(model_config.model.encoder, dataset_name)
 
             # Create graph providers
             self.encoder_graph_provider[dataset_name] = create_graph_provider(
@@ -88,7 +88,10 @@ class AnemoiDiffusionModelEncProcDec(BaseGraphModel):
                 trainable_size=sub_encoder_config.get("trainable_size", 0),
             )
 
-            self.encoder[dataset_name] = instantiate(
+            if key in self.encoder:
+                continue  # Encoder already built for this dataset (e.g., shared encoder), skip to avoid overwriting
+
+            self.encoder[key] = instantiate(
                 sub_encoder_config,
                 _recursive_=False,  # Avoids instantiation of layer_kernels here
                 in_channels_src=self.input_dim[dataset_name],
@@ -117,7 +120,7 @@ class AnemoiDiffusionModelEncProcDec(BaseGraphModel):
         self.decoder_graph_provider = torch.nn.ModuleDict()
         self.decoder = torch.nn.ModuleDict()
         for dataset_name in self.dataset_names:
-            sub_decoder_config = self._get_nested_configuration(model_config.model.decoder, dataset_name)
+            key, sub_decoder_config = self._get_nested_configuration(model_config.model.decoder, dataset_name)
 
             self.decoder_graph_provider[dataset_name] = create_graph_provider(
                 graph=self._graph_data[(self._graph_name_hidden, "to", dataset_name)],
@@ -126,7 +129,11 @@ class AnemoiDiffusionModelEncProcDec(BaseGraphModel):
                 dst_size=self.node_attributes.num_nodes[dataset_name],
                 trainable_size=sub_decoder_config.get("trainable_size", 0),
             )
-            self.decoder[dataset_name] = instantiate(
+
+            if key in self.decoder:
+                continue  # Decoder already built for this dataset (e.g., shared decoder), skip to avoid overwriting
+
+            self.decoder[key] = instantiate(
                 sub_decoder_config,
                 _recursive_=False,  # Avoids instantiation of layer_kernels here
                 in_channels_src=self.num_channels,

--- a/models/src/anemoi/models/models/diffusion_encoder_processor_decoder.py
+++ b/models/src/anemoi/models/models/diffusion_encoder_processor_decoder.py
@@ -27,6 +27,7 @@ from anemoi.models.distributed.shapes import apply_shard_shapes
 from anemoi.models.distributed.shapes import get_or_apply_shard_shapes
 from anemoi.models.distributed.shapes import get_shard_shapes
 from anemoi.models.layers.graph_provider import create_graph_provider
+from anemoi.models.models.base import PREFIX_TO_MEANING
 from anemoi.models.models.base import BaseGraphModel
 from anemoi.models.preprocessing import StepwiseProcessors
 from anemoi.models.samplers import diffusion_samplers
@@ -76,8 +77,14 @@ class AnemoiDiffusionModelEncProcDec(BaseGraphModel):
         # Encoder data -> hidden
         self.encoder_graph_provider = torch.nn.ModuleDict()
         self.encoder = torch.nn.ModuleDict()
+        self.encoder_flags = {}
         for dataset_name in self.dataset_names:
-            key, sub_encoder_config = self._get_nested_configuration(model_config.model.encoder, dataset_name)
+            key, sub_encoder_config, prefix_flags = self._get_nested_configuration(
+                model_config.model.encoder, dataset_name, prefix_mapping=PREFIX_TO_MEANING
+            )
+
+            if not prefix_flags["optional"]:
+                prefix_flags["required"] = True  # Mark as required if not explicitly marked as optional
 
             # Create graph providers
             self.encoder_graph_provider[dataset_name] = create_graph_provider(
@@ -87,6 +94,8 @@ class AnemoiDiffusionModelEncProcDec(BaseGraphModel):
                 dst_size=self.node_attributes.num_nodes[self._graph_name_hidden],
                 trainable_size=sub_encoder_config.get("trainable_size", 0),
             )
+
+            self.encoder_flags[dataset_name] = prefix_flags
 
             if key in self.encoder:
                 continue  # Encoder already built for this dataset (e.g., shared encoder), skip to avoid overwriting
@@ -119,8 +128,15 @@ class AnemoiDiffusionModelEncProcDec(BaseGraphModel):
         # Decoder hidden -> data
         self.decoder_graph_provider = torch.nn.ModuleDict()
         self.decoder = torch.nn.ModuleDict()
+        self.decoder_flags = {}
+
         for dataset_name in self.dataset_names:
-            key, sub_decoder_config = self._get_nested_configuration(model_config.model.decoder, dataset_name)
+            key, sub_decoder_config, prefix_flags = self._get_nested_configuration(
+                model_config.model.decoder, dataset_name, prefix_mapping=PREFIX_TO_MEANING
+            )
+
+            if not prefix_flags["optional"]:
+                prefix_flags["required"] = True  # Mark as required if not explicitly marked as optional
 
             self.decoder_graph_provider[dataset_name] = create_graph_provider(
                 graph=self._graph_data[(self._graph_name_hidden, "to", dataset_name)],
@@ -129,6 +145,8 @@ class AnemoiDiffusionModelEncProcDec(BaseGraphModel):
                 dst_size=self.node_attributes.num_nodes[dataset_name],
                 trainable_size=sub_decoder_config.get("trainable_size", 0),
             )
+
+            self.decoder_flags[dataset_name] = prefix_flags
 
             if key in self.decoder:
                 continue  # Decoder already built for this dataset (e.g., shared decoder), skip to avoid overwriting
@@ -319,6 +337,12 @@ class AnemoiDiffusionModelEncProcDec(BaseGraphModel):
     ) -> torch.Tensor:
         # Multi-dataset case
         dataset_names = list(x.keys())
+        self._validate_required(
+            dataset_names, required=list(d[0] for d in self.encoder_flags.items() if not d[1].get("optional", False))
+        )
+        self._validate_required(
+            dataset_names, required=list(d[0] for d in self.decoder_flags.items() if not d[1].get("optional", False))
+        )
 
         # Extract and validate batch & ensemble sizes across datasets
         batch_size = self._get_consistent_dim(x, 0)

--- a/models/src/anemoi/models/models/encoder_processor_decoder.py
+++ b/models/src/anemoi/models/models/encoder_processor_decoder.py
@@ -21,7 +21,8 @@ from anemoi.models.distributed.graph import shard_tensor
 from anemoi.models.distributed.shapes import get_or_apply_shard_shapes
 from anemoi.models.distributed.shapes import get_shard_shapes
 from anemoi.models.layers.graph_provider import create_graph_provider
-from anemoi.models.models import BaseGraphModel
+from anemoi.models.models.base import PREFIX_TO_MEANING
+from anemoi.models.models.base import BaseGraphModel
 from anemoi.utils.config import DotDict
 
 LOGGER = logging.getLogger(__name__)
@@ -35,9 +36,14 @@ class AnemoiModelEncProcDec(BaseGraphModel):
         # Encoder data -> hidden
         self.encoder_graph_provider = torch.nn.ModuleDict()
         self.encoder = torch.nn.ModuleDict()
+        self.encoder_flags = {}
 
         for dataset_name in self.dataset_names:
-            key, sub_encoder_config = self._get_nested_configuration(model_config.model.encoder, dataset_name)
+            key, sub_encoder_config, prefix_flags = self._get_nested_configuration(
+                model_config.model.encoder, dataset_name, prefix_mapping=PREFIX_TO_MEANING
+            )
+            if not prefix_flags["optional"]:
+                prefix_flags["required"] = True  # Mark as required if not explicitly marked as optional
 
             # Create graph providers
             self.encoder_graph_provider[dataset_name] = create_graph_provider(
@@ -47,6 +53,8 @@ class AnemoiModelEncProcDec(BaseGraphModel):
                 dst_size=self.node_attributes.num_nodes[self._graph_name_hidden],
                 trainable_size=sub_encoder_config.get("trainable_size", 0),
             )
+
+            self.encoder_flags[dataset_name] = prefix_flags
 
             if key in self.encoder:
                 continue  # Encoder already built for this dataset (e.g., shared encoder), skip to avoid overwriting
@@ -79,8 +87,15 @@ class AnemoiModelEncProcDec(BaseGraphModel):
         # Decoder hidden -> data
         self.decoder_graph_provider = torch.nn.ModuleDict()
         self.decoder = torch.nn.ModuleDict()
+        self.decoder_flags = {}
+
         for dataset_name in self.dataset_names:
-            key, sub_decoder_config = self._get_nested_configuration(model_config.model.decoder, dataset_name)
+            key, sub_decoder_config, prefix_flags = self._get_nested_configuration(
+                model_config.model.decoder, dataset_name, prefix_mapping=PREFIX_TO_MEANING
+            )
+
+            if not prefix_flags["optional"]:
+                prefix_flags["required"] = True  # Mark as required if not explicitly marked as optional
 
             # Create graph providers
             self.decoder_graph_provider[dataset_name] = create_graph_provider(
@@ -90,6 +105,8 @@ class AnemoiModelEncProcDec(BaseGraphModel):
                 dst_size=self.node_attributes.num_nodes[dataset_name],
                 trainable_size=sub_decoder_config.get("trainable_size", 0),
             )
+
+            self.decoder_flags[dataset_name] = prefix_flags
 
             if key in self.decoder:
                 continue  # Decoder already built for this dataset (e.g., shared decoder), skip to avoid overwriting
@@ -222,6 +239,12 @@ class AnemoiModelEncProcDec(BaseGraphModel):
             Output of the model, with the same shape as the input (sharded if input is sharded)
         """
         dataset_names = list(x.keys())
+        self._validate_required(
+            dataset_names, required=list(d[0] for d in self.encoder_flags.items() if not d[1].get("optional", False))
+        )
+        self._validate_required(
+            dataset_names, required=list(d[0] for d in self.decoder_flags.items() if not d[1].get("optional", False))
+        )
 
         # Extract and validate batch & ensemble sizes across datasets
         batch_size = self._get_consistent_dim(x, 0)

--- a/models/src/anemoi/models/models/encoder_processor_decoder.py
+++ b/models/src/anemoi/models/models/encoder_processor_decoder.py
@@ -35,8 +35,9 @@ class AnemoiModelEncProcDec(BaseGraphModel):
         # Encoder data -> hidden
         self.encoder_graph_provider = torch.nn.ModuleDict()
         self.encoder = torch.nn.ModuleDict()
+
         for dataset_name in self.dataset_names:
-            sub_encoder_config = self._get_nested_configuration(model_config.model.encoder, dataset_name)
+            key, sub_encoder_config = self._get_nested_configuration(model_config.model.encoder, dataset_name)
 
             # Create graph providers
             self.encoder_graph_provider[dataset_name] = create_graph_provider(
@@ -47,7 +48,10 @@ class AnemoiModelEncProcDec(BaseGraphModel):
                 trainable_size=sub_encoder_config.get("trainable_size", 0),
             )
 
-            self.encoder[dataset_name] = instantiate(
+            if key in self.encoder:
+                continue  # Encoder already built for this dataset (e.g., shared encoder), skip to avoid overwriting
+
+            self.encoder[key] = instantiate(
                 sub_encoder_config,
                 _recursive_=False,  # Avoids instantiation of layer_kernels here
                 in_channels_src=self.input_dim[dataset_name],
@@ -76,7 +80,7 @@ class AnemoiModelEncProcDec(BaseGraphModel):
         self.decoder_graph_provider = torch.nn.ModuleDict()
         self.decoder = torch.nn.ModuleDict()
         for dataset_name in self.dataset_names:
-            sub_decoder_config = self._get_nested_configuration(model_config.model.decoder, dataset_name)
+            key, sub_decoder_config = self._get_nested_configuration(model_config.model.decoder, dataset_name)
 
             # Create graph providers
             self.decoder_graph_provider[dataset_name] = create_graph_provider(
@@ -87,7 +91,10 @@ class AnemoiModelEncProcDec(BaseGraphModel):
                 trainable_size=sub_decoder_config.get("trainable_size", 0),
             )
 
-            self.decoder[dataset_name] = instantiate(
+            if key in self.decoder:
+                continue  # Decoder already built for this dataset (e.g., shared decoder), skip to avoid overwriting
+
+            self.decoder[key] = instantiate(
                 sub_decoder_config,
                 _recursive_=False,  # Avoids instantiation of layer_kernels here
                 in_channels_src=self.num_channels,

--- a/models/src/anemoi/models/models/ens_encoder_processor_decoder.py
+++ b/models/src/anemoi/models/models/ens_encoder_processor_decoder.py
@@ -181,6 +181,12 @@ class AnemoiEnsModelEncProcDec(AnemoiModelEncProcDec):
             Output tensor
         """
         dataset_names = list(x.keys())
+        self._validate_required(
+            dataset_names, required=list(d[0] for d in self.encoder_flags.items() if not d[1].get("optional", False))
+        )
+        self._validate_required(
+            dataset_names, required=list(d[0] for d in self.decoder_flags.items() if not d[1].get("optional", False))
+        )
 
         # Extract and validate batch & ensemble sizes across datasets
         batch_size = self._get_consistent_dim(x, 0)

--- a/models/src/anemoi/models/models/hierarchical.py
+++ b/models/src/anemoi/models/models/hierarchical.py
@@ -19,6 +19,7 @@ from torch.distributed.distributed_c10d import ProcessGroup
 from anemoi.models.distributed.shapes import get_shard_shapes
 from anemoi.models.layers.graph_provider import create_graph_provider
 from anemoi.models.models import AnemoiModelEncProcDec
+from anemoi.models.models.base import PREFIX_TO_MEANING
 
 LOGGER = logging.getLogger(__name__)
 
@@ -36,8 +37,15 @@ class AnemoiModelEncProcDecHierarchical(AnemoiModelEncProcDec):
         # Encoder data -> hidden
         self.encoder_graph_provider = nn.ModuleDict()
         self.encoder = torch.nn.ModuleDict()
+        self.encoder_flags = {}
         for dataset_name in self.dataset_names:
-            key, sub_encoder_config = self._get_nested_configuration(model_config.model.encoder, dataset_name)
+            key, sub_encoder_config, prefix_flags = self._get_nested_configuration(
+                model_config.model.encoder, dataset_name, prefix_mapping=PREFIX_TO_MEANING
+            )
+            if not prefix_flags["optional"]:
+                prefix_flags["required"] = True  # Mark as required if not explicitly marked as optional
+
+            self.encoder_flags[dataset_name] = prefix_flags
 
             self.encoder_graph_provider[dataset_name] = create_graph_provider(
                 graph=self._graph_data[(dataset_name, "to", self._graph_name_hidden[0])],
@@ -128,7 +136,7 @@ class AnemoiModelEncProcDecHierarchical(AnemoiModelEncProcDec):
             src_nodes_name = self._graph_name_hidden[i]
             dst_nodes_name = self._graph_name_hidden[i + 1]
 
-            key, sub_downscale_config = self._get_nested_configuration(model_config.model.encoder, src_nodes_name)
+            key, sub_downscale_config, _ = self._get_nested_configuration(model_config.model.encoder, src_nodes_name)
             if key in self.downscale:
                 raise ValueError(
                     f"Downscale module for hidden node {src_nodes_name} is already defined. Please check your configuration for duplicate entries."
@@ -158,7 +166,7 @@ class AnemoiModelEncProcDecHierarchical(AnemoiModelEncProcDec):
             src_nodes_name = self._graph_name_hidden[i]
             dst_nodes_name = self._graph_name_hidden[i - 1]
 
-            key, sub_upscale_config = self._get_nested_configuration(model_config.model.decoder, src_nodes_name)
+            key, sub_upscale_config, _ = self._get_nested_configuration(model_config.model.decoder, src_nodes_name)
             if key in self.upscale:
                 raise ValueError(
                     f"Upscale module for hidden node {src_nodes_name} is already defined. Please check your configuration for duplicate entries."
@@ -185,8 +193,15 @@ class AnemoiModelEncProcDecHierarchical(AnemoiModelEncProcDec):
         # Decoder hidden -> data
         self.decoder_graph_provider = nn.ModuleDict()
         self.decoder = torch.nn.ModuleDict()
+        self.decoder_flags = {}
         for dataset_name in self.dataset_names:
-            key, sub_decoder_config = self._get_nested_configuration(model_config.model.decoder, dataset_name)
+            key, sub_decoder_config, prefix_flags = self._get_nested_configuration(
+                model_config.model.decoder, dataset_name, prefix_mapping=PREFIX_TO_MEANING
+            )
+            if not prefix_flags["optional"]:
+                prefix_flags["required"] = True  # Mark as required if not explicitly marked as optional
+
+            self.decoder_flags[dataset_name] = prefix_flags
 
             self.decoder_graph_provider[dataset_name] = create_graph_provider(
                 graph=self._graph_data[(self._graph_name_hidden[0], "to", dataset_name)],
@@ -233,6 +248,12 @@ class AnemoiModelEncProcDecHierarchical(AnemoiModelEncProcDec):
             Output of the model, with the same shape as the input (sharded if input is sharded)
         """
         dataset_names = list(x.keys())
+        self._validate_required(
+            dataset_names, required=list(d[0] for d in self.encoder_flags.items() if not d[1].get("optional", False))
+        )
+        self._validate_required(
+            dataset_names, required=list(d[0] for d in self.decoder_flags.items() if not d[1].get("optional", False))
+        )
 
         # Extract and validate batch & ensemble sizes across datasets
         batch_size = self._get_consistent_dim(x, 0)

--- a/models/src/anemoi/models/models/hierarchical.py
+++ b/models/src/anemoi/models/models/hierarchical.py
@@ -37,7 +37,7 @@ class AnemoiModelEncProcDecHierarchical(AnemoiModelEncProcDec):
         self.encoder_graph_provider = nn.ModuleDict()
         self.encoder = torch.nn.ModuleDict()
         for dataset_name in self.dataset_names:
-            sub_encoder_config = self._get_nested_configuration(model_config.model.encoder, dataset_name)
+            key, sub_encoder_config = self._get_nested_configuration(model_config.model.encoder, dataset_name)
 
             self.encoder_graph_provider[dataset_name] = create_graph_provider(
                 graph=self._graph_data[(dataset_name, "to", self._graph_name_hidden[0])],
@@ -47,7 +47,10 @@ class AnemoiModelEncProcDecHierarchical(AnemoiModelEncProcDec):
                 trainable_size=sub_encoder_config.get("trainable_size", 0),
             )
 
-            self.encoder[dataset_name] = instantiate(
+            if key in self.encoder:
+                continue  # Encoder already built for this dataset (e.g., shared encoder), skip to avoid overwriting
+
+            self.encoder[key] = instantiate(
                 sub_encoder_config,
                 _recursive_=False,  # Avoids instantiation of layer_kernels here
                 in_channels_src=self.input_dim[dataset_name],
@@ -125,7 +128,11 @@ class AnemoiModelEncProcDecHierarchical(AnemoiModelEncProcDec):
             src_nodes_name = self._graph_name_hidden[i]
             dst_nodes_name = self._graph_name_hidden[i + 1]
 
-            sub_downscale_config = self._get_nested_configuration(model_config.model.encoder, src_nodes_name)
+            key, sub_downscale_config = self._get_nested_configuration(model_config.model.encoder, src_nodes_name)
+            if key in self.downscale:
+                raise ValueError(
+                    f"Downscale module for hidden node {src_nodes_name} is already defined. Please check your configuration for duplicate entries."
+                )
 
             self.downscale_graph_providers[src_nodes_name] = create_graph_provider(
                 graph=self._graph_data[(src_nodes_name, "to", dst_nodes_name)],
@@ -151,7 +158,11 @@ class AnemoiModelEncProcDecHierarchical(AnemoiModelEncProcDec):
             src_nodes_name = self._graph_name_hidden[i]
             dst_nodes_name = self._graph_name_hidden[i - 1]
 
-            sub_upscale_config = self._get_nested_configuration(model_config.model.decoder, src_nodes_name)
+            key, sub_upscale_config = self._get_nested_configuration(model_config.model.decoder, src_nodes_name)
+            if key in self.upscale:
+                raise ValueError(
+                    f"Upscale module for hidden node {src_nodes_name} is already defined. Please check your configuration for duplicate entries."
+                )
 
             self.upscale_graph_providers[src_nodes_name] = create_graph_provider(
                 graph=self._graph_data[(src_nodes_name, "to", dst_nodes_name)],
@@ -175,7 +186,7 @@ class AnemoiModelEncProcDecHierarchical(AnemoiModelEncProcDec):
         self.decoder_graph_provider = nn.ModuleDict()
         self.decoder = torch.nn.ModuleDict()
         for dataset_name in self.dataset_names:
-            sub_decoder_config = self._get_nested_configuration(model_config.model.decoder, dataset_name)
+            key, sub_decoder_config = self._get_nested_configuration(model_config.model.decoder, dataset_name)
 
             self.decoder_graph_provider[dataset_name] = create_graph_provider(
                 graph=self._graph_data[(self._graph_name_hidden[0], "to", dataset_name)],
@@ -185,7 +196,10 @@ class AnemoiModelEncProcDecHierarchical(AnemoiModelEncProcDec):
                 trainable_size=sub_decoder_config.get("trainable_size", 0),
             )
 
-            self.decoder[dataset_name] = instantiate(
+            if key in self.decoder:
+                continue  # Decoder already built for this dataset (e.g., shared decoder), skip to avoid overwriting
+
+            self.decoder[key] = instantiate(
                 sub_decoder_config,
                 _recursive_=False,  # Avoids instantiation of layer_kernels here
                 in_channels_src=self.hidden_dims[self._graph_name_hidden[0]],

--- a/models/src/anemoi/models/models/hierarchical_autoencoder.py
+++ b/models/src/anemoi/models/models/hierarchical_autoencoder.py
@@ -95,7 +95,7 @@ class AnemoiModelHierarchicalAutoEncoder(AnemoiModelAutoEncoder):
         self.encoder_graph_provider = nn.ModuleDict()
         self.encoder = torch.nn.ModuleDict()
         for dataset_name in self.dataset_names:
-            sub_encoder_config = self._get_nested_configuration(model_config.model.encoder, dataset_name)
+            key, sub_encoder_config = self._get_nested_configuration(model_config.model.encoder, dataset_name)
 
             self.encoder_graph_provider[dataset_name] = create_graph_provider(
                 graph=self._graph_data[(dataset_name, "to", self._graph_name_hidden[0])],
@@ -104,7 +104,11 @@ class AnemoiModelHierarchicalAutoEncoder(AnemoiModelAutoEncoder):
                 dst_size=self.node_attributes.num_nodes[self._graph_name_hidden[0]],
                 trainable_size=sub_encoder_config.get("trainable_size", 0),
             )
-            self.encoder[dataset_name] = instantiate(
+
+            if key in self.encoder:
+                continue  # Encoder already built for this dataset (e.g., shared encoder), skip to avoid overwriting
+
+            self.encoder[key] = instantiate(
                 sub_encoder_config,
                 _recursive_=False,  # Avoids instantiation of layer_kernels here
                 in_channels_src=self.input_dim[dataset_name],
@@ -165,7 +169,11 @@ class AnemoiModelHierarchicalAutoEncoder(AnemoiModelAutoEncoder):
             src_nodes_name = self._graph_name_hidden[i]
             dst_nodes_name = self._graph_name_hidden[i + 1]
 
-            sub_downscale_config = self._get_nested_configuration(model_config.model.encoder, src_nodes_name)
+            key, sub_downscale_config = self._get_nested_configuration(model_config.model.encoder, src_nodes_name)
+            if key in self.downscale:
+                raise ValueError(
+                    f"Downscale module for hidden node {src_nodes_name} is already defined. Please check your configuration for duplicate entries."
+                )
 
             self.downscale_graph_providers[src_nodes_name] = create_graph_provider(
                 graph=self._graph_data[(src_nodes_name, "to", dst_nodes_name)],
@@ -192,7 +200,11 @@ class AnemoiModelHierarchicalAutoEncoder(AnemoiModelAutoEncoder):
             src_nodes_name = self._graph_name_hidden[i]
             dst_nodes_name = self._graph_name_hidden[i - 1]
 
-            sub_upscale_config = self._get_nested_configuration(model_config.model.decoder, src_nodes_name)
+            key, sub_upscale_config = self._get_nested_configuration(model_config.model.decoder, src_nodes_name)
+            if key in self.upscale:
+                raise ValueError(
+                    f"Upscale module for hidden node {src_nodes_name} is already defined. Please check your configuration for duplicate entries."
+                )
 
             self.upscale_graph_providers[src_nodes_name] = create_graph_provider(
                 graph=self._graph_data[(src_nodes_name, "to", dst_nodes_name)],
@@ -216,7 +228,7 @@ class AnemoiModelHierarchicalAutoEncoder(AnemoiModelAutoEncoder):
         self.decoder_graph_provider = nn.ModuleDict()
         self.decoder = torch.nn.ModuleDict()
         for dataset_name in self.dataset_names:
-            sub_decoder_config = self._get_nested_configuration(model_config.model.decoder, dataset_name)
+            key, sub_decoder_config = self._get_nested_configuration(model_config.model.decoder, dataset_name)
 
             self.decoder_graph_provider[dataset_name] = create_graph_provider(
                 graph=self._graph_data[(self._graph_name_hidden[0], "to", dataset_name)],
@@ -226,7 +238,10 @@ class AnemoiModelHierarchicalAutoEncoder(AnemoiModelAutoEncoder):
                 trainable_size=sub_decoder_config.get("trainable_size", 0),
             )
 
-            self.decoder[dataset_name] = instantiate(
+            if key in self.decoder:
+                continue  # Decoder already built for this dataset (e.g., shared decoder), skip to avoid overwriting
+
+            self.decoder[key] = instantiate(
                 sub_decoder_config,
                 _recursive_=False,  # Avoids instantiation of layer_kernels here
                 in_channels_src=self.hidden_dims[self._graph_name_hidden[0]],

--- a/models/src/anemoi/models/models/hierarchical_autoencoder.py
+++ b/models/src/anemoi/models/models/hierarchical_autoencoder.py
@@ -21,6 +21,7 @@ from anemoi.models.layers.bounding import build_boundings
 from anemoi.models.layers.graph import NamedNodesAttributes
 from anemoi.models.layers.graph_provider import create_graph_provider
 from anemoi.models.models import AnemoiModelAutoEncoder
+from anemoi.models.models.base import PREFIX_TO_MEANING
 from anemoi.utils.config import DotDict
 
 
@@ -94,8 +95,15 @@ class AnemoiModelHierarchicalAutoEncoder(AnemoiModelAutoEncoder):
         # Encoder data -> hidden
         self.encoder_graph_provider = nn.ModuleDict()
         self.encoder = torch.nn.ModuleDict()
+        self.encoder_flags = {}
         for dataset_name in self.dataset_names:
-            key, sub_encoder_config = self._get_nested_configuration(model_config.model.encoder, dataset_name)
+            key, sub_encoder_config, prefix_flags = self._get_nested_configuration(
+                model_config.model.encoder, dataset_name, prefix_mapping=PREFIX_TO_MEANING
+            )
+            if not prefix_flags["optional"]:
+                prefix_flags["required"] = True  # Mark as required if not explicitly marked as optional
+
+            self.encoder_flags[dataset_name] = prefix_flags
 
             self.encoder_graph_provider[dataset_name] = create_graph_provider(
                 graph=self._graph_data[(dataset_name, "to", self._graph_name_hidden[0])],
@@ -169,7 +177,7 @@ class AnemoiModelHierarchicalAutoEncoder(AnemoiModelAutoEncoder):
             src_nodes_name = self._graph_name_hidden[i]
             dst_nodes_name = self._graph_name_hidden[i + 1]
 
-            key, sub_downscale_config = self._get_nested_configuration(model_config.model.encoder, src_nodes_name)
+            key, sub_downscale_config, _ = self._get_nested_configuration(model_config.model.encoder, src_nodes_name)
             if key in self.downscale:
                 raise ValueError(
                     f"Downscale module for hidden node {src_nodes_name} is already defined. Please check your configuration for duplicate entries."
@@ -200,7 +208,7 @@ class AnemoiModelHierarchicalAutoEncoder(AnemoiModelAutoEncoder):
             src_nodes_name = self._graph_name_hidden[i]
             dst_nodes_name = self._graph_name_hidden[i - 1]
 
-            key, sub_upscale_config = self._get_nested_configuration(model_config.model.decoder, src_nodes_name)
+            key, sub_upscale_config, _ = self._get_nested_configuration(model_config.model.decoder, src_nodes_name)
             if key in self.upscale:
                 raise ValueError(
                     f"Upscale module for hidden node {src_nodes_name} is already defined. Please check your configuration for duplicate entries."
@@ -227,8 +235,15 @@ class AnemoiModelHierarchicalAutoEncoder(AnemoiModelAutoEncoder):
         # Decoder hidden -> data
         self.decoder_graph_provider = nn.ModuleDict()
         self.decoder = torch.nn.ModuleDict()
+        self.decoder_flags = {}
         for dataset_name in self.dataset_names:
-            key, sub_decoder_config = self._get_nested_configuration(model_config.model.decoder, dataset_name)
+            key, sub_decoder_config, prefix_flags = self._get_nested_configuration(
+                model_config.model.decoder, dataset_name, prefix_mapping=PREFIX_TO_MEANING
+            )
+            if not prefix_flags["optional"]:
+                prefix_flags["required"] = True  # Mark as required if not explicitly marked as optional
+
+            self.decoder_flags[dataset_name] = prefix_flags
 
             self.decoder_graph_provider[dataset_name] = create_graph_provider(
                 graph=self._graph_data[(self._graph_name_hidden[0], "to", dataset_name)],
@@ -275,6 +290,12 @@ class AnemoiModelHierarchicalAutoEncoder(AnemoiModelAutoEncoder):
             Output of the model, with the same shape as the input (sharded if input is sharded)
         """
         dataset_names = list(x.keys())
+        self._validate_required(
+            dataset_names, required=list(d[0] for d in self.encoder_flags.items() if not d[1].get("optional", False))
+        )
+        self._validate_required(
+            dataset_names, required=list(d[0] for d in self.decoder_flags.items() if not d[1].get("optional", False))
+        )
 
         # Extract and validate batch & ensemble sizes across datasets
         batch_size = self._get_consistent_dim(x, 0)


### PR DESCRIPTION
## Summary

Extends the dictionary-style encoder/decoder configuration (from the parent branch) with optional/shared semantics and runtime validation.

### Optional prefix (`~`)

Mark a dataset's encoder/decoder as optional so it need not be present at forward time. Prefix the dataset key with `~` in the config:

```yaml
defaults:
  - encoder@encoder.data: gt16        # required
  - encoder@encoder.~other: gnn       # optional
```

This produces:

```yaml
encoder:
  data:
    _target_: anemoi.models.layers.mapper.GraphTransformerForwardMapper
    ...
  ~other:
    _target_: anemoi.models.layers.mapper.GNNForwardMapper
    ...
```

At forward time, `_validate_required` raises if any non-optional dataset is missing from the input batch.

### Shared config (`,`)

Multiple datasets can share the same configuration (each getting an independently instantiated module) by joining their names with `,`:

```yaml
encoder:
  dataset1,dataset2:
    _target_: anemoi.models.layers.mapper.GraphTransformerForwardMapper
    ...
```

This is equivalent to writing the same config under each dataset key individually. Each dataset receives a separate module instance built from the shared config.

### Shared instance (`&`) (not yet enabled)

Define a single encoder/decoder instance shared across multiple datasets:

```yaml
encoder:
  dataset1&dataset2:
    _target_: anemoi.models.layers.mapper.GraphTransformerForwardMapper
    ...
```

Unlike `,`, this instantiates the encoder **once** and reuses the same module for both datasets. The build loop skips instantiation if the key already exists, and `_get_from_dict_with_and` resolves lookups at runtime. Currently gated behind `NotImplementedError` pending forward pass support.

### Runtime validation

Each model's `forward` method now calls `_validate_required` to check that all non-optional encoders and decoders have matching datasets in the input. Flags are stored in `encoder_flags` / `decoder_flags` dicts per dataset.

### Migration

`1777984565_add_enc_dec_flags.py` adds `encoder_flags` and `decoder_flags` to old checkpoints by inferring dataset names from encoder state dict keys, defaulting all to `{"optional": False}`.

### Files changed

All changes are in `models/src/anemoi/models/`:
- `models/base.py` -- `PREFIX_TO_MEANING`, updated `_get_nested_configuration` (returns 3-tuple with key + flags), `_validate_required`, `_get_from_dict_with_and`, `,` separator for shared configs
- `models/encoder_processor_decoder.py` -- encoder/decoder flags, shared key dedup
- `models/diffusion_encoder_processor_decoder.py` -- same
- `models/ens_encoder_processor_decoder.py` -- validation calls
- `models/hierarchical.py` -- flags + dedup for encoder/decoder/downscale/upscale
- `models/hierarchical_autoencoder.py` -- same
- `models/autoencoder.py` -- validation calls, type hints updated
- `migrations/scripts/1777984565_add_enc_dec_flags.py` -- new migration

---

*By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)*

<!-- readthedocs-preview anemoi-training start -->
----
📚 Documentation preview 📚: https://anemoi-training--1092.org.readthedocs.build/en/1092/

<!-- readthedocs-preview anemoi-training end -->

<!-- readthedocs-preview anemoi-graphs start -->
----
📚 Documentation preview 📚: https://anemoi-graphs--1092.org.readthedocs.build/en/1092/

<!-- readthedocs-preview anemoi-graphs end -->

<!-- readthedocs-preview anemoi-models start -->
----
📚 Documentation preview 📚: https://anemoi-models--1092.org.readthedocs.build/en/1092/

<!-- readthedocs-preview anemoi-models end -->