### PR TITLE
fix: spectral loss for lam

### DIFF
--- a/training/docs/modules/losses.rst
+++ b/training/docs/modules/losses.rst
@@ -241,12 +241,13 @@ Supported transforms include:
   native grid of ERA5 such as N320.
 * ``OctahedralSHT``: Spherical harmonic transform (SHT) on the octahedral reduced Gaussian grid.
 
-.. note::
+.. notes::
 
-   SHT-based transforms expect a flattened reduced-grid ordering:
+   1. SHT-based transforms expect a flattened reduced-grid ordering:
    ``[batch, ensemble, grid_points, variables]`` and return spectral coefficients with
    shape ``[batch, ensemble, l, m, variables]`` where ``l = truncation + 1``.
 
+<<<<<<< Updated upstream
 .. note::
 
    ``ReducedSHT`` and ``OctahedralSHT`` both perform a spherical harmonic transform on a reduced Gaussian grid.
@@ -254,11 +255,16 @@ Supported transforms include:
    executed on GPUs. Therefore an optimised version using graphs is provided, which can be switched on by setting
    ``use_graphed_rfft=True`` in the section of the config file corresponding to your spectral loss. This can provide
    significant speedups, but may not be supported on all devices and can have higher memory usage.
+=======
+   2. Before the transform is applied the grid can be subset to a subgrid by setting the optional ``subgrid`` argument.
+   This can be a slice represented by a tuple, e.g. ``(0, 100)``, to select the first 100 gridpoints, or the string ``output_mask``
+   that will restrict to grid to the region specified by the ``output_mask`` of LAM models.
+>>>>>>> Stashed changes
 
 Spectral projections
 --------------------
 
-Before the spectral transform is applied, an optional sparse projection can remap
+Before the spectral transform is applied, but after the grid has been subset, an optional sparse projection can remap
 the input field from its native (possibly unstructured) grid to the regular 2D grid
 expected by the transform. This is configured via the ``projection_config`` key and
 works with *any* spectral loss class (``SpectralCRPSLoss``, ``SpectralL2Loss``,

--- a/training/docs/modules/losses.rst
+++ b/training/docs/modules/losses.rst
@@ -241,13 +241,12 @@ Supported transforms include:
   native grid of ERA5 such as N320.
 * ``OctahedralSHT``: Spherical harmonic transform (SHT) on the octahedral reduced Gaussian grid.
 
-.. notes::
+.. note::
 
-   1. SHT-based transforms expect a flattened reduced-grid ordering:
+   SHT-based transforms expect a flattened reduced-grid ordering:
    ``[batch, ensemble, grid_points, variables]`` and return spectral coefficients with
    shape ``[batch, ensemble, l, m, variables]`` where ``l = truncation + 1``.
 
-<<<<<<< Updated upstream
 .. note::
 
    ``ReducedSHT`` and ``OctahedralSHT`` both perform a spherical harmonic transform on a reduced Gaussian grid.
@@ -255,11 +254,13 @@ Supported transforms include:
    executed on GPUs. Therefore an optimised version using graphs is provided, which can be switched on by setting
    ``use_graphed_rfft=True`` in the section of the config file corresponding to your spectral loss. This can provide
    significant speedups, but may not be supported on all devices and can have higher memory usage.
-=======
-   2. Before the transform is applied the grid can be subset to a subgrid by setting the optional ``subgrid`` argument.
+
+.. note::
+
+   Before the transform is applied the grid can be subset to a subgrid by setting the optional ``subgrid`` argument.
    This can be a slice represented by a tuple, e.g. ``(0, 100)``, to select the first 100 gridpoints, or the string ``output_mask``
    that will restrict to grid to the region specified by the ``output_mask`` of LAM models.
->>>>>>> Stashed changes
+
 
 Spectral projections
 --------------------

--- a/training/src/anemoi/training/losses/spectral.py
+++ b/training/src/anemoi/training/losses/spectral.py
@@ -81,7 +81,7 @@ class SpectralLoss(BaseLoss):
             "dct2d",
         ] = "fft2d",
         *,
-        nodes_slice: tuple[int, int | None] | None = None,
+        nodes_slice: slice = slice(None),
         projection_config: object | None = None,
         graph_data: HeteroData | None = None,
         data_node_name: str = DEFAULT_DATASET_NAME,
@@ -128,7 +128,7 @@ class SpectralLoss(BaseLoss):
         # Enforce loss to be calculated on full grids.
         self.supports_sharding = False
 
