### PR TITLE
feat(training): load only data required for current rollout length

### DIFF
--- a/training/docs/user-guide/performance-optimisation.rst
+++ b/training/docs/user-guide/performance-optimisation.rst
@@ -277,10 +277,8 @@ their recommended settings
 
 .. note::
 
-   Longer rollout increases the CPU memory required by the dataloaders.
-   It can be beneficial to break rollout runs into multiple runs (e.g.
-   rollout 1->6 and rollout 7->12) and tune the number of workers for
-   both runs accordingly.
+   Dataloader CPU memory can increase as the active rollout length
+   grows. Longer rollouts might require reducing the number of workers.
 
 Change attention backend
 ========================

--- a/training/src/anemoi/training/data/datamodule.py
+++ b/training/src/anemoi/training/data/datamodule.py
@@ -149,6 +149,9 @@ class AnemoiDatasetsDataModule(pl.LightningDataModule):
                 continue
 
             dataset = self.__dict__[dataset_name]
+            # Store the current rollout length, and refresh the time steps that must
+            # be loaded for it. The task provides both values: steps() gives the rollout
+            # length, and get_offsets() gives the time steps via compute_relative_date_indices().
             dataset.set_epoch(
                 epoch,
                 rollout=len(tuple(self.task.steps(label))),

--- a/training/src/anemoi/training/data/datamodule.py
+++ b/training/src/anemoi/training/data/datamodule.py
@@ -141,20 +141,30 @@ class AnemoiDatasetsDataModule(pl.LightningDataModule):
         )
 
     def set_epoch(self, epoch: int) -> None:
-        """Update epoch-dependent dataset state before the next DataLoader worker launch."""
+        """Update the epoch for each dataset. This will take effect once the DataLoader workers are re-started."""
         self.epoch = epoch
-        if "ds_train" not in self.__dict__:
-            return
 
-        self.ds_train.set_epoch(
-            epoch,
-            rollout=len(tuple(self.task.steps("training"))),
-            relative_date_indices=compute_relative_date_indices(
-                self.task,
-                self.ds_train.data_readers,
-                mode="training",
-            ),
-        )
+        for dataset_name, label in (("ds_train", "training"), ("ds_valid", "validation"), ("ds_test", "test")):
+            if dataset_name not in self.__dict__:
+                continue
+
+            dataset = self.__dict__[dataset_name]
+            dataset.set_epoch(
+                epoch,
+                rollout=len(tuple(self.task.steps(label))),
+                relative_date_indices=compute_relative_date_indices(
+                    self.task,
+                    dataset.data_readers,
+                    mode=label,
+                ),
+            )
+
+    def _persistent_workers(self) -> bool:
+        """Return whether DataLoader workers can persist across epochs."""
+        rollout = getattr(self.task, "rollout", None)
+        if rollout is None:
+            return True
+        return rollout.epoch_increment == 0 or rollout.step >= rollout.maximum
 
     def _get_dataloader(self, ds: MultiDataset, stage: str) -> DataLoader:
         """Create DataLoader for multi-dataset."""
@@ -177,7 +187,7 @@ class AnemoiDatasetsDataModule(pl.LightningDataModule):
             pin_memory=self.config.dataloader.pin_memory,
             worker_init_fn=worker_init_func,
             prefetch_factor=self.config.dataloader.prefetch_factor,
-            persistent_workers=False,
+            persistent_workers=self._persistent_workers(),
             **extra,
         )
 

--- a/training/src/anemoi/training/data/datamodule.py
+++ b/training/src/anemoi/training/data/datamodule.py
@@ -61,6 +61,8 @@ class AnemoiDatasetsDataModule(pl.LightningDataModule):
         if not self.config.dataloader.pin_memory:
             LOGGER.info("Data loader memory pinning disabled.")
 
+        self.epoch = 0
+
     @cached_property
     def statistics(self) -> dict:
         """Return statistics from all training datasets."""
@@ -134,6 +136,24 @@ class AnemoiDatasetsDataModule(pl.LightningDataModule):
             relative_date_indices=relative_date_indices,
             shuffle=shuffle,
             label=label,
