### PR TITLE
fix(training): enable coupling of validation rollout to training rollout

### DIFF
--- a/training/src/anemoi/training/config/task/forecaster.yaml
+++ b/training/src/anemoi/training/config/task/forecaster.yaml
@@ -12,4 +12,4 @@ rollout:
   maximum: 1
 
 # number of rollout steps to use for validation, or null to use the training rollout
-validation_rollout: 1
+validation_rollout: null

--- a/training/src/anemoi/training/config/task/forecaster.yaml
+++ b/training/src/anemoi/training/config/task/forecaster.yaml
@@ -10,6 +10,6 @@ rollout:
   epoch_increment: 0
   # maximum rollout to use
   maximum: 1
-  # number of rollout steps to use for validation
 
+# number of rollout steps to use for validation, or null to use the training rollout
 validation_rollout: 1

--- a/training/src/anemoi/training/diagnostics/callbacks/evaluation.py
+++ b/training/src/anemoi/training/diagnostics/callbacks/evaluation.py
@@ -27,20 +27,20 @@ class RolloutEval(Callback):
     distributed synchronization.
     """
 
-    def __init__(self, rollout: list[int] | ListConfig, every_n_batches: int) -> None:
+    def __init__(self, rollout: list[int | None] | ListConfig, every_n_batches: int) -> None:
         """Initialize RolloutEval callback.
 
         Parameters
         ----------
-        rollout : list[int] | ListConfig
-            Rollout lengths for evaluation
+        rollout : list[int | None] | ListConfig
+            Rollout lengths for evaluation. ``[None]`` follows the task validation rollout.
         every_n_batches : int
             Frequency of rollout evaluation, runs every `n` validation batches
 
         """
         super().__init__()
 
-        assert isinstance(rollout, list | ListConfig), f"rollout must be a list of ints, got {type(rollout)}"
+        assert isinstance(rollout, list | ListConfig), f"rollout must be a list of ints or None, got {type(rollout)}"
         rollout_values = list(rollout)
 
         LOGGER.debug(
@@ -49,7 +49,12 @@ class RolloutEval(Callback):
             every_n_batches,
         )
         self.rollout = rollout_values
-        self.max_rollout = max(rollout_values)
+        self.follow_task_validation_rollout = False
+        if rollout_values == [None]:
+            self.follow_task_validation_rollout = True
+            self.max_rollout = None
+        else:
+            self.max_rollout = max(rollout_values)
         self.every_n_batches = every_n_batches
 
     def _eval(
@@ -60,6 +65,9 @@ class RolloutEval(Callback):
         batch_tensor = batch
         if isinstance(batch, dict):
             batch_tensor = next(iter(batch.values()))
+
+        if self.follow_task_validation_rollout:
+            self.max_rollout = len(tuple(pl_module.task.steps("validation")))
 
         assert batch_tensor.shape[1] >= self.max_rollout * pl_module.n_step_output + pl_module.n_step_input, (
             "Batch length not sufficient for requested validation rollout length! "

--- a/training/src/anemoi/training/diagnostics/callbacks/plot_adapter.py
+++ b/training/src/anemoi/training/diagnostics/callbacks/plot_adapter.py
@@ -78,7 +78,8 @@ class ForecasterPlotAdapter(BasePlotAdapter):
 
         x = input_data[self.get_init_step(), ...].squeeze()
 
-        for rollout_step in range(self._task.validation_rollout):
+        for validation_step_kwargs in self._task.steps("validation"):
+            rollout_step = validation_step_kwargs["rollout_step"]
             output_time_indices = self._task.get_batch_output_indices(rollout_step=rollout_step)
 
             output_data = data[output_time_indices, ...]
@@ -158,9 +159,14 @@ class EnsemblePlotAdapterWrapper(BasePlotAdapter):
         Parameters
         ----------
         tensor : Any
-            Tensor with shape (..., members, grid, vars)
+            Tensor with shape (..., members, grid, vars).
         members : int | list[int] | None
             Members to select. None returns all members, int/list selects specific members.
+
+        Returns
+        -------
+        Any
+            Tensor with selected ensemble members.
         """
         if members is None:
             return tensor

--- a/training/src/anemoi/training/schemas/tasks.py
+++ b/training/src/anemoi/training/schemas/tasks.py
@@ -42,8 +42,8 @@ class ForecasterSchema(BaseModel):
     "Timestep string (e.g. '6H') defining the frequency of the input and output steps."
     rollout: RolloutSchema = Field(...)
     "Rollout configuration for autoregressive training."
-    validation_rollout: NonNegativeInt = Field(example=[0, 6, 12])
-    "Number of rollouts to use for validation."
+    validation_rollout: NonNegativeInt | None = Field(default=None, example=[None, 6, 12])
+    "Number of rollouts to use for validation. If unset, validation uses the training rollout."
 
 
 class AutoencoderTaskSchema(BaseModel):

