### PR TITLE
fix: asyncio loop thread management with Python 3.13

### DIFF
--- a/training/src/anemoi/training/diagnostics/callbacks/plot.py
+++ b/training/src/anemoi/training/diagnostics/callbacks/plot.py
@@ -228,7 +228,6 @@ class BasePlotCallback(Callback, ABC):
             self.loop.call_soon_threadsafe(self.loop.stop)
             self.loop_thread.join()
             # Step 3: Close the asyncio event loop
-            self.loop_thread._stop()
             self.loop_thread._delete()
 
     def apply_output_mask(self, pl_module: pl.LightningModule, data: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
## Description
Remove the call to stop the asyncio loop thread directly. `threading.Threads_stop` [has been removed](https://github.com/python/cpython/commit/33da0e844c922b3dcded75fbb9b7be67cb013a17) in Python 3.13. From the documentation, I see no reason to call `_stop` after `join()` at all.

## What problem does this change solve?
During the "teardown" at the end of the training run, we encountered a Python 3.13 compatibility issue:
```
AttributeError: 'Thread' object has no attribute '_stop'
```

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