+            epoch=self.epoch,
+            rollout=len(tuple(self.task.steps(label))),
+        )
+
+    def set_epoch(self, epoch: int) -> None:
+        """Update epoch-dependent dataset state before the next DataLoader worker launch."""
+        self.epoch = epoch
+        if "ds_train" not in self.__dict__:
+            return
+
+        self.ds_train.set_epoch(
+            epoch,
+            rollout=len(tuple(self.task.steps("training"))),
+            relative_date_indices=compute_relative_date_indices(
+                self.task,
+                self.ds_train.data_readers,
+                mode="training",
+            ),
         )
 
     def _get_dataloader(self, ds: MultiDataset, stage: str) -> DataLoader:
@@ -157,7 +177,7 @@ class AnemoiDatasetsDataModule(pl.LightningDataModule):
             pin_memory=self.config.dataloader.pin_memory,
             worker_init_fn=worker_init_func,
             prefetch_factor=self.config.dataloader.prefetch_factor,
-            persistent_workers=True,
+            persistent_workers=False,
             **extra,
         )
 

--- a/training/src/anemoi/training/data/datamodule.py
+++ b/training/src/anemoi/training/data/datamodule.py
@@ -164,7 +164,10 @@ class AnemoiDatasetsDataModule(pl.LightningDataModule):
         rollout = getattr(self.task, "rollout", None)
         if rollout is None:
             return True
-        return rollout.epoch_increment == 0 or rollout.step >= rollout.maximum
+        # Workers could also be persisted once rollout.step >= rollout.maximum,
+        # but that would make resumed runs behave differently from uninterrupted
+        # runs.
+        return rollout.epoch_increment == 0
 
     def _get_dataloader(self, ds: MultiDataset, stage: str) -> DataLoader:
         """Create DataLoader for multi-dataset."""

--- a/training/src/anemoi/training/data/multidataset.py
+++ b/training/src/anemoi/training/data/multidataset.py
@@ -87,6 +87,7 @@ class MultiDataset(IterableDataset):
         if relative_date_indices is None:
             return
 
+        # Refresh which sample dates can provide the currently required time steps.
         self.valid_date_indices = compute_valid_data_indices(self.data_readers, relative_date_indices)
 
         # Normalize the date indices to use slices where possible, which can improve downstream indexing performance.

--- a/training/src/anemoi/training/data/multidataset.py
+++ b/training/src/anemoi/training/data/multidataset.py
@@ -42,6 +42,8 @@ class MultiDataset(IterableDataset):
         relative_date_indices: dict[str, TimeIndices],
         shuffle: bool = True,
         label: str = "multi",
+        epoch: int = 0,
+        rollout: int = 1,
     ) -> None:
         """Initialize multi-dataset with synchronized data readers.
 
@@ -56,11 +58,34 @@ class MultiDataset(IterableDataset):
             Shuffle batches, by default True
         label : str, optional
             label for the dataset, by default "multi"
+        epoch : int, optional
+            Epoch used for deterministic epoch-dependent shuffling, by default 0
+        rollout : int, optional
+            Rollout length represented by the loaded relative date indices, by default 1
         """
         self.data_readers = data_readers
         self.label = label
         self.shuffle = shuffle
         self.dataset_names = list(data_readers.keys())
+        self.epoch = epoch
+        self.rollout = rollout
+        self.set_epoch(epoch, rollout=rollout, relative_date_indices=relative_date_indices)
+
+        self._lazy_init_model_and_reader_group_info()
+
+    def set_epoch(
+        self,
+        epoch: int,
+        *,
+        rollout: int | None = None,
+        relative_date_indices: dict[str, TimeIndices] | None = None,
+    ) -> None:
+        """Set epoch-dependent sampling state before DataLoader workers are launched."""
+        self.epoch = epoch
+        if rollout is not None:
+            self.rollout = rollout
+        if relative_date_indices is None:
+            return
 
         self.valid_date_indices = compute_valid_data_indices(self.data_readers, relative_date_indices)
 