--- a/training/src/anemoi/training/tasks/forecaster.py
+++ b/training/src/anemoi/training/tasks/forecaster.py
@@ -63,7 +63,7 @@ class Forecaster(BaseTask):
         multistep_output: int,
         timestep: str,
         rollout: dict | None = None,
-        validation_rollout: int = 1,
+        validation_rollout: int | None = None,
         **kwargs,
     ) -> None:
 
@@ -89,7 +89,9 @@ class Forecaster(BaseTask):
 
     def steps(self, mode: str = "training") -> tuple[dict[str, int], ...]:
         """Return the current steps configuration based on the rollout step."""
-        max_rollout = self.validation_rollout if mode == "validation" else self.rollout.step
+        max_rollout = self.rollout.step
+        if mode == "validation" and self.validation_rollout is not None:
+            max_rollout = self.validation_rollout
         return tuple({"rollout_step": i} for i in range(max_rollout))
 
     def get_metric_name(self, rollout_step: int = 0, **_kwargs) -> str:
@@ -114,20 +116,24 @@ class Forecaster(BaseTask):
         if mode == "training":
             rollout_step = self.rollout.maximum
         elif mode == "validation":
-            rollout_step = self.validation_rollout
+            rollout_step = self.rollout.maximum if self.validation_rollout is None else self.validation_rollout
         else:
             LOGGER.debug(
                 "Unknown mode '%s' for %s.get_offsets(), defaulting to training rollout.",
                 mode,
                 self.__class__.__name__,
             )
-            rollout_step = max(self.rollout.maximum, self.validation_rollout)
+            validation_rollout = self.rollout.maximum if self.validation_rollout is None else self.validation_rollout
+            rollout_step = max(self.rollout.maximum, validation_rollout)
 
         return self._compute_rollout_offsets(rollout_step)
 
-    def get_output_offsets(self, rollout_step: int = 0, mode: str = "training", **_kwargs) -> list[datetime.timedelta]:
+    def get_output_offsets(
+        self,
+        rollout_step: int = 0,
+        **_kwargs,
+    ) -> list[datetime.timedelta]:
         """Return output offsets shifted by ``rollout_step``."""
-        rollout_step = rollout_step if mode == "training" else self.validation_rollout
         shift = self._step_shift * rollout_step
         return sorted(o + shift for o in self._output_offsets)
 

--- a/training/src/anemoi/training/tasks/forecaster.py
+++ b/training/src/anemoi/training/tasks/forecaster.py
@@ -119,7 +119,7 @@ class Forecaster(BaseTask):
             rollout_step = self.rollout.maximum if self.validation_rollout is None else self.validation_rollout
         else:
             LOGGER.debug(
-                "Unknown mode '%s' for %s.get_offsets(), defaulting to training rollout.",
+                "Unknown mode '%s' for %s.get_offsets(); using offsets for the longest configured rollout.",
                 mode,
                 self.__class__.__name__,
             )

--- a/training/tests/unit/tasks/test_forecaster.py
+++ b/training/tests/unit/tasks/test_forecaster.py
@@ -81,10 +81,32 @@ def test_forecaster_steps_is_single_element() -> None:
 
 def test_forecaster_steps_reflect_rollout_start() -> None:
     """Rollout start=2 produces two steps at construction time."""
-    task = Forecaster(multistep_input=1, multistep_output=1, timestep="6h", rollout={"start": 2})
+    task = Forecaster(multistep_input=1, multistep_output=1, timestep="6h", rollout={"start": 2, "maximum": 2})
     assert list(task.steps("training")) == [{"rollout_step": 0}, {"rollout_step": 1}]
-    assert list(task.steps("validation")) == [{"rollout_step": 0}]
+    assert list(task.steps("validation")) == [{"rollout_step": 0}, {"rollout_step": 1}]
     assert list(task.steps("testing")) == [{"rollout_step": 0}, {"rollout_step": 1}]
+
+
+def test_forecaster_validation_rollout_none_follows_training_rollout() -> None:
+    """Unset validation_rollout follows the current training rollout."""
+    task = Forecaster(
+        multistep_input=1,
+        multistep_output=1,
+        timestep="6h",
+        rollout={"start": 1, "epoch_increment": 1, "maximum": 3},
+    )
+
+    assert list(task.steps("validation")) == [{"rollout_step": 0}]
+    assert task.get_offsets(mode="validation") == [
+        datetime.timedelta(0),
+        datetime.timedelta(hours=6),
+        datetime.timedelta(hours=12),
+        datetime.timedelta(hours=18),
+    ]
+
+    task.on_train_epoch_end(0)
+
+    assert list(task.steps("validation")) == [{"rollout_step": 0}, {"rollout_step": 1}]
 
 
 def test_forecaster_steps_reflect_validation_rollout() -> None:


### PR DESCRIPTION
currently validation rollout is independent from training rollout which means the validation loss is not directly comparable to the training loss. This pull request makes the validation rollout setting optional, if not set, the training rollout is used in validation.