-        self.nodes_slice = slice(*(nodes_slice or (0, None)))
+        self.nodes_slice = nodes_slice
         self.projection_provider = ProjectionGraphProvider.from_config(
             projection_config,
             graph_data=graph_data,

--- a/training/src/anemoi/training/losses/spectral.py
+++ b/training/src/anemoi/training/losses/spectral.py
@@ -96,26 +96,23 @@ class SpectralLoss(BaseLoss):
         transform
             Spectral transform type.
         subgrid
-            Optional ``(start, end)`` slice to select a subset of nodes before
-            the transform. ``end`` may be ``None`` to select to the last node.
+            Optional ``(start, end)`` slice applied to the grid before the transform;
+            ``end=None`` runs to the last gridpoint.
         projection_config
-            Optional config for a sparse projection applied after the node
-            slice and before the spectral transform.  See
+            Optional sparse-projection config applied after the slice and before the
+            transform. See
             :meth:`~anemoi.models.layers.graph_provider.ProjectionGraphProvider.from_config`
-            for supported modes.
+            for the supported modes.
         graph_data
-            Full model graph; required when *projection_config* uses edge or
-            target-grid mode.
+            Model graph; required when *projection_config* uses edge or target-grid mode.
         data_node_name
-            Node type in *graph_data* holding data-grid coordinates.
+            Node type in *graph_data* holding the data-grid coordinates.
         ignore_nans
-            Spectral losses cannot handle missing values;
-            ignore_nans must be False.
+            Must be False; spectral losses cannot handle missing values.
         scalers
-            Kept for Hydra/config backwards compatibility. This module does not
-            consume this argument directly (scaling is handled by BaseLoss).
+            Accepted for config backwards-compatibility; scaling is handled by BaseLoss.
         kwargs
-            Additional arguments for the spectral transform.
+            Forwarded to the spectral transform.
         """
         assert not ignore_nans, "Spectral losses cannot handle missing values; ignore_nans must be False"
         BaseLoss.__init__(self, ignore_nans=ignore_nans)
@@ -145,12 +142,12 @@ class SpectralLoss(BaseLoss):
             self.transform = DCT2D(**kwargs)
         elif transform == "reduced_sht":
             # expected additional args: grid
-            # optional args: truncation
+            # optional args: truncation, use_graphed_rfft
             LOGGER.info("Using ReducedSHT spectral transform in spectral loss.")
             self.transform = ReducedSHT(**kwargs)
         elif transform == "octahedral_sht":
             # expected additional args: nlat
-            # optional args: truncation
+            # optional args: truncation, use_graphed_rfft
             LOGGER.info("Using Octahedral SHT spectral transform in spectral loss.")
             self.transform = OctahedralSHT(**kwargs)
         else:
@@ -158,24 +155,26 @@ class SpectralLoss(BaseLoss):
             raise ValueError(msg)
 
     def _select_subgrid(self, x: torch.Tensor) -> torch.Tensor:
-        # Slice the grid dim as a view, avoiding an explicit index-tensor allocation.
+        # Obtain a subgrid by slicing the grid dim as a view, avoiding an explicit index-tensor allocation.
         index = [slice(None)] * x.ndim
         index[TensorDim.GRID] = self.subgrid
         return x[tuple(index)]
 
-    def _prepare_spatial(self, x: torch.Tensor) -> torch.Tensor:
+    def _select_and_project(self, x: torch.Tensor) -> torch.Tensor:
         x = self._select_subgrid(x)
         if self.projection_provider is not None:
-            x = self.projector.apply_with_provider(x, self.projection_provider)
+            x = self.projector.project(x, self.projection_provider)
         return x
 
+    def _to_spectral(self, x: torch.Tensor) -> torch.Tensor:
+        """Select the node subset and optionally project to the target grid, then transform to the spectral domain."""
+        return self.transform.forward(self._select_and_project(x))
+
     def _to_spectral_flat(self, x: torch.Tensor) -> torch.Tensor:
-        """Transform to spectral domain and flatten spectral dimensions."""
-        x = self._prepare_spatial(x)
-        x_spec = self.transform.forward(x)
-        # flatten only transformed spatial/spectral dims into one "mode" axis
-        spatial_start_dim = x.ndim - 2
-        return x_spec.flatten(start_dim=spatial_start_dim, end_dim=-2)
+        """Transform to spectral domain and flatten the transformed dims into one "mode" axis."""
+        x_spec = self._to_spectral(x)
+        # the transform splits the single grid dim into two spectral dims; flatten them back to one
+        return x_spec.flatten(start_dim=x_spec.ndim - 3, end_dim=-2)
 
 
 class SpectralAMSELoss(SpectralLoss):
@@ -247,8 +246,8 @@ class SpectralAMSELoss(SpectralLoss):
         with torch.amp.autocast(device_type=pred.device.type, enabled=False):
             # transform to spectral domain: [B, T, E, grid, vars] -> [B, T, E, L, M, vars]
             # don't flatten to modes here since we need to calculate PSD and coherence per-L
-            pred_spec = self.transform.forward(pred)
-            target_spec = self.transform.forward(target)
+            pred_spec = self._to_spectral(pred)
+            target_spec = self._to_spectral(target)
 
             # per-L PSD: [B, T, E, L, vars]
             psd_pred = self.transform.power_spectral_density(pred_spec)

--- a/training/src/anemoi/training/losses/spectral.py
+++ b/training/src/anemoi/training/losses/spectral.py
@@ -30,9 +30,6 @@ from typing import Literal
 import einops
 import torch
 
-from anemoi.graphs.projection_helpers import DEFAULT_DATASET_NAME
-from anemoi.models.layers.graph_provider import ProjectionGraphProvider
-from anemoi.models.layers.sparse_projector import SparseProjector
 from anemoi.models.layers.spectral_transforms import DCT2D
 from anemoi.models.layers.spectral_transforms import FFT2D
 from anemoi.models.layers.spectral_transforms import OctahedralSHT
@@ -46,7 +43,6 @@ from anemoi.training.utils.enums import TensorDim
 
 if TYPE_CHECKING:
     from torch.distributed.distributed_c10d import ProcessGroup
-    from torch_geometric.data import HeteroData
 
 LOGGER = logging.getLogger(__name__)
 
@@ -70,7 +66,6 @@ class SpectralLoss(BaseLoss):
     """Base class for spectral losses."""
 
     transform: SpectralTransform
-    needs_graph_data: bool = True
 
     def __init__(
         self,
@@ -81,10 +76,6 @@ class SpectralLoss(BaseLoss):
             "dct2d",
         ] = "fft2d",
         *,
-        subgrid: slice = slice(None),
-        projection_config: object | None = None,
-        graph_data: HeteroData | None = None,
-        data_node_name: str = DEFAULT_DATASET_NAME,
         ignore_nans: bool = False,
         scalers: list | None = None,
         **kwargs,
@@ -95,23 +86,14 @@ class SpectralLoss(BaseLoss):
         ----------
         transform
             Spectral transform type.
-        subgrid
-            Optional slice to subset the grid before the transform.
-        projection_config
-            Optional sparse-projection config applied after the slice and before the
-            transform. See
-            :meth:`~anemoi.models.layers.graph_provider.ProjectionGraphProvider.from_config`
-            for the supported modes.
-        graph_data
-            Model graph; required when *projection_config* uses edge or target-grid mode.
-        data_node_name
-            Node type in *graph_data* holding the data-grid coordinates.
         ignore_nans
-            Must be False; spectral losses cannot handle missing values.
+            Spectral losses cannot handle missing values;
+            ignore_nans must be False.
         scalers
-            Accepted for config backwards-compatibility; scaling is handled by BaseLoss.
+            Kept for Hydra/config backwards compatibility. This module does not
+            consume this argument directly (scaling is handled by BaseLoss).
         kwargs
-            Forwarded to the spectral transform.
+            Additional arguments for the spectral transform.
         """
         assert not ignore_nans, "Spectral losses cannot handle missing values; ignore_nans must be False"
         BaseLoss.__init__(self, ignore_nans=ignore_nans)
@@ -123,15 +105,6 @@ class SpectralLoss(BaseLoss):
         # Sharding over grid dimension is not supported for spectral transforms.
         # Enforce loss to be calculated on full grids.
         self.supports_sharding = False
-
-        self.subgrid = subgrid
-        self.projection_provider = ProjectionGraphProvider.from_config(
-            projection_config,
-            graph_data=graph_data,
-            data_node_name=data_node_name,
-        )
-        if self.projection_provider is not None:
-            self.projector = SparseProjector()
 
         if transform == "fft2d":
             LOGGER.info("Using FFT2D spectral transform in spectral loss.")
@@ -153,27 +126,12 @@ class SpectralLoss(BaseLoss):
             msg = f"Unknown transform type: {transform}"
             raise ValueError(msg)
 
-    def _subset_grid(self, x: torch.Tensor) -> torch.Tensor:
-        # Slice the grid dim as a view, avoiding an explicit index-tensor allocation.
-        index = [slice(None)] * x.ndim
-        index[TensorDim.GRID] = self.subgrid
-        return x[tuple(index)]
-
-    def _select_and_project(self, x: torch.Tensor) -> torch.Tensor:
-        x = self._subset_grid(x)
-        if self.projection_provider is not None:
-            x = self.projector.project(x, self.projection_provider)
-        return x
-
-    def _to_spectral(self, x: torch.Tensor) -> torch.Tensor:
-        """Select the node subset and optionally project to the target grid, then transform to the spectral domain."""
-        return self.transform.forward(self._select_and_project(x))
-
     def _to_spectral_flat(self, x: torch.Tensor) -> torch.Tensor:
-        """Transform to spectral domain and flatten the transformed dims into one "mode" axis."""
-        x_spec = self._to_spectral(x)
-        # the transform splits the single grid dim into two spectral dims; flatten them back to one
-        return x_spec.flatten(start_dim=x_spec.ndim - 3, end_dim=-2)
+        """Transform to spectral domain and flatten spectral dimensions."""
+        x_spec = self.transform.forward(x)
+        # flatten only transformed spatial/spectral dims into one "mode" axis
+        spatial_start_dim = x.ndim - 2
+        return x_spec.flatten(start_dim=spatial_start_dim, end_dim=-2)
 
 
 class SpectralAMSELoss(SpectralLoss):
@@ -245,8 +203,8 @@ class SpectralAMSELoss(SpectralLoss):
         with torch.amp.autocast(device_type=pred.device.type, enabled=False):
             # transform to spectral domain: [B, T, E, grid, vars] -> [B, T, E, L, M, vars]
             # don't flatten to modes here since we need to calculate PSD and coherence per-L
-            pred_spec = self._to_spectral(pred)
-            target_spec = self._to_spectral(target)
+            pred_spec = self.transform.forward(pred)
+            target_spec = self.transform.forward(target)
 
             # per-L PSD: [B, T, E, L, vars]
             psd_pred = self.transform.power_spectral_density(pred_spec)

--- a/training/src/anemoi/training/losses/spectral.py
+++ b/training/src/anemoi/training/losses/spectral.py
@@ -81,7 +81,7 @@ class SpectralLoss(BaseLoss):
             "dct2d",
         ] = "fft2d",
         *,