@@ -68,8 +93,6 @@ class MultiDataset(IterableDataset):
         self.relative_date_indices = {
             name: normalize_time_indices(indices) for name, indices in relative_date_indices.items()
         }
-
-        self._lazy_init_model_and_reader_group_info()
 
     def _lazy_init_model_and_reader_group_info(self) -> None:
         """Lazy initialize model and reader group info."""
@@ -265,17 +288,21 @@ class MultiDataset(IterableDataset):
         )
 
         base_seed = get_base_seed()
+        seed = base_seed + self.epoch
 
-        torch.manual_seed(base_seed)
-        random.seed(base_seed)
-        self.rng = np.random.default_rng(seed=base_seed)
+        torch.manual_seed(seed)
+        random.seed(seed)
+        self.seed = seed
+        self.rng = np.random.default_rng(seed=seed)
         sanity_rnd = self.rng.random(1)[0]
         LOGGER.info(
-            ("Worker %d (%s, pid %d, base_seed %d, sanity rnd %f)"),
+            ("Worker %d (%s, pid %d, epoch %d, rollout %d, seed %d, sanity rnd %f)"),
             worker_id,
             self.label,
             os.getpid(),
-            base_seed,
+            self.epoch,
+            self.rollout,
+            seed,
             sanity_rnd,
         )
 

--- a/training/src/anemoi/training/tasks/forecaster.py
+++ b/training/src/anemoi/training/tasks/forecaster.py
@@ -115,7 +115,7 @@ class Forecaster(BaseTask):
         if mode == "training":
             rollout_step = self.rollout.step
         elif mode == "validation":
