### PR TITLE
fix: add missing arguments to TruncatedConnection schema

### DIFF
--- a/models/src/anemoi/models/schemas/residual.py
+++ b/models/src/anemoi/models/schemas/residual.py
@@ -52,6 +52,9 @@ class TruncatedConnectionSchema(BaseModel):
     truncation_config: TruncationConfigDiskSchema | TruncationConfigOnTheFlySchema | None = None
     edge_weight_attribute: str | None = None
     src_node_weight_attribute: str | None = None
+    truncation_down_edges_name: tuple[str, str, str] | None = None
+    truncation_up_edges_name: tuple[str, str, str] | None = None
+    data_node_name: str | None = None
     autocast: bool = False
     row_normalize: bool = False
     # Deprecated: pass inside truncation_config instead.


### PR DESCRIPTION
## Description
Adds three missing fields to the Pydantic validation schema `TruncatedConnectionSchema` for the `TruncatedConnection` class.

## What problem does this change solve?
Due to some missing fields in the `TruncatedConnectionSchema` class some initialisations of the `TruncatedConnection` class are refuted by the Pydantic validation, resulting in a validation error.

## What issue or task does this change relate to?
#1144

##  Additional notes ##


***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