-        nodes_slice: slice = slice(None),
+        subgrid: slice = slice(None),
         projection_config: object | None = None,
         graph_data: HeteroData | None = None,
         data_node_name: str = DEFAULT_DATASET_NAME,
@@ -95,9 +95,8 @@ class SpectralLoss(BaseLoss):
         ----------
         transform
             Spectral transform type.
-        nodes_slice
-            Optional ``(start, end)`` node slice applied before the transform;
-            ``end=None`` runs to the last node.
+        subgrid
+            Optional slice to subset the grid before the transform.
         projection_config
             Optional sparse-projection config applied after the slice and before the
             transform. See
@@ -125,7 +124,7 @@ class SpectralLoss(BaseLoss):
         # Enforce loss to be calculated on full grids.
         self.supports_sharding = False
 
-        self.nodes_slice = nodes_slice
+        self.subgrid = subgrid
         self.projection_provider = ProjectionGraphProvider.from_config(
             projection_config,
             graph_data=graph_data,
@@ -154,14 +153,14 @@ class SpectralLoss(BaseLoss):
             msg = f"Unknown transform type: {transform}"
             raise ValueError(msg)
 
-    def _apply_nodes_slice(self, x: torch.Tensor) -> torch.Tensor:
+    def _subset_grid(self, x: torch.Tensor) -> torch.Tensor:
         # Slice the grid dim as a view, avoiding an explicit index-tensor allocation.
         index = [slice(None)] * x.ndim
-        index[TensorDim.GRID] = self.nodes_slice
+        index[TensorDim.GRID] = self.subgrid
         return x[tuple(index)]
 
     def _select_and_project(self, x: torch.Tensor) -> torch.Tensor:
-        x = self._apply_nodes_slice(x)
+        x = self._subset_grid(x)
         if self.projection_provider is not None:
             x = self.projector.project(x, self.projection_provider)
         return x

--- a/training/src/anemoi/training/losses/spectral.py
+++ b/training/src/anemoi/training/losses/spectral.py
@@ -30,6 +30,9 @@ from typing import Literal
 import einops
 import torch
 
+from anemoi.graphs.projection_helpers import DEFAULT_DATASET_NAME
+from anemoi.models.layers.graph_provider import ProjectionGraphProvider
+from anemoi.models.layers.sparse_projector import SparseProjector
 from anemoi.models.layers.spectral_transforms import DCT2D
 from anemoi.models.layers.spectral_transforms import FFT2D
 from anemoi.models.layers.spectral_transforms import OctahedralSHT
@@ -43,6 +46,7 @@ from anemoi.training.utils.enums import TensorDim
 
 if TYPE_CHECKING:
     from torch.distributed.distributed_c10d import ProcessGroup
+    from torch_geometric.data import HeteroData
 
 LOGGER = logging.getLogger(__name__)
 
@@ -66,6 +70,7 @@ class SpectralLoss(BaseLoss):
     """Base class for spectral losses."""
 
     transform: SpectralTransform
+    needs_graph_data: bool = True
 
     def __init__(
         self,
@@ -76,6 +81,10 @@ class SpectralLoss(BaseLoss):
             "dct2d",
         ] = "fft2d",
         *,
+        subgrid: tuple[int, int | None] | None = None,
+        projection_config: object | None = None,
+        graph_data: HeteroData | None = None,
+        data_node_name: str = DEFAULT_DATASET_NAME,
         ignore_nans: bool = False,
         scalers: list | None = None,
         **kwargs,
@@ -86,6 +95,19 @@ class SpectralLoss(BaseLoss):
         ----------
         transform
             Spectral transform type.
+        subgrid
+            Optional ``(start, end)`` slice to select a subset of nodes before
+            the transform. ``end`` may be ``None`` to select to the last node.
+        projection_config
+            Optional config for a sparse projection applied after the node
+            slice and before the spectral transform.  See
+            :meth:`~anemoi.models.layers.graph_provider.ProjectionGraphProvider.from_config`
+            for supported modes.
+        graph_data
+            Full model graph; required when *projection_config* uses edge or
+            target-grid mode.
+        data_node_name
+            Node type in *graph_data* holding data-grid coordinates.
         ignore_nans
             Spectral losses cannot handle missing values;
             ignore_nans must be False.
@@ -106,6 +128,15 @@ class SpectralLoss(BaseLoss):
         # Enforce loss to be calculated on full grids.
         self.supports_sharding = False
 
+        self.subgrid = slice(*(subgrid or (0, None)))
+        self.projection_provider = ProjectionGraphProvider.from_config(
+            projection_config,
+            graph_data=graph_data,
+            data_node_name=data_node_name,
+        )
+        if self.projection_provider is not None:
+            self.projector = SparseProjector()
+
         if transform == "fft2d":
             LOGGER.info("Using FFT2D spectral transform in spectral loss.")
             self.transform = FFT2D(**kwargs)
@@ -114,20 +145,33 @@ class SpectralLoss(BaseLoss):
             self.transform = DCT2D(**kwargs)
         elif transform == "reduced_sht":
             # expected additional args: grid
-            # optional args: truncation, use_graphed_rfft
+            # optional args: truncation
             LOGGER.info("Using ReducedSHT spectral transform in spectral loss.")
             self.transform = ReducedSHT(**kwargs)
         elif transform == "octahedral_sht":
             # expected additional args: nlat
-            # optional args: truncation, use_graphed_rfft
+            # optional args: truncation
             LOGGER.info("Using Octahedral SHT spectral transform in spectral loss.")
             self.transform = OctahedralSHT(**kwargs)
         else:
             msg = f"Unknown transform type: {transform}"
             raise ValueError(msg)
 
+    def _select_subgrid(self, x: torch.Tensor) -> torch.Tensor:
+        # Slice the grid dim as a view, avoiding an explicit index-tensor allocation.
+        index = [slice(None)] * x.ndim
+        index[TensorDim.GRID] = self.subgrid
+        return x[tuple(index)]
+
+    def _prepare_spatial(self, x: torch.Tensor) -> torch.Tensor:
+        x = self._select_subgrid(x)
+        if self.projection_provider is not None:
+            x = self.projector.apply_with_provider(x, self.projection_provider)
+        return x
+
     def _to_spectral_flat(self, x: torch.Tensor) -> torch.Tensor:
         """Transform to spectral domain and flatten spectral dimensions."""
+        x = self._prepare_spatial(x)
         x_spec = self.transform.forward(x)
         # flatten only transformed spatial/spectral dims into one "mode" axis
         spatial_start_dim = x.ndim - 2

--- a/training/src/anemoi/training/schemas/training.py
+++ b/training/src/anemoi/training/schemas/training.py
@@ -470,8 +470,8 @@ class SpectralLossSchema(BaseLossSchema):
 
     transform: Literal["fft2d", "dct2d", "reduced_sht", "octahedral_sht"] = Field(..., example="fft2d")
     """Type of spectral transform to use."""
-    nodes_slice: tuple[int, int | None] | None = None
-    """Optional ``(start, end)`` slice to select a subset of nodes before the transform."""
+    subgrid: tuple[int, int | None] | str | None = None
+    """Optional slice or string to select a subgrid before the transform."""
     projection_config: SpectralProjectionConfigSchema | None = None
     """Optional sparse projection applied to the data before the spectral transform."""
 

--- a/training/src/anemoi/training/train/methods/base.py
+++ b/training/src/anemoi/training/train/methods/base.py
@@ -226,7 +226,7 @@ class BaseTrainingModule(pl.LightningModule, ABC):
 
         dataset_variable_groups = get_multiple_datasets_config(self.config.training.variable_groups)
         loss_configs = get_multiple_datasets_config(config.training.training_loss)
-        self._resolve_nodes_slice(loss_configs)
+        self._resolve_subgrid(loss_configs)
 
         scalers_configs = get_multiple_datasets_config(config.training.scalers)
         val_metrics_configs = get_multiple_datasets_config(config.training.validation_metrics)
@@ -1170,12 +1170,12 @@ class BaseTrainingModule(pl.LightningModule, ABC):
             hyper_params.update({"variable_loss_scaling": self._scaling_values_log})
             self.logger.log_hyperparams(hyper_params)
 
-    def _resolve_nodes_slice(self, config: dict) -> None:
+    def _resolve_subgrid(self, config: dict) -> None:
         def per_dataset_resolve(per_dataset_config: dict, dataset_name: str) -> None:
             for k, v in per_dataset_config.items():
                 if isinstance(v, dict):
                     per_dataset_resolve(v, dataset_name)
-                elif k == "nodes_slice":
+                elif k == "subgrid":
                     if v == "output_mask":
                         per_dataset_config[k] = self.output_mask[dataset_name].as_slice()
                     else:

--- a/training/src/anemoi/training/train/methods/base.py
+++ b/training/src/anemoi/training/train/methods/base.py
@@ -1175,11 +1175,8 @@ class BaseTrainingModule(pl.LightningModule, ABC):
             for k, v in per_dataset_config.items():
                 if isinstance(v, dict):
                     per_dataset_resolve(v, dataset_name)
-                elif k == "subgrid":
-                    if v == "output_mask":
-                        per_dataset_config[k] = self.output_mask[dataset_name].as_slice()
-                    else:
-                        per_dataset_config[k] = slice(*(v or (0, None)))
+                elif (k, v) == ("subgrid", "output_mask"):
+                    per_dataset_config[k] = self.output_mask[dataset_name].as_tuple()
 
         for dataset_name, dataset_config in config.items():
             if dataset_config is not None:

--- a/training/src/anemoi/training/train/methods/base.py
+++ b/training/src/anemoi/training/train/methods/base.py
@@ -226,6 +226,8 @@ class BaseTrainingModule(pl.LightningModule, ABC):
 
         dataset_variable_groups = get_multiple_datasets_config(self.config.training.variable_groups)
         loss_configs = get_multiple_datasets_config(config.training.training_loss)
+        self._resolve_nodes_slice(loss_configs)
+
         scalers_configs = get_multiple_datasets_config(config.training.scalers)
         val_metrics_configs = get_multiple_datasets_config(config.training.validation_metrics)
         metrics_to_log = get_multiple_datasets_config(config.training.metrics)
@@ -1160,3 +1162,18 @@ class BaseTrainingModule(pl.LightningModule, ABC):
             hyper_params = OmegaConf.to_container(self.config, resolve=True)
             hyper_params.update({"variable_loss_scaling": self._scaling_values_log})
             self.logger.log_hyperparams(hyper_params)
+
+    def _resolve_nodes_slice(self, config: dict) -> None:
+        def per_dataset_resolve(per_dataset_config: dict, dataset_name: str) -> None:
+            for k, v in per_dataset_config.items():
+                if isinstance(v, dict):
+                    per_dataset_resolve(v, dataset_name)
+                elif k == "nodes_slice":
+                    if v == "output_mask":
+                        per_dataset_config[k] = self.output_mask[dataset_name].as_slice()
+                    else:
+                        per_dataset_config[k] = slice(*(v or (0, None)))
+
+        for dataset_name, dataset_config in config.items():
+            if dataset_config is not None:
+                per_dataset_resolve(dataset_config, dataset_name)

--- a/training/src/anemoi/training/utils/masks.py
+++ b/training/src/anemoi/training/utils/masks.py
@@ -28,6 +28,11 @@ class BaseMask:
         return {}
 
     @abstractmethod
+    def as_slice(self) -> slice:
+        error_message = "Method `as_slice` must be implemented in subclass."
+        raise NotImplementedError(error_message)
+
+    @abstractmethod
     def apply(self, x: torch.Tensor, *args, **kwargs) -> torch.Tensor:
         error_message = "Method `apply` must be implemented in subclass."
         raise NotImplementedError(error_message)
@@ -50,6 +55,12 @@ class Boolean1DMask(torch.nn.Module, BaseMask):
     @property
     def supporting_arrays(self) -> dict:
         return {"output_mask": self.mask.numpy()}
+
+    def as_slice(self) -> slice:
+        n = int(self.mask.sum())
+        first = int(self.mask.int().argmax())
+        assert bool(self.mask[first : first + n].all()), "Currently only contiguous output_masks are supported."
+        return slice(first, first + n)
 
     def broadcast_like(self, x: torch.Tensor, dim: int, grid_shard_slice: slice | None = None) -> torch.Tensor:
         assert x.shape[dim] == len(
@@ -142,6 +153,9 @@ class Boolean1DMask(torch.nn.Module, BaseMask):
 
 class NoOutputMask(BaseMask):
     """No output mask."""
+
+    def as_slice(self) -> slice:
+        return slice(None)
 
     def apply(self, x: torch.Tensor, *args, **kwargs) -> torch.Tensor:  # noqa: ARG002
         return x

--- a/training/src/anemoi/training/utils/masks.py
+++ b/training/src/anemoi/training/utils/masks.py
@@ -28,8 +28,9 @@ class BaseMask:
         return {}
 
     @abstractmethod
-    def as_slice(self) -> slice:
-        error_message = "Method `as_slice` must be implemented in subclass."
+    def as_tuple(self) -> tuple:
+        """Return the range of contiguous True values in the mask as a tuple (start, end)."""
+        error_message = "Method `as_tuple` must be implemented in subclass."
         raise NotImplementedError(error_message)
 
     @abstractmethod
@@ -56,11 +57,13 @@ class Boolean1DMask(torch.nn.Module, BaseMask):
     def supporting_arrays(self) -> dict:
         return {"output_mask": self.mask.numpy()}
 
-    def as_slice(self) -> slice:
+    def as_tuple(self) -> tuple:
         n = int(self.mask.sum())
         first = int(self.mask.int().argmax())
-        assert bool(self.mask[first : first + n].all()), "Currently only contiguous output_masks are supported."
-        return slice(first, first + n)
+        assert bool(
+            self.mask[first : first + n].all(),
+        ), "Currently only output_masks with a contiguous block of True values are supported."
+        return (first, first + n)
 
     def broadcast_like(self, x: torch.Tensor, dim: int, grid_shard_slice: slice | None = None) -> torch.Tensor:
         assert x.shape[dim] == len(
@@ -154,8 +157,8 @@ class Boolean1DMask(torch.nn.Module, BaseMask):
 class NoOutputMask(BaseMask):
     """No output mask."""
 
-    def as_slice(self) -> slice:
-        return slice(None)
+    def as_tuple(self) -> tuple:
+        return (None, None)
 
     def apply(self, x: torch.Tensor, *args, **kwargs) -> torch.Tensor:  # noqa: ARG002
         return x

--- a/training/tests/unit/losses/test_loss_function.py
+++ b/training/tests/unit/losses/test_loss_function.py
@@ -12,7 +12,6 @@ import hydra
 import pytest
 import torch
 from omegaconf import DictConfig
-from omegaconf import OmegaConf
 from pytest_mock import MockerFixture
 
 from anemoi.training.losses import CRPS
@@ -526,8 +525,8 @@ def test_sht_amse_loss() -> None:
         )
 
 
-def test_sht_amse_loss_applies_subgrid() -> None:
-    # SpectralAMSELoss.forward has its own transform path; subgrid must still be applied there.
+def test_sht_amse_loss_applies_nodes_slice() -> None:
+    # SpectralAMSELoss.forward has its own transform path; nodes_slice must still be applied there.
     nlat = 8
     nvars = 3
     expected_points = _octahedral_expected_points(nlat)
@@ -536,7 +535,7 @@ def test_sht_amse_loss_applies_subgrid() -> None:
         "anemoi.training.losses.spectral.SpectralAMSELoss",
         transform="octahedral_sht",
         nlat=nlat,
-        subgrid=slice(0, expected_points),
+        nodes_slice=(0, expected_points),
     )
     # twice the expected nodes; without the slice the SHT receives the wrong node count and raises.
     pred = torch.zeros((2, 1, 1, 2 * expected_points, nvars))
@@ -640,20 +639,20 @@ def test_spectral_loss_projection_actually_applied(mocker: MockerFixture) -> Non
     assert result.numel() == 1
 
 
-def test_spectral_loss_subgrid_actually_applied() -> None:
-    """Subgrid must be applied: input has 2x the expected nodes, subgrid selects half.
+def test_spectral_loss_nodes_slice_actually_applied() -> None:
+    """nodes_slice must be applied: input has 2x the expected nodes, slice selects half.
 
-    If subgrid is skipped FFT2D fails to reshape the oversized spatial dimension.
+    If nodes_slice is skipped FFT2D fails to reshape the oversized spatial dimension.
     """
     x_dim, y_dim = 4, 2  # FFT2D expects 8 nodes
-    n_total = 16  # input has 16 nodes; subgrid=slice(0, 8) should reduce to 8
+    n_total = 16  # input has 16 nodes; slice=(0, 8) should reduce to 8
     bs, nvars = 1, 2
 
     loss = SpectralL2Loss(
         transform="fft2d",
         x_dim=x_dim,
         y_dim=y_dim,
-        subgrid=slice(0, 8),
+        nodes_slice=(0, 8),
     )
 
     pred = torch.randn(bs, 1, 1, n_total, nvars)
@@ -684,16 +683,16 @@ def test_spectral_loss_projection_wrong_output_size_raises(mocker: MockerFixture
         loss(pred, target)
 
 
-def test_spectral_loss_subgrid_out_of_bounds_raises() -> None:
-    """Subgrid that requests more nodes than available should raise."""
+def test_spectral_loss_nodes_slice_out_of_bounds_raises() -> None:
+    """nodes_slice that requests more nodes than available should raise."""
     x_dim, y_dim = 4, 2  # expects 8 nodes
-    n_total = 6  # fewer nodes than subgrid requests
+    n_total = 6  # fewer nodes than slice end requests
 
     loss = SpectralL2Loss(
         transform="fft2d",
         x_dim=x_dim,
         y_dim=y_dim,
-        subgrid=slice(0, 8),  # requests 8 nodes but only 6 exist
+        nodes_slice=(0, 8),  # requests 8 nodes but only 6 exist
     )
     pred = torch.randn(1, 1, 1, n_total, 2)
     target = torch.randn(1, 1, 1, n_total, 2)
@@ -716,7 +715,7 @@ def test_spectral_loss_ambiguous_projection_config_raises() -> None:
         )
 
 
-def test_spectral_crps_projection_applies_subgrid_before_projection(mocker: MockerFixture) -> None:
+def test_spectral_crps_projection_applies_nodes_slice_before_projection(mocker: MockerFixture) -> None:
     from scipy.sparse import eye
 
     bs, ens, nvars = 2, 5, 3
@@ -730,17 +729,16 @@ def test_spectral_crps_projection_applies_subgrid_before_projection(mocker: Mock
     mocker.patch("scipy.sparse.load_npz", return_value=eye(projected_grid, format="csr"))
 
     loss = get_loss_function(
-        OmegaConf.create(
+        DictConfig(
             {
                 "_target_": "anemoi.training.losses.spectral.SpectralCRPSLoss",
                 "transform": "fft2d",
                 "x_dim": x_dim,
                 "y_dim": y_dim,
-                "subgrid": slice(0, projected_grid),
+                "nodes_slice": (0, projected_grid),
                 "projection_config": {"matrix_path": "/path/to/projection_matrix.npz"},
                 "scalers": [],
             },
-            flags={"allow_objects": True},
         ),
     )
 

--- a/training/tests/unit/losses/test_loss_function.py
+++ b/training/tests/unit/losses/test_loss_function.py
@@ -7,6 +7,9 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
+
+from types import SimpleNamespace
+
 import einops
 import hydra
 import pytest
@@ -28,6 +31,7 @@ from anemoi.training.losses import WeightedMSELoss
 from anemoi.training.losses import get_loss_function
 from anemoi.training.losses.base import BaseLoss
 from anemoi.training.losses.base import FunctionalLoss
+from anemoi.training.train.methods.base import BaseTrainingModule
 from anemoi.training.utils.enums import TensorDim
 
 losses = [MSELoss, HuberLoss, MAELoss, RMSELoss, LogCoshLoss, CRPS, WeightedMSELoss]
@@ -35,9 +39,17 @@ spectral_losses = [SpectralL2Loss, SpectralCRPSLoss, FourierCorrelationLoss, Log
 losses += spectral_losses
 
 
-def _make_loss(target: str, **kwargs) -> BaseLoss:
+def _resolve_subgrid(cfg: dict, output_mask: SimpleNamespace | None = None) -> None:
+    mock_method = SimpleNamespace(output_mask={"data": output_mask})
+    multi_cfg = {"data": cfg}
+    BaseTrainingModule._resolve_subgrid(mock_method, multi_cfg)
+    return multi_cfg["data"]
+
+
+def _make_loss(target: str, output_mask: SimpleNamespace | None = None, **kwargs) -> BaseLoss:
     cfg = {"_target_": target, "scalers": []}
     cfg.update(kwargs)
+    cfg = _resolve_subgrid(cfg, output_mask)
     return get_loss_function(DictConfig(cfg))
 
 
@@ -639,7 +651,14 @@ def test_spectral_loss_projection_actually_applied(mocker: MockerFixture) -> Non
     assert result.numel() == 1
 
 
-def test_spectral_loss_subgrid_actually_applied() -> None:
+@pytest.mark.parametrize(
+    "subgrid",
+    [
+        (0, 8),
+        "output_mask",
+    ],
+)
+def test_spectral_loss_subgrid_actually_applied(subgrid: str | tuple) -> None:
     """Subgrid must be applied: input has 2x the expected nodes, slice selects half.
 
     If subgrid is skipped FFT2D fails to reshape the oversized spatial dimension.
@@ -647,13 +666,16 @@ def test_spectral_loss_subgrid_actually_applied() -> None:
     x_dim, y_dim = 4, 2  # FFT2D expects 8 nodes
     n_total = 16  # input has 16 nodes; slice=(0, 8) should reduce to 8
     bs, nvars = 1, 2
+    loss_cfg = {
+        "transform": "fft2d",
+        "x_dim": x_dim,
+        "y_dim": y_dim,
+        "subgrid": subgrid,
+    }
 
-    loss = SpectralL2Loss(
-        transform="fft2d",
-        x_dim=x_dim,
-        y_dim=y_dim,
-        subgrid=(0, 8),
-    )
+    output_mask = SimpleNamespace(as_tuple=lambda: (0, 8))
+
+    loss = _make_loss("anemoi.training.losses.spectral.SpectralL2Loss", output_mask=output_mask, **loss_cfg)
 
     pred = torch.randn(bs, 1, 1, n_total, nvars)
     target = torch.randn(bs, 1, 1, n_total, nvars)

--- a/training/tests/unit/losses/test_loss_function.py
+++ b/training/tests/unit/losses/test_loss_function.py
@@ -525,8 +525,8 @@ def test_sht_amse_loss() -> None:
         )
 
 