-            rollout_step = self.rollout.maximum if self.validation_rollout is None else self.validation_rollout
+            rollout_step = self.rollout.step if self.validation_rollout is None else self.validation_rollout
         else:
             LOGGER.debug(
                 "Unknown mode '%s' for %s.get_offsets(); using offsets for the longest configured rollout.",

--- a/training/src/anemoi/training/tasks/forecaster.py
+++ b/training/src/anemoi/training/tasks/forecaster.py
@@ -34,7 +34,7 @@ class RolloutConfig:
 
     def should_increase(self, current_epoch: int) -> bool:
         """Check if rollout should be increased at the end of the current epoch."""
-        return self.epoch_increment > 0 and current_epoch % self.epoch_increment == 0
+        return self.epoch_increment > 0 and current_epoch % self.epoch_increment == 0 and self.step < self.maximum
 
     def increase(self) -> None:
         """Increase the rollout window by one step."""
@@ -49,10 +49,9 @@ class Forecaster(BaseTask):
     Builds input and output offsets from ``multistep_input``,
     ``multistep_output`` and a ``timestep`` string (e.g. ``"6H"``).
 
-    For rollout training the ``offset`` property extends the output
-    offsets up to ``rollout_max`` steps so the datamodule loads enough
-    time steps, while ``steps`` only iterates over the current
-    ``rollout`` value which grows via ``on_train_epoch_end``.
+    For rollout training, training offsets extend up to the current
+    ``rollout.step`` so the dataloader only loads the required time
+    steps. ``rollout.step`` grows via ``on_train_epoch_end``.
     """
 
     name: str = "forecaster"
@@ -114,7 +113,7 @@ class Forecaster(BaseTask):
 
     def get_offsets(self, mode: str | None = None) -> list[datetime.timedelta]:
         if mode == "training":
-            rollout_step = self.rollout.maximum
+            rollout_step = self.rollout.step
         elif mode == "validation":
             rollout_step = self.rollout.maximum if self.validation_rollout is None else self.validation_rollout
         else:

--- a/training/src/anemoi/training/train/methods/base.py
+++ b/training/src/anemoi/training/train/methods/base.py
@@ -1131,6 +1131,8 @@ class BaseTrainingModule(pl.LightningModule, ABC):
 
     def on_train_epoch_end(self) -> None:
         self.task.on_train_epoch_end(current_epoch=self.current_epoch)
+        if hasattr(self.trainer.datamodule, "set_epoch"):
+            self.trainer.datamodule.set_epoch(self.current_epoch + 1)
 
     def configure_optimizers(
         self,

--- a/training/src/anemoi/training/train/methods/base.py
+++ b/training/src/anemoi/training/train/methods/base.py
@@ -1131,8 +1131,7 @@ class BaseTrainingModule(pl.LightningModule, ABC):
 
     def on_train_epoch_end(self) -> None:
         self.task.on_train_epoch_end(current_epoch=self.current_epoch)
-        if hasattr(self.trainer.datamodule, "set_epoch"):
-            self.trainer.datamodule.set_epoch(self.current_epoch + 1)
+        self.trainer.datamodule.set_epoch(self.current_epoch + 1)
 
     def configure_optimizers(
         self,

--- a/training/tests/unit/data/test_datamodule.py
+++ b/training/tests/unit/data/test_datamodule.py
@@ -46,7 +46,7 @@ def _make_datamodule(task: Forecaster) -> AnemoiDatasetsDataModule:
     [
         ({"start": 1, "epoch_increment": 1, "maximum": 3}, False),
         ({"start": 1, "epoch_increment": 0, "maximum": 3}, True),
-        ({"start": 3, "epoch_increment": 1, "maximum": 3}, True),
+        ({"start": 3, "epoch_increment": 1, "maximum": 3}, False),
     ],
 )
 def test_persistent_workers_follow_shared_rollout_progression_policy(

--- a/training/tests/unit/data/test_datamodule.py
+++ b/training/tests/unit/data/test_datamodule.py
@@ -1,0 +1,132 @@
+# (C) Copyright 2026- Anemoi contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+from collections.abc import Iterator
+
+import pytest
+from omegaconf import DictConfig
+from pytest_mock import MockFixture
+from torch.utils.data import IterableDataset
+
+from anemoi.training.data.datamodule import AnemoiDatasetsDataModule
+from anemoi.training.tasks import Forecaster
+
+
+class TinyIterableDataset(IterableDataset):
+    """Minimal iterable dataset for DataLoader construction tests."""
+
+    def __iter__(self) -> Iterator[int]:
+        yield 0
+
+
+def _make_datamodule(task: Forecaster) -> AnemoiDatasetsDataModule:
+    datamodule = AnemoiDatasetsDataModule.__new__(AnemoiDatasetsDataModule)
+    datamodule.task = task
+    datamodule.config = DictConfig(
+        {
+            "dataloader": {
+                "batch_size": {"training": 1, "validation": 1, "test": 1},
+                "num_workers": {"training": 1, "validation": 1, "test": 1},
+                "pin_memory": False,
+                "prefetch_factor": 1,
+            },
+        },
+    )
+    return datamodule
+
+
+@pytest.mark.parametrize(
+    ("rollout", "persistent_workers"),
+    [
+        ({"start": 1, "epoch_increment": 1, "maximum": 3}, False),
+        ({"start": 1, "epoch_increment": 0, "maximum": 3}, True),
+        ({"start": 3, "epoch_increment": 1, "maximum": 3}, True),
+    ],
+)
+def test_persistent_workers_follow_shared_rollout_progression_policy(
+    rollout: dict[str, int],
+    persistent_workers: bool,
+) -> None:
+    """All dataloaders share the same persistence policy based on rollout progression."""
+    task = Forecaster(multistep_input=1, multistep_output=1, timestep="6h", rollout=rollout)
+    datamodule = _make_datamodule(task)
+
+    loaders = [datamodule._get_dataloader(TinyIterableDataset(), stage) for stage in ("training", "validation", "test")]
+
+    assert [loader.persistent_workers for loader in loaders] == [persistent_workers] * len(loaders)
+
+
+def test_set_epoch_updates_all_constructed_datasets(mocker: MockFixture) -> None:
+    """set_epoch updates every already-cached dataset and leaves lazy datasets untouched."""
+    datamodule = AnemoiDatasetsDataModule.__new__(AnemoiDatasetsDataModule)
+    datamodule.epoch = 0
+    datamodule.task = mocker.Mock()
+    datamodule.task.steps.side_effect = lambda label: tuple(
+        {} for _ in range({"training": 1, "validation": 2, "test": 3}[label])
+    )
+
+    ds_train = mocker.Mock()
+    ds_train.data_readers = {"data": object()}
+    ds_valid = mocker.Mock()
+    ds_valid.data_readers = {"data": object()}
+    ds_test = mocker.Mock()
+    ds_test.data_readers = {"data": object()}
+    datamodule.__dict__.update(ds_train=ds_train, ds_valid=ds_valid, ds_test=ds_test)
+
+    mocker.patch(
+        "anemoi.training.data.datamodule.compute_relative_date_indices",
+        side_effect=lambda _task, _data_readers, mode: {"data": [mode]},
+    )
+
+    datamodule.set_epoch(5)
+
+    assert datamodule.epoch == 5
+    ds_train.set_epoch.assert_called_once_with(
+        5,
+        rollout=1,
+        relative_date_indices={"data": ["training"]},
+    )
+    ds_valid.set_epoch.assert_called_once_with(
+        5,
+        rollout=2,
+        relative_date_indices={"data": ["validation"]},
+    )
+    ds_test.set_epoch.assert_called_once_with(
+        5,
+        rollout=3,
+        relative_date_indices={"data": ["test"]},
+    )
+
+
+def test_get_dataset_uses_current_epoch_for_lazy_construction(mocker: MockFixture) -> None:
+    """Datasets constructed after set_epoch receive the datamodule's current epoch."""
+    datamodule = AnemoiDatasetsDataModule.__new__(AnemoiDatasetsDataModule)
+    datamodule.epoch = 7
+    datamodule.task = mocker.Mock()
+    datamodule.task.steps.return_value = ({}, {})
+
+    data_reader = object()
+    create_dataset = mocker.patch("anemoi.training.data.datamodule.create_dataset", return_value=data_reader)
+    mocker.patch(
+        "anemoi.training.data.datamodule.compute_relative_date_indices",
+        return_value={"data": [0, 1]},
+    )
+    multi_dataset = mocker.patch("anemoi.training.data.datamodule.MultiDataset")
+
+    datamodule._get_dataset({"data": object()}, shuffle=False, label="validation")
+
+    create_dataset.assert_called_once()
+    multi_dataset.assert_called_once_with(
+        data_readers={"data": data_reader},
+        relative_date_indices={"data": [0, 1]},
+        shuffle=False,
+        label="validation",
+        epoch=7,
+        rollout=2,
+    )

--- a/training/tests/unit/data/test_multidataset.py
+++ b/training/tests/unit/data/test_multidataset.py
@@ -58,6 +58,34 @@ class TestMultiDataset:
         expected_indices = np.array([0, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23])
         assert np.array_equal(valid_indices, expected_indices)
 
+    def test_set_epoch_updates_contiguous_relative_date_indices(self, multi_dataset: MultiDataset) -> None:
+        """Test that set_epoch can update the loaded rollout to contiguous relative date indices."""
+        multi_dataset.set_epoch(
+            2,
+            rollout=3,
+            relative_date_indices={"dataset_a": [0, 1, 2], "dataset_b": [0, 1, 2]},
+        )
+
+        assert multi_dataset.epoch == 2
+        assert multi_dataset.rollout == 3
+        assert multi_dataset.relative_date_indices == {
+            "dataset_a": slice(0, 3, 1),
+            "dataset_b": slice(0, 3, 1),
+        }
+        assert len(multi_dataset.valid_date_indices) > 0
+
+    def test_worker_seed_includes_epoch(self, multi_dataset: MultiDataset, mocker: MockFixture) -> None:
+        """Test that worker RNG seed changes with epoch while staying shared across worker partitions."""
+        mocker.patch("anemoi.training.data.multidataset.get_base_seed", return_value=1000)
+
+        multi_dataset.set_epoch(0)
+        multi_dataset.per_worker_init(n_workers=1, worker_id=0)
+        assert multi_dataset.seed == 1000
+
+        multi_dataset.set_epoch(5)
+        multi_dataset.per_worker_init(n_workers=1, worker_id=0)
+        assert multi_dataset.seed == 1005
+
     def test_valid_date_indices_empty_dataset(self, multi_dataset: MultiDataset, mocker: MockFixture) -> None:
         """Test that MultiDataset raises ValueError when a dataset has no valid indices."""
         data_readers = multi_dataset.data_readers

--- a/training/tests/unit/tasks/test_forecaster.py
+++ b/training/tests/unit/tasks/test_forecaster.py
@@ -97,16 +97,16 @@ def test_forecaster_validation_rollout_none_follows_training_rollout() -> None:
     )
 
     assert list(task.steps("validation")) == [{"rollout_step": 0}]
