### PR TITLE
fix: Schemas for learnable residual connections.

### DIFF
--- a/models/src/anemoi/models/schemas/residual.py
+++ b/models/src/anemoi/models/schemas/residual.py
@@ -74,6 +74,10 @@ class ScalarOrnsteinConnectionSchema(BaseModel):
         True,
         description="Whether theta is a trainable parameter.",
     )
+    regressors: list[str] | None = Field(
+        None,
+        description="Variable names to use as regressors.",
+    )
 
 
 class SpectralOrnsteinConnectionSchema(BaseModel):
@@ -85,8 +89,8 @@ class SpectralOrnsteinConnectionSchema(BaseModel):
         description="Maximum spherical harmonic degree for the theta/mu coefficients.",
     )
     grid: str = Field(
-        "legendre-gauss",
-        description='Grid type: "legendre-gauss" for regular lat-lon, "octahedral" for octahedral reduced grids.',
+        "regular",
+        description='Grid type: "regular" for regular lat-lon, "octahedral" for octahedral reduced grids.',
     )
     theta_init: float = Field(
         0.0,
@@ -96,7 +100,7 @@ class SpectralOrnsteinConnectionSchema(BaseModel):
         0.0,
         description="Lower bound buffer for theta.",
     )
-    zmean_term: bool = Field(
+    use_mean: bool = Field(
         True,
         description="Whether to include a zonal mean (mu) term.",
     )

--- a/models/src/anemoi/models/schemas/residual.py
+++ b/models/src/anemoi/models/schemas/residual.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from typing import Annotated
 from typing import Literal
 from typing import Self
@@ -80,6 +81,13 @@ class ScalarOrnsteinConnectionSchema(BaseModel):
     )
 
 
+class SpectralOrnsteinSupportedGrids(str, Enum):
+    """Supported grid types for SpectralOrnsteinConnection."""
+
+    REGULAR = "regular"
+    OCTAHEDRAL = "octahedral"
+
+
 class SpectralOrnsteinConnectionSchema(BaseModel):
     """Schema for spectral Ornstein residual connections."""
 
@@ -88,8 +96,8 @@ class SpectralOrnsteinConnectionSchema(BaseModel):
         2,
         description="Maximum spherical harmonic degree for the theta/mu coefficients.",
     )
-    grid: str = Field(
-        "regular",
+    grid: SpectralOrnsteinSupportedGrids = Field(
+        SpectralOrnsteinSupportedGrids.REGULAR,
         description='Grid type: "regular" for regular lat-lon, "octahedral" for octahedral reduced grids.',
     )
     theta_init: float = Field(


### PR DESCRIPTION
## Description

Fix Pydantic schemas for learnable residual connections (`ScalarOrnsteinConnectionSchema` and `SpectralOrnsteinConnectionSchema`) to match the actual layer constructor signatures.

## What problem does this change solve?

Three schema fields were inconsistent with the corresponding layer constructors in `residual.py`:

1. `ScalarOrnsteinConnectionSchema` missing `regressors` field 

2. `SpectralOrnsteinConnectionSchema.zmean_term` renamed to `use_mean`

3. `SpectralOrnsteinConnectionSchema.grid` wrong default 

## What issue or task does this change relate to?

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