-def test_sht_amse_loss_applies_nodes_slice() -> None:
-    # SpectralAMSELoss.forward has its own transform path; nodes_slice must still be applied there.
+def test_sht_amse_loss_applies_subgrid() -> None:
+    # SpectralAMSELoss.forward has its own transform path; subgrid must still be applied there.
     nlat = 8
     nvars = 3
     expected_points = _octahedral_expected_points(nlat)
@@ -535,7 +535,7 @@ def test_sht_amse_loss_applies_nodes_slice() -> None:
         "anemoi.training.losses.spectral.SpectralAMSELoss",
         transform="octahedral_sht",
         nlat=nlat,
-        nodes_slice=(0, expected_points),
+        subgrid=(0, expected_points),
     )
     # twice the expected nodes; without the slice the SHT receives the wrong node count and raises.
     pred = torch.zeros((2, 1, 1, 2 * expected_points, nvars))
@@ -639,10 +639,10 @@ def test_spectral_loss_projection_actually_applied(mocker: MockerFixture) -> Non
     assert result.numel() == 1
 
 
-def test_spectral_loss_nodes_slice_actually_applied() -> None:
-    """nodes_slice must be applied: input has 2x the expected nodes, slice selects half.
+def test_spectral_loss_subgrid_actually_applied() -> None:
+    """Subgrid must be applied: input has 2x the expected nodes, slice selects half.
 