-    assert task.get_offsets(mode="validation") == [
-        datetime.timedelta(0),
-        datetime.timedelta(hours=6),
-        datetime.timedelta(hours=12),
-        datetime.timedelta(hours=18),
-    ]
+    assert task.get_offsets(mode="validation") == [datetime.timedelta(0), datetime.timedelta(hours=6)]
 
     task.on_train_epoch_end(0)
 
     assert list(task.steps("validation")) == [{"rollout_step": 0}, {"rollout_step": 1}]
+    assert task.get_offsets(mode="validation") == [
+        datetime.timedelta(0),
+        datetime.timedelta(hours=6),
+        datetime.timedelta(hours=12),
+    ]
 
 
 def test_forecaster_steps_reflect_validation_rollout() -> None:

--- a/training/tests/unit/tasks/test_forecaster.py
+++ b/training/tests/unit/tasks/test_forecaster.py
@@ -117,6 +117,24 @@ def test_forecaster_steps_reflect_validation_rollout() -> None:
     assert list(task.steps("testing")) == [{"rollout_step": 0}]
 
 
+def test_forecaster_training_offsets_reflect_current_rollout() -> None:
+    """Training offsets grow with the current rollout instead of always using the configured maximum."""
+    task = Forecaster(
+        multistep_input=1,
+        multistep_output=1,
+        timestep="6h",
+        rollout={"start": 1, "epoch_increment": 1, "maximum": 3},
+    )
+
+    assert task.get_offsets(mode="training") == [datetime.timedelta(0), datetime.timedelta(hours=6)]
+    task.on_train_epoch_end(0)
+    assert task.get_offsets(mode="training") == [
+        datetime.timedelta(0),
+        datetime.timedelta(hours=6),
+        datetime.timedelta(hours=12),
+    ]
+
+
 def test_forecaster_metric_name_encodes_rollout_step() -> None:
     """get_metric_name returns a string containing the rollout step index."""
     task = Forecaster(multistep_input=1, multistep_output=1, timestep="6h")


### PR DESCRIPTION
This branch changes rollout training so the dataloader follows the current rollout length instead of always using the maximum configured rollout.

- Training dataloader offsets use the current rollout length.
- Validation without validation_rollout also uses the current training rollout window.
- Train/validation/test datasets are updated when the epoch changes.
- Dataloader worker persistence depends on whether epoch_increment > 0
- Worker seeds include the epoch.

@cathalobrien @HCookie @japols 

<!-- readthedocs-preview anemoi-training start -->
----
📚 Documentation preview 📚: https://anemoi-training--1169.org.readthedocs.build/en/1169/

<!-- readthedocs-preview anemoi-training end -->

<!-- readthedocs-preview anemoi-graphs start -->
----
📚 Documentation preview 📚: https://anemoi-graphs--1169.org.readthedocs.build/en/1169/

<!-- readthedocs-preview anemoi-graphs end -->

<!-- readthedocs-preview anemoi-models start -->
----
📚 Documentation preview 📚: https://anemoi-models--1169.org.readthedocs.build/en/1169/

<!-- readthedocs-preview anemoi-models end -->