### PR TITLE
fix: include anemoi-graphs as models dependancy

### DIFF
--- a/models/pyproject.toml
+++ b/models/pyproject.toml
@@ -34,12 +34,13 @@ classifiers = [
 ]
 dynamic = [ "version" ]
 dependencies = [
+  "anemoi-graphs>=0.9.4",
   # Fix certain dependencies during development
   "anemoi-utils>=0.1.9",
   "einops>=0.6.1",
   "hydra-core>=1.3",
   "torch>=2.3,<2.11",
-  "torch-geometric>=2.3",
+  "torch-geometric>=2.3"
 ]
 optional-dependencies.all = [ "anemoi-models[migrations]" ]
 optional-dependencies.dev = [


### PR DESCRIPTION
## Description
Fix anemoi-models dependencies, to allow on the fly graph building for residual connections we use anemoi-graphs and hence we need to add these dependency to anemoi-models pyproject.toml 

## What problem does this change solve?
<!-- Describe if it's a bugfix, new feature, doc update, or breaking change -->

## What issue or task does this change relate to?
<!-- link to Issue Number -->

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