-    If nodes_slice is skipped FFT2D fails to reshape the oversized spatial dimension.
+    If subgrid is skipped FFT2D fails to reshape the oversized spatial dimension.
     """
     x_dim, y_dim = 4, 2  # FFT2D expects 8 nodes
     n_total = 16  # input has 16 nodes; slice=(0, 8) should reduce to 8
@@ -652,7 +652,7 @@ def test_spectral_loss_nodes_slice_actually_applied() -> None:
         transform="fft2d",
         x_dim=x_dim,
         y_dim=y_dim,
-        nodes_slice=(0, 8),
+        subgrid=(0, 8),
     )
 
     pred = torch.randn(bs, 1, 1, n_total, nvars)
@@ -683,8 +683,8 @@ def test_spectral_loss_projection_wrong_output_size_raises(mocker: MockerFixture
         loss(pred, target)
 
 
-def test_spectral_loss_nodes_slice_out_of_bounds_raises() -> None:
-    """nodes_slice that requests more nodes than available should raise."""
+def test_spectral_loss_subgrid_out_of_bounds_raises() -> None:
+    """Subgrid that requests more nodes than available should raise."""
     x_dim, y_dim = 4, 2  # expects 8 nodes
     n_total = 6  # fewer nodes than slice end requests
 
@@ -692,7 +692,7 @@ def test_spectral_loss_nodes_slice_out_of_bounds_raises() -> None:
         transform="fft2d",
         x_dim=x_dim,
         y_dim=y_dim,
-        nodes_slice=(0, 8),  # requests 8 nodes but only 6 exist
+        subgrid=(0, 8),  # requests 8 nodes but only 6 exist
     )
     pred = torch.randn(1, 1, 1, n_total, 2)
     target = torch.randn(1, 1, 1, n_total, 2)
@@ -715,7 +715,7 @@ def test_spectral_loss_ambiguous_projection_config_raises() -> None:
         )
 
 
-def test_spectral_crps_projection_applies_nodes_slice_before_projection(mocker: MockerFixture) -> None:
+def test_spectral_crps_projection_applies_subgrid_before_projection(mocker: MockerFixture) -> None:
     from scipy.sparse import eye
 
     bs, ens, nvars = 2, 5, 3
@@ -735,7 +735,7 @@ def test_spectral_crps_projection_applies_nodes_slice_before_projection(mocker: 
                 "transform": "fft2d",
                 "x_dim": x_dim,
                 "y_dim": y_dim,
-                "nodes_slice": (0, projected_grid),
+                "subgrid": (0, projected_grid),
                 "projection_config": {"matrix_path": "/path/to/projection_matrix.npz"},
                 "scalers": [],
             },

--- a/training/tests/unit/losses/test_loss_function.py
+++ b/training/tests/unit/losses/test_loss_function.py
@@ -12,6 +12,7 @@ import hydra
 import pytest
 import torch
 from omegaconf import DictConfig
+from omegaconf import OmegaConf
 from pytest_mock import MockerFixture
 
 from anemoi.training.losses import CRPS
@@ -535,7 +536,7 @@ def test_sht_amse_loss_applies_subgrid() -> None:
         "anemoi.training.losses.spectral.SpectralAMSELoss",
         transform="octahedral_sht",
         nlat=nlat,
-        subgrid=slice((0, expected_points)),
+        subgrid=slice(0, expected_points),
     )
     # twice the expected nodes; without the slice the SHT receives the wrong node count and raises.
     pred = torch.zeros((2, 1, 1, 2 * expected_points, nvars))
@@ -645,14 +646,14 @@ def test_spectral_loss_subgrid_actually_applied() -> None:
     If subgrid is skipped FFT2D fails to reshape the oversized spatial dimension.
     """
     x_dim, y_dim = 4, 2  # FFT2D expects 8 nodes
