### PR TITLE
fix: extend loss discriminator to combinedloss schema

### DIFF
--- a/training/src/anemoi/training/schemas/training.py
+++ b/training/src/anemoi/training/schemas/training.py
@@ -369,11 +369,39 @@ class SpectralLossSchema(BaseLossSchema):
         extra = "allow"
 
 
+def _loss_discriminator(v: Any) -> str:
+    target = v.get("_target_", "") if hasattr(v, "get") else getattr(v, "target_", "")
+    if target == "anemoi.training.losses.combined.CombinedLoss":
+        return "combined"
+    if target == "anemoi.training.losses.MultiscaleLossWrapper":
+        return "multiscale"
+    if target == "anemoi.training.losses.CRPS":
+        return "crps"
+    if target in {
+        "anemoi.training.losses.spectral.FourierCorrelationLoss",
+        "anemoi.training.losses.spectral.LogSpectralDistance",
+        "anemoi.training.losses.spectral.LogFFT2Distance",
+        "anemoi.training.losses.spectral.SpectralCRPSLoss",
+        "anemoi.training.losses.spectral.SpectralL2Loss",
+    }:
+        return "spectral"
+    if target == "anemoi.training.losses.HuberLoss":
+        return "huber"
+    return "base"
+
+
 class CombinedLossSchema(BaseLossSchema):
     target_: Literal["anemoi.training.losses.combined.CombinedLoss"] = Field(..., alias="_target_")
-    losses: list[MultiScaleLossSchema | SpectralLossSchema | CRPSSchema | HuberLossSchema | BaseLossSchema] = Field(
-        min_length=1,
-    )
+    losses: list[
+        Annotated[
+            Annotated[BaseLossSchema, Tag("base")]
+            | Annotated[HuberLossSchema, Tag("huber")]
+            | Annotated[CRPSSchema, Tag("crps")]
+            | Annotated[SpectralLossSchema, Tag("spectral")]
+            | Annotated[MultiScaleLossSchema, Tag("multiscale")],
+            Discriminator(_loss_discriminator),
+        ]
+    ] = Field(min_length=1)
     "Losses to combine, can be any of the normal losses."
     loss_weights: list[int | float] | None = None
     "Weightings of losses, if not set, all losses are weighted equally."
@@ -405,27 +433,6 @@ class CombinedLossSchema(BaseLossSchema):
             error_msg = "Number of losses and weights must match"
             raise ValueError(error_msg)
         return self
-
-
-def _loss_discriminator(v: Any) -> str:
-    target = v.get("_target_", "") if hasattr(v, "get") else getattr(v, "target_", "")
-    if target == "anemoi.training.losses.combined.CombinedLoss":
-        return "combined"
-    if target == "anemoi.training.losses.MultiscaleLossWrapper":
-        return "multiscale"
-    if target == "anemoi.training.losses.CRPS":
-        return "crps"
-    if target in {
-        "anemoi.training.losses.spectral.FourierCorrelationLoss",
-        "anemoi.training.losses.spectral.LogSpectralDistance",
-        "anemoi.training.losses.spectral.LogFFT2Distance",
-        "anemoi.training.losses.spectral.SpectralCRPSLoss",
-        "anemoi.training.losses.spectral.SpectralL2Loss",
-    }:
-        return "spectral"
-    if target == "anemoi.training.losses.HuberLoss":
-        return "huber"
-    return "base"
 
 
 LossSchemas = Annotated[


### PR DESCRIPTION
## Description
Integration tests are currently failing for main https://github.com/ecmwf/anemoi-core/actions/runs/25850035257 since the CombinedLossSchemas are not properly discriminating the schemas and the WeightMSE loss gets matched with CRPS schema adding invalid kwargs. 

This PR fixes the problem via making the combinedLossSchema use the loss_discriminator.
Tests are passing here https://github.com/ecmwf/anemoi-core/actions/runs/25853504545

## What problem does this change solve?
<!-- Describe if it's a bugfix, new feature, doc update, or breaking change -->

## What issue or task does this change relate to?
<!-- link to Issue Number -->

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
