### PR TITLE
fix(training): allow setting blosc num threads via config

### DIFF
--- a/training/docs/troubleshooting.rst
+++ b/training/docs/troubleshooting.rst
@@ -58,6 +58,29 @@ the metadata stored in the checkpoint using
 
    anemoi-utils metadata checkpoint.ckpt --remove --output output.ckpt
 
+****************
+ Miscellaneous errors
+****************
+
+1. Error during blosc decompression
+========================================
+
+If you encounter this error during runtime
+
+.. code:: bash
+
+   File "numcodecs/blosc.pyx", line 585, in numcodecs.blosc.Blosc.decode
+   File "numcodecs/blosc.pyx", line 414, in numcodecs.blosc.decompress
+   RuntimeError: error during blosc decompression: 0
+
+You can set the number of threads used by blosc to 1 to avoid this error.
+This can be done by setting the following config value:
+
+.. code:: yaml
+
+   dataloader:
+       blosc_num_threads: 1
+
 ***********************************
  PyTorch Lightning Debugging Tools
 ***********************************

--- a/training/src/anemoi/training/data/datamodule.py
+++ b/training/src/anemoi/training/data/datamodule.py
@@ -10,6 +10,7 @@
 
 import logging
 from functools import cached_property
+from functools import partial
 
 import pytorch_lightning as pl
 from torch.utils.data import DataLoader
@@ -155,7 +156,7 @@ class AnemoiDatasetsDataModule(pl.LightningDataModule):
             batch_size=self.config.dataloader.batch_size[stage],
             num_workers=self.config.dataloader.num_workers[stage],
             pin_memory=self.config.dataloader.pin_memory,
-            worker_init_fn=worker_init_func,
+            worker_init_fn=partial(worker_init_func, dataloader_config=self.config.dataloader),
             prefetch_factor=self.config.dataloader.prefetch_factor,
             persistent_workers=True,
             **extra,

--- a/training/src/anemoi/training/data/datamodule.py
+++ b/training/src/anemoi/training/data/datamodule.py
@@ -156,7 +156,7 @@ class AnemoiDatasetsDataModule(pl.LightningDataModule):
             batch_size=self.config.dataloader.batch_size[stage],
             num_workers=self.config.dataloader.num_workers[stage],
             pin_memory=self.config.dataloader.pin_memory,
-            worker_init_fn=partial(worker_init_func, dataloader_config=self.config.dataloader),
+            worker_init_fn=partial(worker_init_func, blosc_num_threads=self.config.dataloader.blosc_num_threads),
             prefetch_factor=self.config.dataloader.prefetch_factor,
             persistent_workers=True,
             **extra,

--- a/training/src/anemoi/training/schemas/dataloader.py
+++ b/training/src/anemoi/training/schemas/dataloader.py
@@ -135,5 +135,5 @@ class DataLoaderSchema(PydanticBaseModel):
     "Number of GPUs per reader group. Defaults to number of GPUs (see BaseSchema validators)."
     multiprocessing_context: str | None = Field(default=None, examples=[None, "spawn", "fork", "forkserver"])
     "Multiprocessing context to use for workers. If None, the default context will be used."
-    blosc_num_threads: PositiveInt | None = Field(default=1)
+    blosc_num_threads: PositiveInt | None = Field(default=None)
     "Sets how many threads used when decompressing Zarr chunks. If None, the thread count will be determined by Blosc."

--- a/training/src/anemoi/training/schemas/dataloader.py
+++ b/training/src/anemoi/training/schemas/dataloader.py
@@ -134,4 +134,6 @@ class DataLoaderSchema(PydanticBaseModel):
     read_group_size: PositiveInt = Field(example=None)
     "Number of GPUs per reader group. Defaults to number of GPUs (see BaseSchema validators)."
     multiprocessing_context: str | None = Field(default=None, examples=[None, "spawn", "fork", "forkserver"])
-    "Multiprocessing context to use for workers. If None, the default context will be used"
+    "Multiprocessing context to use for workers. If None, the default context will be used."
+    blosc_num_threads: PositiveInt | None = Field(default=1)
+    "Sets how many threads used when decompressing Zarr chunks. If None, the thread count will be determined by Blosc."

--- a/training/src/anemoi/training/utils/worker_init.py
+++ b/training/src/anemoi/training/utils/worker_init.py
@@ -14,12 +14,10 @@ from numcodecs.blosc import get_nthreads
 from numcodecs.blosc import set_nthreads
 from torch.utils.data import get_worker_info
 
-from anemoi.training.schemas.base_schema import BaseSchema
-
 LOGGER = logging.getLogger(__name__)
 
 
