### PR TITLE
feat(training): Initial spectral AMSE implementation

### DIFF
--- a/training/src/anemoi/training/losses/__init__.py
+++ b/training/src/anemoi/training/losses/__init__.py
@@ -20,6 +20,7 @@ from .rmse import RMSELoss
 from .spectral import FourierCorrelationLoss
 from .spectral import LogFFT2Distance
 from .spectral import LogSpectralDistance
+from .spectral import SpectralAMSELoss
 from .spectral import SpectralCRPSLoss
 from .spectral import SpectralL2Loss
 from .variable_mapper import LossVariableMapper
@@ -39,6 +40,7 @@ __all__ = [
     "MSELoss",
     "MultiscaleLossWrapper",
     "RMSELoss",
+    "SpectralAMSELoss",
     "SpectralCRPSLoss",
     "SpectralL2Loss",
     "WeightedMSELoss",

--- a/training/src/anemoi/training/losses/spectral.py
+++ b/training/src/anemoi/training/losses/spectral.py
@@ -129,6 +129,99 @@ class SpectralLoss(BaseLoss):
         return x_spec.flatten(start_dim=spatial_start_dim, end_dim=-2)
 
 
+class SpectralAMSELoss(SpectralLoss):
+    r"""AMSE loss in spectral domain.
+
+    Implements the AMSE formula from Subich et al. (arXiv:2501.19374, 2025):
+
+    .. math::
+
+        \text{AMSE} = \sum_L \left[
+            \left( \sqrt{S^\text{pred}_L} - \sqrt{S^\text{target}_L} \right)^2
+            + 2 \max\!\left(S^\text{pred}_L,\, S^\text{target}_L\right)
+              \left(1 - \gamma_L \right)
+        \right]
+
+    where
+
+    .. math::
+
+        S_L = \sum_M \left| c_{L,M} \right|^2, \qquad
+        \gamma_L = \frac{
+            \operatorname{Re}\!\left[\sum_M c^\text{pred}_{L,M}
+                \overline{c^\text{target}_{L,M}}\right]
+        }{
+            \sqrt{S^\text{pred}_L}\,\sqrt{S^\text{target}_L} + \varepsilon
+        }.
+
+    The sum over :math:`M` is performed before the nonlinear AMSE computation.
+
+    The physical interpretation of :math:`L` and :math:`M` depends on the
+    spectral transform:
+
+    - ``octahedral_sht`` / ``reduced_sht``: :math:`L` is the total wavenumber
+      and :math:`M` is the zonal wavenumber, consistent with the original paper.
+      The sum over :math:`M` gives per-total-wavenumber power spectra.
+    - ``fft2d`` / ``dct2d``: :math:`L` is the meridional frequency index and
+      :math:`M` is the zonal frequency index. The sum over :math:`M` gives
+      per-meridional-wavenumber power spectra. This is mathematically valid but
+      no longer corresponds to the spherical-harmonic-motivated formulation of
+      the paper. For ``dct2d``, coefficients are real-valued; computing coherence
+      per coefficient before summing would degenerate to :math:`\pm 1`, but the
+      :math:`M`-sum here avoids this by computing coherence as a cosine similarity
+      over the zonal-frequency profile at each :math:`L`.
+    """
+
+    eps: float = 1e-8
+
+    def forward(
+        self,
+        pred: torch.Tensor,
+        target: torch.Tensor,
+        squash: bool = True,
+        *,
+        scaler_indices: tuple[int, ...] | None = None,
+        without_scalers: list[str] | list[int] | None = None,
+        grid_shard_slice: slice | None = None,
+        group: ProcessGroup | None = None,
+        squash_mode: str = "avg",
+        **kwargs,
+    ) -> torch.Tensor:
+        del kwargs  # unused
+        is_sharded = grid_shard_slice is not None
+        group = group if is_sharded else None
+
+        with torch.amp.autocast(device_type="cuda", enabled=False):
+            # transform to spectral domain: [B, T, E, grid, vars] -> [B, T, E, L, M, vars]
+            # don't flatten to modes here since we need to calculate PSD and coherence per-L
+            pred_spec = self.transform.forward(pred)
+            target_spec = self.transform.forward(target)
+
+            # per-L PSD: [B, T, E, L, vars]
+            psd_pred = (torch.abs(pred_spec) ** 2).sum(dim=-2)
+            psd_target = (torch.abs(target_spec) ** 2).sum(dim=-2)
+            # cross-spectrum summed over M: [B, T, E, L, vars]
+            cross = torch.real(pred_spec * torch.conj(target_spec)).sum(dim=-2)
+
+            amp_pred = torch.sqrt(psd_pred + self.eps)
+            amp_target = torch.sqrt(psd_target + self.eps)
+            coherence = cross / (amp_pred * amp_target + self.eps)
+
+            # per-L AMSE: [B, T, E, L, vars]
+            amse_per_l = (amp_pred - amp_target) ** 2 + 2 * torch.maximum(psd_pred, psd_target) * (1 - coherence)
+
+        # sum over L (dim 3) -> [B, T, E, 1, vars] (dummy grid dim for scale/reduce compat)
+        amse = amse_per_l.sum(dim=TensorDim.GRID.value, keepdim=True)
+
+        result = self.scale(
+            amse,
+            scaler_indices,
+            without_scalers=_ensure_without_scalers_has_grid_dimension(without_scalers),
+            grid_shard_slice=grid_shard_slice,
+        )
+        return self.reduce(result, squash=squash, group=group, squash_mode=squash_mode)
+
+
 class SpectralL2Loss(SpectralLoss):
     r"""L2 loss in spectral domain.
 


### PR DESCRIPTION
This pull request introduces a new loss function to the spectral losses module and updates the module's public API accordingly. The most significant change is the addition of the `SpectralAMSELoss` class, which implements the AMSE loss based on a recent research paper. The changes are as follows:

**New Loss Function Implementation:**

* Added the `SpectralAMSELoss` class to `spectral.py`, implementing the AMSE loss in the spectral domain as described by Subich et al. (arXiv:2501.19374, 2025). This loss computes amplitude and coherence differences between predicted and target spectra, and is compatible with multiple spectral transforms.

**API and Import Updates:**

* Added `SpectralAMSELoss` to the list of imports in `losses/__init__.py`, making it available for use throughout the package.
* Included `"SpectralAMSELoss"` in the `__all__` list in `losses/__init__.py`, ensuring it is part of the module's public API.

##  Additional notes ##
AMSE was introduced in Subich et al, 2025.
@jameschappell has thankfully provided their implementation and we are incorporating it in anemoi.

see https://github.com/ecmwf/anemoi-core/issues/1147


***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
