### PR TITLE
fix: spectral losses for lam

### DIFF
--- a/training/src/anemoi/training/losses/base.py
+++ b/training/src/anemoi/training/losses/base.py
@@ -47,6 +47,7 @@ class BaseLoss(nn.Module, ABC):
     def __init__(
         self,
         ignore_nans: bool = False,
+        **kwargs,
     ) -> None:
         """Node- and feature_weighted Loss.
 
@@ -70,6 +71,7 @@ class BaseLoss(nn.Module, ABC):
             Allow nans in the loss and apply methods ignoring nans for measuring the loss, by default False
 
         """
+        del kwargs
         super().__init__()
 
         self.add_module("scaler", ScaleTensor())

--- a/training/src/anemoi/training/losses/combined.py
+++ b/training/src/anemoi/training/losses/combined.py
@@ -126,6 +126,7 @@ class CombinedLoss(BaseLoss):
                         data_indices=data_indices,
                         graph_data=kwargs.get("graph_data"),
                         data_node_name=kwargs.get("data_node_name"),
+                        output_mask=kwargs.get("output_mask"),
                     ),
                 )
             elif isinstance(loss, type):

--- a/training/src/anemoi/training/losses/multiscale.py
+++ b/training/src/anemoi/training/losses/multiscale.py
@@ -49,6 +49,7 @@ class MultiscaleLossWrapper(BaseLossWrapper):
         # Deprecated: pass loss_matrices_path / loss_matrices inside multiscale_config instead.
         loss_matrices_path: Path | str | None = None,
         loss_matrices: list[Path | str] | None = None,
+        **kwargs,
     ) -> None:
         """Wrapper for multi-scale loss computation.
 
@@ -94,6 +95,7 @@ class MultiscaleLossWrapper(BaseLossWrapper):
         loss_matrices : list[Path | str] | None
             Deprecated.  Pass inside *multiscale_config* instead.
         """
+        del kwargs
         super().__init__(loss=per_scale_loss, ignore_nans=ignore_nans)
 
         _has_matrices = bool(loss_matrices)  # [None] still signals file mode (identity scale)

--- a/training/src/anemoi/training/losses/spectral.py
+++ b/training/src/anemoi/training/losses/spectral.py
@@ -38,6 +38,8 @@ from anemoi.training.losses.base import BaseLoss
 from anemoi.training.losses.kcrps import CRPS
 from anemoi.training.losses.kcrps import CRPSBackend
 from anemoi.training.utils.enums import TensorDim
+from anemoi.training.utils.masks import BaseMask
+from anemoi.training.utils.masks import NoOutputMask
 
 if TYPE_CHECKING:
     from torch.distributed.distributed_c10d import ProcessGroup
@@ -76,6 +78,7 @@ class SpectralLoss(BaseLoss):
         *,
         ignore_nans: bool = False,
         scalers: list | None = None,