-def worker_init_func(worker_id: int, dataloader_config: BaseSchema) -> None:
+def worker_init_func(worker_id: int, blosc_num_threads: int | None = None) -> None:
     """Configures each dataset worker process.
 
     Calls per_worker_init() on each dataset object.
@@ -28,8 +26,9 @@ def worker_init_func(worker_id: int, dataloader_config: BaseSchema) -> None:
     ----------
     worker_id : int
         Worker ID
-    dataloader_config : BaseSchema
-        Dataloader configuration
+    blosc_num_threads : int, optional
+        Number of threads to use for Blosc decompression, by default None.
+        If None, the number of threads will be determined by Blosc.
 
     Raises
     ------
@@ -38,7 +37,6 @@ def worker_init_func(worker_id: int, dataloader_config: BaseSchema) -> None:
 
     """
     # read the dataloader config to set the number of threads blosc should use when decompressing zarr chunks.
-    blosc_num_threads = dataloader_config.get("blosc_num_threads", None)
     if blosc_num_threads is not None:
         set_nthreads(blosc_num_threads)
         LOGGER.info("Set number of threads used by Blosc to %d.", blosc_num_threads)

--- a/training/src/anemoi/training/utils/worker_init.py
+++ b/training/src/anemoi/training/utils/worker_init.py
@@ -10,7 +10,8 @@
 
 import logging
 
-from numcodecs.blosc import set_nthreads, get_nthreads
+from numcodecs.blosc import get_nthreads
+from numcodecs.blosc import set_nthreads
 from torch.utils.data import get_worker_info
 
 from anemoi.training.schemas.base_schema import BaseSchema

--- a/training/src/anemoi/training/utils/worker_init.py
+++ b/training/src/anemoi/training/utils/worker_init.py
@@ -10,7 +10,7 @@
 
 import logging
 
-from numcodecs.blosc import set_nthreads as blosc_set_nthreads
+from numcodecs.blosc import set_nthreads, get_nthreads
 from torch.utils.data import get_worker_info
 
 from anemoi.training.schemas.base_schema import BaseSchema
@@ -37,9 +37,12 @@ def worker_init_func(worker_id: int, dataloader_config: BaseSchema) -> None:
 
     """
     # read the dataloader config to set the number of threads blosc should use when decompressing zarr chunks.
-    blosc_num_threads = dataloader_config.get("blosc_num_threads", 1)
-    blosc_set_nthreads(blosc_num_threads)
-    LOGGER.debug("Set number of threads used by Blosc to %d.", blosc_num_threads)
+    blosc_num_threads = dataloader_config.get("blosc_num_threads", None)
+    if blosc_num_threads is not None:
+        set_nthreads(blosc_num_threads)
+        LOGGER.info("Set number of threads used by Blosc to %d.", blosc_num_threads)
+    else:
+        LOGGER.info("Using Blosc default number of threads (%d) for decompression.", get_nthreads())
 
     worker_info = get_worker_info()  # information specific to each worker process
     if worker_info is None:

--- a/training/src/anemoi/training/utils/worker_init.py
+++ b/training/src/anemoi/training/utils/worker_init.py
@@ -10,12 +10,15 @@
 
 import logging
 
+from numcodecs.blosc import set_nthreads as blosc_set_nthreads
 from torch.utils.data import get_worker_info
+
+from anemoi.training.schemas.base_schema import BaseSchema
 
 LOGGER = logging.getLogger(__name__)
 
 
-def worker_init_func(worker_id: int) -> None:
+def worker_init_func(worker_id: int, dataloader_config: BaseSchema) -> None:
     """Configures each dataset worker process.
 
     Calls per_worker_init() on each dataset object.
@@ -24,6 +27,8 @@ def worker_init_func(worker_id: int) -> None:
     ----------
     worker_id : int
         Worker ID
+    dataloader_config : BaseSchema
+        Dataloader configuration
 
     Raises
     ------
