### PR TITLE
fix(models): gather_in_backward=False

### DIFF
--- a/models/src/anemoi/models/distributed/graph.py
+++ b/models/src/anemoi/models/distributed/graph.py
@@ -13,6 +13,7 @@ from torch import Tensor
 from torch.distributed.distributed_c10d import ProcessGroup
 
 from anemoi.models.distributed.primitives import _alltoall_transpose
+from anemoi.models.distributed.primitives import _expand_sharded_tensor
 from anemoi.models.distributed.primitives import _gather
 from anemoi.models.distributed.primitives import _reduce
 from anemoi.models.distributed.primitives import _split
@@ -319,14 +320,23 @@ class _ShardParallelSection(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, grad_output):
-        if ctx.comm_group and ctx.gather_in_backward is True:
-            return (
-                _gather(grad_output, ctx.dim, ctx.sizes, group=ctx.comm_group),
-                None,
-                None,
-                None,
-                None,
-            )
+        if ctx.comm_group is not None:
+            if ctx.gather_in_backward:
+                return (
+                    _gather(grad_output, ctx.dim, ctx.sizes, group=ctx.comm_group),
+                    None,
+                    None,
+                    None,
+                    None,
+                )
+            else:
+                return (
+                    _expand_sharded_tensor(grad_output, ctx.dim, ctx.sizes, group=ctx.comm_group),
+                    None,
+                    None,
+                    None,
+                    None,
+                )
         return grad_output, None, None, None, None
 
 

--- a/models/src/anemoi/models/distributed/primitives.py
+++ b/models/src/anemoi/models/distributed/primitives.py
@@ -182,6 +182,51 @@ def _gather(
     return _gather_default(input_, dim_, sizes, group)
 
 
+def _expand_sharded_tensor(
+    input_: Tensor,
+    dim_: int,
+    sizes: ShardSizes,
+    group: Optional[ProcessGroup] = None,
+) -> Tensor:
+    """Expand a local shard to the gathered shape without communication.
+
+    Only the local rank slice is materialized from ``input_``. The remaining
+    slices are left uninitialized in the returned tensor.
+    """
+    if dist.get_world_size(group=group) == 1:
+        return input_
+
+    assert (
+        -input_.dim() <= dim_ < input_.dim()
+    ), f"Error, cannot expand along {dim_} for tensor with {input_.dim()} dimensions."
+
+    input_format = get_memory_format(input_)
+    input_ = input_.contiguous(memory_format=input_format)
+    dim = dim_ % input_.dim()
+    rank = dist.get_rank(group=group)
+
+    expected_local_size = sizes[rank]
+    assert input_.shape[dim] == expected_local_size, (
+        f"Error, expected local shard size {expected_local_size} along dimension {dim} "
+        f"for rank {rank}, but got {input_.shape[dim]}"
+    )
+
+    output_shape = list(input_.shape)
+    output_shape[dim] = sum(sizes)
+    output = torch.empty(
+        output_shape,
+        dtype=input_.dtype,
+        layout=input_.layout,
+        device=input_.device,
+        memory_format=input_format,
+    )
+
+    start = sum(sizes[:rank])
+    output.narrow(dim, start, expected_local_size).copy_(input_)
+
+    return output
+
+
 def _reduce(input_: Tensor, use_fp32: bool = True, group: Optional[ProcessGroup] = None) -> Tensor:
     """All-reduce the input tensor across model parallel group."""
     # Modified from


### PR DESCRIPTION
## Description
Fix: shard_tensor when gather_in_backward=False to expand to correct shape without communication.

## What problem does this change solve?
<!-- Describe if it's a bugfix, new feature, doc update, or breaking change -->

## What issue or task does this change relate to?
<!-- link to Issue Number -->

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