+        output_mask: BaseMask | None = None,
         **kwargs,
     ) -> None:
         """Create a spectral loss.
@@ -97,6 +100,8 @@ class SpectralLoss(BaseLoss):
         # Backwards-compatibility: older configs pass scalers to the loss ctor.
         _ = scalers  # intentionally unused
         kwargs.pop("scalers", None)
+
+        self.output_mask = output_mask if output_mask is not None else NoOutputMask()
 
         # Sharding over grid dimension is not supported for spectral transforms.
         # Enforce loss to be calculated on full grids.
@@ -124,6 +129,7 @@ class SpectralLoss(BaseLoss):
 
     def _to_spectral_flat(self, x: torch.Tensor) -> torch.Tensor:
         """Transform to spectral domain and flatten spectral dimensions."""
+        x = self.output_mask.crop(x, dim=-2)
         x_spec = self.transform.forward(x)
         # flatten only transformed spatial/spectral dims into one "mode" axis
         spatial_start_dim = x.ndim - 2

--- a/training/src/anemoi/training/train/methods/base.py
+++ b/training/src/anemoi/training/train/methods/base.py
@@ -267,6 +267,7 @@ class BaseTrainingModule(pl.LightningModule, ABC):
                 data_indices[dataset_name],
                 graph_data=graph_data,
                 data_node_name=data_node_name,
+                output_mask=self.output_mask[dataset_name],
             )
 
             self.metrics[dataset_name] = self._build_metrics_for_dataset(
@@ -275,6 +276,7 @@ class BaseTrainingModule(pl.LightningModule, ABC):
                 data_indices=data_indices[dataset_name],
                 graph_data=graph_data,
                 data_node_name=data_node_name,
+                output_mask=self.output_mask[dataset_name],
             )
             self._scaling_values_log[dataset_name] = print_variable_scaling(
                 self.loss[dataset_name],
@@ -395,6 +397,7 @@ class BaseTrainingModule(pl.LightningModule, ABC):
         data_indices: IndexCollection,
         graph_data: object | None = None,
         data_node_name: str = DEFAULT_DATASET_NAME,
+        output_mask: object | None = None,
     ) -> torch.nn.ModuleDict:
         return torch.nn.ModuleDict(
             {
@@ -404,6 +407,7 @@ class BaseTrainingModule(pl.LightningModule, ABC):
                     data_indices=data_indices,
                     graph_data=graph_data,
                     data_node_name=data_node_name,
+                    output_mask=output_mask,
                 )
                 for metric_name, val_metric_config in validation_metrics_configs.items()
             },

--- a/training/src/anemoi/training/utils/masks.py
+++ b/training/src/anemoi/training/utils/masks.py
@@ -32,6 +32,7 @@ class BaseMask:
         error_message = "Method `apply` must be implemented in subclass."
         raise NotImplementedError(error_message)
 
+    @abstractmethod
     def rollout_boundary(self, x: torch.Tensor, *args, **kwargs) -> torch.Tensor:
         error_message = "Method `rollout_boundary` must be implemented in subclass."
         raise NotImplementedError(error_message)

--- a/training/src/anemoi/training/utils/masks.py
+++ b/training/src/anemoi/training/utils/masks.py
@@ -8,6 +8,7 @@
 # nor does it submit to any jurisdiction.
 
 
+import logging
 from abc import abstractmethod
 
 import numpy as np
@@ -15,6 +16,8 @@ import torch
 from torch_geometric.data.storage import NodeStorage
 
 from anemoi.models.data_indices.collection import IndexCollection
+
+LOGGER = logging.getLogger(__name__)
 
 
 class BaseMask:
@@ -33,6 +36,11 @@ class BaseMask:
         raise NotImplementedError(error_message)
 
     @abstractmethod
+    def crop(self, x: torch.Tensor, dim: int, **kwargs) -> torch.Tensor:
+        error_message = "Method `crop` must be implemented in subclass."
+        raise NotImplementedError(error_message)
+
+    @abstractmethod
     def rollout_boundary(self, x: torch.Tensor, *args, **kwargs) -> torch.Tensor:
         error_message = "Method `rollout_boundary` must be implemented in subclass."
         raise NotImplementedError(error_message)
@@ -46,6 +54,28 @@ class Boolean1DMask(torch.nn.Module, BaseMask):
 
         mask = nodes[attribute_name].bool().squeeze()
         self.register_buffer("mask", mask)
+
+        self._crop_start, self._crop_n = Boolean1DMask._find_contiguous_block(mask, attribute_name)
+
+    @staticmethod
+    def _find_contiguous_block(mask: torch.Tensor, attribute_name: str) -> tuple[int | None, int]:
+        """Return (start, n) for the contiguous True block in mask, or (None, n) if non-contiguous.
+
+        start is None when the True positions are non-contiguous,
+        in which case a warning is logged.
+        """
+        n = int(mask.sum())
+        if n > 0:
+            first = int(mask.int().argmax())
+            if bool(mask[first : first + n].all()):
+                return first, n
+            if n < len(mask):
+                LOGGER.warning(
+                    "Boolean1DMask %r: non-contiguous masked indices; "
+                    "reordering to a contiguous block would allow zero-copy operations.",
+                    attribute_name,
+                )
+        return None, n
 
     @property
     def supporting_arrays(self) -> dict:
@@ -109,6 +139,10 @@ class Boolean1DMask(torch.nn.Module, BaseMask):
 
     def crop(self, x: torch.Tensor, dim: int, grid_shard_slice: slice | None = None) -> torch.Tensor:
         """Return x with only the True positions of the mask along dim."""
+        if grid_shard_slice is None and self._crop_start is not None:
+            return x.narrow(dim, self._crop_start, self._crop_n)
+        # TODO(dieter): optimize for sharding.
+        # Currently crop is only called in SpectralLoss, which operates on unsharded states.
         mask = self.mask[grid_shard_slice] if grid_shard_slice is not None else self.mask
         indices = mask.nonzero(as_tuple=True)[0]
         return torch.index_select(x, dim, indices.to(x.device))

--- a/training/src/anemoi/training/utils/masks.py
+++ b/training/src/anemoi/training/utils/masks.py
@@ -32,7 +32,6 @@ class BaseMask:
         error_message = "Method `apply` must be implemented in subclass."
         raise NotImplementedError(error_message)
 
-    @abstractmethod
     def rollout_boundary(self, x: torch.Tensor, *args, **kwargs) -> torch.Tensor:
         error_message = "Method `rollout_boundary` must be implemented in subclass."
         raise NotImplementedError(error_message)
@@ -107,6 +106,12 @@ class Boolean1DMask(torch.nn.Module, BaseMask):
         mask = self.broadcast_like(x, dim, grid_shard_slice).cpu()
         return Boolean1DMask._fill_tensor_with_float(x, ~mask, fill_value)
 
+    def crop(self, x: torch.Tensor, dim: int, grid_shard_slice: slice | None = None) -> torch.Tensor:
+        """Return x with only the True positions of the mask along dim."""
+        mask = self.mask[grid_shard_slice] if grid_shard_slice is not None else self.mask
+        indices = mask.nonzero(as_tuple=True)[0]
+        return torch.index_select(x, dim, indices.to(x.device))
+
     def rollout_boundary(
         self,
         pred_state: torch.Tensor,
@@ -144,6 +149,9 @@ class NoOutputMask(BaseMask):
     """No output mask."""
 
     def apply(self, x: torch.Tensor, *args, **kwargs) -> torch.Tensor:  # noqa: ARG002
+        return x
+
+    def crop(self, x: torch.Tensor, dim: int, **kwargs) -> torch.Tensor:  # noqa: ARG002
         return x
 
     def rollout_boundary(self, x: torch.Tensor, *args, **kwargs) -> torch.Tensor:  # noqa: ARG002


### PR DESCRIPTION
## Description
Makes `SpectralLoss` respect `output_mask`, i.e. for lam models loss should be computed only on regional domain. 

## What problem does this change solve?
Spectral transform, and then spectral loss, is [automatically] computed only over region determined by `output_mask`, as was already the case for spatial losses.

## What issue or task does this change relate to?
#1142

##  Additional notes ##
Additional arguments for SpectralLosses, such as e.g. `x_dim` and `y_dim` as set in the config should be wrt the region selected by the `output_mask`, not wrt the full data grid.

Currently draft PR. Tests will be added once some sanity checks have been performed.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