@@ -31,6 +36,11 @@ def worker_init_func(worker_id: int) -> None:
         If worker_info is None
 
     """
+    # read the dataloader config to set the number of threads blosc should use when decompressing zarr chunks.
+    blosc_num_threads = dataloader_config.get("blosc_num_threads", 1)
+    blosc_set_nthreads(blosc_num_threads)
+    LOGGER.debug("Set number of threads used by Blosc to %d.", blosc_num_threads)
+
     worker_info = get_worker_info()  # information specific to each worker process
     if worker_info is None:
         LOGGER.error("worker_info is None! Set num_workers > 0 in your dataloader!")

--- a/training/tests/unit/data/test_dataset.py
+++ b/training/tests/unit/data/test_dataset.py
@@ -436,3 +436,28 @@ def test_native_dataset_schema_without_validation_accepts_invalid_payload() -> N
     )
 
     assert cfg.dataset_config == {"invalid_key": "not-supported"}
+
+
+def test_worker_init_func_sets_blosc_num_threads() -> None:
+    """Test that worker_init_func sets the Blosc thread count when blosc_num_threads is provided."""
+    from unittest.mock import MagicMock
+    from unittest.mock import patch
+
+    from numcodecs.blosc import get_nthreads
+    from numcodecs.blosc import set_nthreads
+
+    from anemoi.training.utils.worker_init import worker_init_func
+
+    initial_threads = 8
+    set_nthreads(initial_threads)
+
+    mock_dataset = MagicMock()
+    mock_worker_info = MagicMock()
+    mock_worker_info.num_workers = 1
+    mock_worker_info.dataset = mock_dataset
+
+    with patch("anemoi.training.utils.worker_init.get_worker_info", return_value=mock_worker_info):
+        worker_init_func(worker_id=0, blosc_num_threads=1)
+
+    assert get_nthreads() != initial_threads, f"Expected blosc nthreads!=initial_threads, got {get_nthreads()}"
+    assert get_nthreads() == 1, f"Expected blosc nthreads=1, got {get_nthreads()}"


### PR DESCRIPTION
## Description
This PR adds an optional entry to the **dataloader** config which sets how many threads is used by blosc to decompress Zarr chunks
```
blosc_num_threads: PositiveInt | None = Field(default=None)
"Sets how many threads used when decompressing Zarr chunks. If None, the thread count will be determined by Blosc."
```
The default value is None, meaning the thread count will be determined by blosc. In my tests this is 8 threads (numcodecs v0.15.1 on AG).

In theory, changing the number of threads could impact performance. But in my tests there were no performance difference between 1 and 64 threads while training an n320 model. However, this could vary depending on the CPU node and the number of dataloader processes available.

## What problem does this change solve?
Multiple users have reported this error on arm architectures like Grace-Hopper systems. This error is non-deterministic 

The fix for this error is to set **blosc_num_threads=1** 
```
  File "/nfs/dh2_02_perm_a/ecm1032/venvs/myvenv_ag_test/.venv/lib/python3.12/site-packages/anemoi/datasets/data/stores.py", line 230, in __getitem__
    return self.data[n]
           ~~~~~~~~~^^^
  File "/nfs/dh2_02_perm_a/ecm1032/venvs/myvenv_ag_test/.venv/lib/python3.12/site-packages/zarr/core.py", line 796, in __getitem__
    result = self.get_orthogonal_selection(pure_selection, fields=fields)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nfs/dh2_02_perm_a/ecm1032/venvs/myvenv_ag_test/.venv/lib/python3.12/site-packages/zarr/core.py", line 1078, in get_orthogonal_selection
    return self._get_selection(indexer=indexer, out=out, fields=fields)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nfs/dh2_02_perm_a/ecm1032/venvs/myvenv_ag_test/.venv/lib/python3.12/site-packages/zarr/core.py", line 1341, in _get_selection
    self._chunk_getitems(
  File "/nfs/dh2_02_perm_a/ecm1032/venvs/myvenv_ag_test/.venv/lib/python3.12/site-packages/zarr/core.py", line 2186, in _chunk_getitems
    self._process_chunk(
  File "/nfs/dh2_02_perm_a/ecm1032/venvs/myvenv_ag_test/.venv/lib/python3.12/site-packages/zarr/core.py", line 2099, in _process_chunk
    chunk = self._decode_chunk(cdata)
            ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nfs/dh2_02_perm_a/ecm1032/venvs/myvenv_ag_test/.venv/lib/python3.12/site-packages/zarr/core.py", line 2355, in _decode_chunk
    chunk = self._compressor.decode(cdata)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "numcodecs/blosc.pyx", line 585, in numcodecs.blosc.Blosc.decode
  File "numcodecs/blosc.pyx", line 414, in numcodecs.blosc.decompress
RuntimeError: error during blosc decompression: 0

```

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)


<!-- readthedocs-preview anemoi-training start -->
----
📚 Documentation preview 📚: https://anemoi-training--1131.org.readthedocs.build/en/1131/

<!-- readthedocs-preview anemoi-training end -->

<!-- readthedocs-preview anemoi-graphs start -->
----
📚 Documentation preview 📚: https://anemoi-graphs--1131.org.readthedocs.build/en/1131/

<!-- readthedocs-preview anemoi-graphs end -->

<!-- readthedocs-preview anemoi-models start -->
----
📚 Documentation preview 📚: https://anemoi-models--1131.org.readthedocs.build/en/1131/

<!-- readthedocs-preview anemoi-models end -->