-    n_total = 16  # input has 16 nodes; subgrid=slice((0, 8)) should reduce to 8
+    n_total = 16  # input has 16 nodes; subgrid=slice(0, 8) should reduce to 8
     bs, nvars = 1, 2
 
     loss = SpectralL2Loss(
         transform="fft2d",
         x_dim=x_dim,
         y_dim=y_dim,
-        subgrid=slice((0, 8)),
+        subgrid=slice(0, 8),
     )
 
     pred = torch.randn(bs, 1, 1, n_total, nvars)
@@ -692,7 +693,7 @@ def test_spectral_loss_subgrid_out_of_bounds_raises() -> None:
         transform="fft2d",
         x_dim=x_dim,
         y_dim=y_dim,
-        subgrid=slice((0, 8)),  # requests 8 nodes but only 6 exist
+        subgrid=slice(0, 8),  # requests 8 nodes but only 6 exist
     )
     pred = torch.randn(1, 1, 1, n_total, 2)
     target = torch.randn(1, 1, 1, n_total, 2)
@@ -729,16 +730,17 @@ def test_spectral_crps_projection_applies_subgrid_before_projection(mocker: Mock
     mocker.patch("scipy.sparse.load_npz", return_value=eye(projected_grid, format="csr"))
 
     loss = get_loss_function(
-        DictConfig(
+        OmegaConf.create(
             {
                 "_target_": "anemoi.training.losses.spectral.SpectralCRPSLoss",
                 "transform": "fft2d",
                 "x_dim": x_dim,
                 "y_dim": y_dim,
-                "subgrid": slice((0, projected_grid)),
+                "subgrid": slice(0, projected_grid),
                 "projection_config": {"matrix_path": "/path/to/projection_matrix.npz"},
                 "scalers": [],
             },
+            flags={"allow_objects": True},
         ),
     )
 

--- a/training/tests/unit/losses/test_loss_function.py
+++ b/training/tests/unit/losses/test_loss_function.py
@@ -525,8 +525,8 @@ def test_sht_amse_loss() -> None:
         )
 
 
-def test_sht_amse_loss_applies_nodes_slice() -> None:
-    # SpectralAMSELoss.forward has its own transform path; nodes_slice must still be applied there.
+def test_sht_amse_loss_applies_subgrid() -> None:
+    # SpectralAMSELoss.forward has its own transform path; subgrid must still be applied there.
     nlat = 8
     nvars = 3
     expected_points = _octahedral_expected_points(nlat)
@@ -535,7 +535,7 @@ def test_sht_amse_loss_applies_nodes_slice() -> None:
         "anemoi.training.losses.spectral.SpectralAMSELoss",
         transform="octahedral_sht",
         nlat=nlat,
-        nodes_slice=(0, expected_points),
+        subgrid=slice((0, expected_points)),
     )
     # twice the expected nodes; without the slice the SHT receives the wrong node count and raises.
     pred = torch.zeros((2, 1, 1, 2 * expected_points, nvars))
