### PR TITLE
fix(models): Disabled latent_skip == False does not use processor information x_latent_proc

### DIFF
--- a/models/src/anemoi/models/models/encoder_processor_decoder.py
+++ b/models/src/anemoi/models/models/encoder_processor_decoder.py
@@ -293,7 +293,7 @@ class AnemoiModelEncProcDec(BaseGraphModel):
 
         # Latent skip connection
         if self.latent_skip:
-            x_latent = x_latent_proc + x_latent
+            x_latent_proc = x_latent_proc + x_latent
 
         # Decoder
         x_out_dict = {}
@@ -314,7 +314,7 @@ class AnemoiModelEncProcDec(BaseGraphModel):
             )
 
             x_out = self.decoder[dataset_name](
-                (x_latent, x_data_latent_dict[dataset_name]),
+                (x_latent_proc, x_data_latent_dict[dataset_name]),
                 batch_size=batch_size,
                 shard_info=dec_shard_info,
                 edge_attr=decoder_edge_attr,

--- a/models/src/anemoi/models/models/ens_encoder_processor_decoder.py
+++ b/models/src/anemoi/models/models/ens_encoder_processor_decoder.py
@@ -279,7 +279,7 @@ class AnemoiEnsModelEncProcDec(AnemoiModelEncProcDec):
         )
 
         if self.latent_skip:
-            x_latent = x_latent_proc + x_latent
+            x_latent_proc = x_latent_proc + x_latent
 
         x_out_dict = {}
         for dataset_name in dataset_names:
@@ -300,7 +300,7 @@ class AnemoiEnsModelEncProcDec(AnemoiModelEncProcDec):
             )
 
             x_out = self.decoder[dataset_name](
-                (x_latent, x_data_latent_dict[dataset_name]),
+                (x_latent_proc, x_data_latent_dict[dataset_name]),
                 batch_size=batch_ens_size,
                 shard_info=dec_shard_info,
                 edge_attr=decoder_edge_attr,

--- a/models/src/anemoi/models/models/transport_encoder_processor_decoder.py
+++ b/models/src/anemoi/models/models/transport_encoder_processor_decoder.py
@@ -354,7 +354,7 @@ class AnemoiTransportModelEncProcDec(AnemoiModelEncProcDec):
 
         if self.latent_skip:
             # Processor skip connection
-            x_latent = x_latent_proc + x_latent
+            x_latent_proc = x_latent_proc + x_latent
 
         # Decoder
         x_out_dict = {}
@@ -376,7 +376,7 @@ class AnemoiTransportModelEncProcDec(AnemoiModelEncProcDec):
             )
 
             x_out = self.decoder[dataset_name](
-                (x_latent, x_data_latent_dict[dataset_name]),
+                (x_latent_proc, x_data_latent_dict[dataset_name]),
                 batch_size=bse,
                 shard_info=dec_shard_info,
                 edge_attr=decoder_edge_attr,


### PR DESCRIPTION
## Description
<!-- What issue or task does this change relate to? -->
For a given forecaster model if `self.latent_skip == False` then the decoder will retrieve information from the encoded state `x_latent` and not `x_latent_proc` from the processed state (i.e processor).

## What problem does this change solve?
<!-- Describe if it's a bugfix, new feature, doc update, or breaking change -->
old:
```
if self.latent_skip:
  # Processor skip connection
  x_latent = x_latent_proc + x_latent

x_out = self.decoder[dataset_name](
                (x_latent, x_data_latent_dict[dataset_name]),
                batch_size=bse,
                shard_info=dec_shard_info,
                edge_attr=decoder_edge_attr,
                edge_index=decoder_edge_index,
                model_comm_group=model_comm_group,
                keep_x_dst_sharded=in_out_sharded[dataset_name],
                **bwd_mapper_kwargs[dataset_name],
            )
```
fix:
```
if self.latent_skip:
  # Processor skip connection
  x_latent_proc = x_latent_proc + x_latent

x_out = self.decoder[dataset_name](
                (x_latent_proc, x_data_latent_dict[dataset_name]),
                batch_size=bse,
                shard_info=dec_shard_info,
                edge_attr=decoder_edge_attr,
                edge_index=decoder_edge_index,
                model_comm_group=model_comm_group,
                keep_x_dst_sharded=in_out_sharded[dataset_name],
                **bwd_mapper_kwargs[dataset_name],
            )
```

## What issue or task does this change relate to?
<!-- link to Issue Number -->
None

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->
I am a bit unsure about hierarchical model as I can see the same problem there, but pinning @icedoom888 here to check it out.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
