### PR TITLE
fix(training): gather sharded batches if loss does not support sharding

### DIFF
--- a/training/src/anemoi/training/train/methods/ensemble.py
+++ b/training/src/anemoi/training/train/methods/ensemble.py
@@ -179,6 +179,7 @@ class EnsembleTraining(BaseTrainingModule):
         target_layout: IndexSpace | str | None = None,
         **_kwargs,
     ) -> tuple[torch.Tensor | None, dict[str, torch.Tensor], torch.Tensor]:
+
         y_pred_ens = gather_tensor(
             y_pred.clone(),  # for bwd because we checkpoint this region
             dim=TensorDim.ENSEMBLE_DIM,
@@ -186,10 +187,17 @@ class EnsembleTraining(BaseTrainingModule):
             mgroup=self.ens_comm_subgroup,
         )
 
-        loss = self._compute_loss(
+        y_pred_ens_full, y_full, grid_shard_slice = self._prepare_tensors_for_loss(
             y_pred_ens,
             y,
-            grid_shard_slice=self.grid_shard_slice[dataset_name],
+            validation_mode=validation_mode,
+            dataset_name=dataset_name,
+        )
+
+        loss = self._compute_loss(
+            y_pred_ens_full,
+            y_full,
+            grid_shard_slice=grid_shard_slice,
             dataset_name=dataset_name,
             pred_layout=pred_layout,
             target_layout=target_layout,
@@ -199,11 +207,11 @@ class EnsembleTraining(BaseTrainingModule):
         metrics_next = {}
         if validation_mode:
             metrics_next = self._compute_metrics(
-                y_pred_ens,
-                y,
+                y_pred_ens_full,
+                y_full,
                 rollout_step=rollout_step,
                 dataset_name=dataset_name,
-                grid_shard_slice=self.grid_shard_slice[dataset_name],
+                grid_shard_slice=grid_shard_slice,
                 pred_layout=pred_layout,
                 target_layout=target_layout,
             )

--- a/training/tests/unit/train/test_methods.py
+++ b/training/tests/unit/train/test_methods.py
@@ -1371,6 +1371,16 @@ def test_ensemble_compute_dataset_loss_metrics_forwards_data_full_layout(
 
     captured: dict[str, Any] = {}
 
+    def _prepare_tensors_stub(
+        self: DiffusionTendencyTraining,
+        y_pred: torch.Tensor,
+        y: torch.Tensor,
+        validation_mode: bool = False,
+        dataset_name: str | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor, slice]:
+        del self, validation_mode, dataset_name
+        return y_pred, y, slice(0, 1)
+
     def _compute_loss_stub(
         self: EnsembleTraining,
         y_pred: torch.Tensor,
@@ -1391,6 +1401,7 @@ def test_ensemble_compute_dataset_loss_metrics_forwards_data_full_layout(
         captured["metric_kwargs"] = kwargs
         return {"dummy": torch.tensor(1.0)}
 
+    monkeypatch.setattr(EnsembleTraining, "_prepare_tensors_for_loss", _prepare_tensors_stub, raising=True)
     monkeypatch.setattr(EnsembleTraining, "_compute_loss", _compute_loss_stub, raising=True)
     monkeypatch.setattr(EnsembleTraining, "_compute_metrics", _compute_metrics_stub, raising=True)
 


### PR DESCRIPTION
This PR makes sure that in the ensemble training the batches are actually gathered before computing the loss, if the loss does not support sharding.

---

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