@@ -639,20 +639,20 @@ def test_spectral_loss_projection_actually_applied(mocker: MockerFixture) -> Non
     assert result.numel() == 1
 
 
-def test_spectral_loss_nodes_slice_actually_applied() -> None:
-    """nodes_slice must be applied: input has 2x the expected nodes, slice selects half.
+def test_spectral_loss_subgrid_actually_applied() -> None:
+    """Subgrid must be applied: input has 2x the expected nodes, subgrid selects half.
 
-    If nodes_slice is skipped FFT2D fails to reshape the oversized spatial dimension.
+    If subgrid is skipped FFT2D fails to reshape the oversized spatial dimension.
     """
     x_dim, y_dim = 4, 2  # FFT2D expects 8 nodes
-    n_total = 16  # input has 16 nodes; slice=(0, 8) should reduce to 8
+    n_total = 16  # input has 16 nodes; subgrid=slice((0, 8)) should reduce to 8
     bs, nvars = 1, 2
 
     loss = SpectralL2Loss(
         transform="fft2d",
         x_dim=x_dim,
         y_dim=y_dim,
-        nodes_slice=(0, 8),
+        subgrid=slice((0, 8)),
     )
 
     pred = torch.randn(bs, 1, 1, n_total, nvars)
@@ -683,16 +683,16 @@ def test_spectral_loss_projection_wrong_output_size_raises(mocker: MockerFixture
         loss(pred, target)
 
 
-def test_spectral_loss_nodes_slice_out_of_bounds_raises() -> None:
-    """nodes_slice that requests more nodes than available should raise."""
+def test_spectral_loss_subgrid_out_of_bounds_raises() -> None:
+    """Subgrid that requests more nodes than available should raise."""
     x_dim, y_dim = 4, 2  # expects 8 nodes
-    n_total = 6  # fewer nodes than slice end requests
+    n_total = 6  # fewer nodes than subgrid requests
 
     loss = SpectralL2Loss(
         transform="fft2d",
         x_dim=x_dim,
         y_dim=y_dim,
-        nodes_slice=(0, 8),  # requests 8 nodes but only 6 exist
+        subgrid=slice((0, 8)),  # requests 8 nodes but only 6 exist
     )
     pred = torch.randn(1, 1, 1, n_total, 2)
     target = torch.randn(1, 1, 1, n_total, 2)
@@ -715,7 +715,7 @@ def test_spectral_loss_ambiguous_projection_config_raises() -> None:
         )
 
 
-def test_spectral_crps_projection_applies_nodes_slice_before_projection(mocker: MockerFixture) -> None:
+def test_spectral_crps_projection_applies_subgrid_before_projection(mocker: MockerFixture) -> None:
     from scipy.sparse import eye
 
     bs, ens, nvars = 2, 5, 3
@@ -735,7 +735,7 @@ def test_spectral_crps_projection_applies_nodes_slice_before_projection(mocker: 
                 "transform": "fft2d",
                 "x_dim": x_dim,
                 "y_dim": y_dim,
-                "nodes_slice": (0, projected_grid),
+                "subgrid": slice((0, projected_grid)),
                 "projection_config": {"matrix_path": "/path/to/projection_matrix.npz"},
                 "scalers": [],
             },


### PR DESCRIPTION
## Description
Refactor of #1143. For LAM models the spectral loss should be computed only over the regional domain defined by the `output_mask`. As such we allow the `subgrid` argument of spectral losses to be set to `output_mask`, which under the hood will be replaced by a slice representation of the actual output mask object.

Example config:
```yaml
training_loss:
     datasets:
       your_dataset_name:
         _target_: anemoi.training.losses.spectral.SpectralCRPSLoss
         transform: fft2d
         subgrid: "output_mask"
         x_dim: 1069
         y_dim: 1069
```

##  Additional notes ##
Note that the above, for current most typical use cases, is equivalent to
```yaml
training_loss:
     datasets:
       your_dataset_name:
         _target_: anemoi.training.losses.spectral.SpectralCRPSLoss
         transform: fft2d
         subgrid: [0, 1142761]
         x_dim: 1069
         y_dim: 1069
```
which would work without the minor code changes introduced in this PR. Still, having the 'automatic' implementation as introduced by this PR has the following dvantages:
1. users will not need to explicitly know how their `output_mask` is sliced out of the data grid.
2. a change of output mask will remain restricted to a single part of the config, that will then automatically propagate through

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)


<!-- readthedocs-preview anemoi-training start -->
----
📚 Documentation preview 📚: https://anemoi-training--1174.org.readthedocs.build/en/1174/

<!-- readthedocs-preview anemoi-training end -->

<!-- readthedocs-preview anemoi-graphs start -->
----
📚 Documentation preview 📚: https://anemoi-graphs--1174.org.readthedocs.build/en/1174/

<!-- readthedocs-preview anemoi-graphs end -->

<!-- readthedocs-preview anemoi-models start -->
----
📚 Documentation preview 📚: https://anemoi-models--1174.org.readthedocs.build/en/1174/

<!-- readthedocs-preview anemoi-models end -->