### PR TITLE
chore: remove scale_validation_metrics references

### DIFF
--- a/training/docs/modules/losses.rst
+++ b/training/docs/modules/losses.rst
@@ -456,32 +456,10 @@ Validation metrics as defined in the config file at
 ``config.training.validation_metrics`` follow the same initialisation
 behaviour as the loss function, but can be a list. In this case all
 losses are calculated and logged as a dictionary with the corresponding
-name
+name.
 
-Scaling Validation Losses
-=========================
-
-Validation metrics can **not** by default be scaled by scalers across
-the variable dimension, but can be by all other scalers. If you want to
-scale a validation metric by the variable weights, it must be added to
-`config.training.scale_validation_metrics`.
-
-These metrics are then kept in the normalised, preprocessed space, and
-thus the indexing of scalers aligns with the indexing of the tensors.
-
-By default, only `all` is kept in the normalised space and scaled.
-
-.. code:: yaml
-
-   # List of validation metrics to keep in normalised space, and scalers to be applied
-   # Use '*' in reference all metrics, or a list of metric names.
-   # Unlike above, variable scaling is possible due to these metrics being
-   # calculated in the same way as the training loss, within the model space.
-   scale_validation_metrics:
-   scalers_to_apply: ['variable']
-   metrics:
-      - 'all'
-      # - "*"
+Validation metrics can **not** be scaled by scalers across
+the variable dimension, but can be by all other scalers.
 
 ***********************
  Custom Loss Functions

--- a/training/src/anemoi/training/config/training/diffusion.yaml
+++ b/training/src/anemoi/training/config/training/diffusion.yaml
@@ -81,7 +81,6 @@ validation_metrics:
         # Cannot scale over the variable dimension due to possible remappings.
         # Available scalers include:
         # - 'loss_weights_mask': Giving imputed NaNs a zero weight in the loss function
-        # Use the `scale_validation_metrics` section to variable scale.
         scalers: ["node_weights", "time_steps"]
         # other kwargs
         ignore_nans: True

--- a/training/src/anemoi/training/config/training/lam.yaml
+++ b/training/src/anemoi/training/config/training/lam.yaml
@@ -76,7 +76,6 @@ validation_metrics:
         # Cannot scale over the variable dimension due to possible remappings.
         # Available scalers include:
         # - 'loss_weights_mask': Giving imputed NaNs a zero weight in the loss function
-        # Use the `scale_validation_metrics` section to variable scale.
         scalers: ["node_weights", "time_steps"]
         # other kwargs
         ignore_nans: True

--- a/training/src/anemoi/training/config/training/single.yaml
+++ b/training/src/anemoi/training/config/training/single.yaml
@@ -74,7 +74,6 @@ validation_metrics:
         # Cannot scale over the variable dimension due to possible remappings.
         # Available scalers include:
         # - 'loss_weights_mask': Giving imputed NaNs a zero weight in the loss function
-        # Use the `scale_validation_metrics` section to variable scale.
         scalers: ["node_weights", "time_steps"]
         # other kwargs
         ignore_nans: True

--- a/training/src/anemoi/training/config/training/stretched.yaml
+++ b/training/src/anemoi/training/config/training/stretched.yaml
@@ -77,7 +77,6 @@ validation_metrics:
         # Cannot scale over the variable dimension due to possible remappings.
         # Available scalers include:
         # - 'loss_weights_mask': Giving imputed NaNs a zero weight in the loss function
-        # Use the `scale_validation_metrics` section to variable scale.
         scalers: ["node_weights", "time_steps"]
         # other kwargs
         ignore_nans: True


### PR DESCRIPTION
## Description
As mentioned in #1101, contrary to what docs and comments in default configs suggest `training.scale_validation_metrics` is no longer supported. This config entry was removed from the schema in https://github.com/ecmwf/anemoi-core/issues/1101 . This PR cleans up docs and default configs by removing the references to `scale_validation_metrics.

## What problem does this change solve?
closes #1101

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)


<!-- readthedocs-preview anemoi-training start -->
----
📚 Documentation preview 📚: https://anemoi-training--1111.org.readthedocs.build/en/1111/

<!-- readthedocs-preview anemoi-training end -->

<!-- readthedocs-preview anemoi-graphs start -->
----
📚 Documentation preview 📚: https://anemoi-graphs--1111.org.readthedocs.build/en/1111/

<!-- readthedocs-preview anemoi-graphs end -->

<!-- readthedocs-preview anemoi-models start -->
----
📚 Documentation preview 📚: https://anemoi-models--1111.org.readthedocs.build/en/1111/

<!-- readthedocs-preview anemoi-models end -->