### PR TITLE
fix: support pyg-lib for fast graph building when using pyg >= 2.8

### DIFF
--- a/.github/workflows/integration-tests-hpc.yml
+++ b/.github/workflows/integration-tests-hpc.yml
@@ -42,6 +42,9 @@ jobs:
             source .venv/bin/activate
             pip install --upgrade pip
             pip install -e ./training[all,tests] -e ./models[all,tests] -e ./graphs[all,tests]
+            # Install pyg-lib
+            TORCH_VERSION=$(python -c "import torch; print(torch.__version__)")
+            pip install pyg-lib -f https://data.pyg.org/whl/torch-${TORCH_VERSION}.html
             python3 -m pytest -v training/tests/integration --slow --mlflow --mlflow-server=${{ secrets.MLFLOW_TEST_URL }}
             python3 -m pytest -v models/tests/integration --slow
             deactivate
@@ -75,6 +78,9 @@ jobs:
             source .venv/bin/activate
             pip install --upgrade pip
             pip install -e ./training[all,tests,profile] -e ./models[all,tests] -e ./graphs[all,tests]
+            # Install pyg-lib
+            TORCH_VERSION=$(python -c "import torch; print(torch.__version__)")
+            pip install pyg-lib -f https://data.pyg.org/whl/torch-${TORCH_VERSION}.html
             srun python -m pytest -v training/tests/integration/test_benchmark.py --slow --multigpu
             deactivate
             rm -rf $REPO_NAME

--- a/graphs/src/anemoi/graphs/edges/builders/base.py
+++ b/graphs/src/anemoi/graphs/edges/builders/base.py
@@ -28,15 +28,6 @@ from anemoi.utils.config import DotDict
 
 LOGGER = logging.getLogger(__name__)
 
-TORCH_CLUSTER_AVAILABLE = find_spec("torch_cluster") is not None
-
-TORCH_CLUSTER_INSTRUCTIONS = r"""The 'torch-cluster' library is not installed.
-Installing 'torch-cluster' can significantly improve performance for graph creation.
-You can install it using:
-    TORCH_VERSION=$(python -c "import torch; print(torch.__version__)")
-    pip install torch-cluster -f https://data.pyg.org/whl/torch-${TORCH_VERSION}.html
-"""
-
 if PYG_VERSION >= "2.8":
     TORCH_CLUSTER_AVAILABLE = find_spec("pyg_lib") is not None
     TORCH_CLUSTER_INSTRUCTIONS = r"""The 'pyg-lib' library is not installed.
@@ -46,6 +37,14 @@ if PYG_VERSION >= "2.8":
         pip install pyg-lib -f https://data.pyg.org/whl/torch-${TORCH_VERSION}.html
     *NOTE* `torch-cluster` has been deprecated in favor of `pyg-lib` in PyG 2.8,
         so if you are using PyG 2.8 or later, please install `pyg-lib` instead of `torch-cluster`.
+    """
+else:
+    TORCH_CLUSTER_AVAILABLE = find_spec("torch_cluster") is not None
+    TORCH_CLUSTER_INSTRUCTIONS = r"""The 'torch-cluster' library is not installed.
+    Installing 'torch-cluster' can significantly improve performance for graph creation.
+    You can install it using:
+        TORCH_VERSION=$(python -c "import torch; print(torch.__version__)")
+        pip install torch-cluster -f https://data.pyg.org/whl/torch-${TORCH_VERSION}.html
     """
 
 

--- a/graphs/src/anemoi/graphs/edges/builders/base.py
+++ b/graphs/src/anemoi/graphs/edges/builders/base.py
@@ -12,40 +12,21 @@ import logging
 import time
 from abc import ABC
 from abc import abstractmethod
-from importlib.util import find_spec
 
 import numpy as np
 import torch
 from hydra.utils import instantiate
-from torch_geometric import __version__ as PYG_VERSION
 from torch_geometric.data import HeteroData
 from torch_geometric.data.storage import NodeStorage
 
 from anemoi.graphs.edges.builders.masking import NodeMaskingMixin
+from anemoi.graphs.utils import TORCH_CLUSTER_AVAILABLE
+from anemoi.graphs.utils import TORCH_CLUSTER_INSTRUCTIONS
 from anemoi.graphs.utils import concat_edges
 from anemoi.graphs.utils import get_distributed_device
 from anemoi.utils.config import DotDict
 
 LOGGER = logging.getLogger(__name__)
-
-if PYG_VERSION >= "2.8":
-    TORCH_CLUSTER_AVAILABLE = find_spec("pyg_lib") is not None
-    TORCH_CLUSTER_INSTRUCTIONS = r"""The 'pyg-lib' library is not installed.
-    Installing 'pyg-lib' can significantly improve performance for graph creation.
-    You can install it using:
-        TORCH_VERSION=$(python -c "import torch; print(torch.__version__)")
-        pip install pyg-lib -f https://data.pyg.org/whl/torch-${TORCH_VERSION}.html
-    *NOTE* `torch-cluster` has been deprecated in favor of `pyg-lib` in PyG 2.8,
-        so if you are using PyG 2.8 or later, please install `pyg-lib` instead of `torch-cluster`.
-    """
-else:
-    TORCH_CLUSTER_AVAILABLE = find_spec("torch_cluster") is not None
-    TORCH_CLUSTER_INSTRUCTIONS = r"""The 'torch-cluster' library is not installed.
-    Installing 'torch-cluster' can significantly improve performance for graph creation.
-    You can install it using:
-        TORCH_VERSION=$(python -c "import torch; print(torch.__version__)")
-        pip install torch-cluster -f https://data.pyg.org/whl/torch-${TORCH_VERSION}.html
-    """
 
 
 class BaseEdgeBuilder(ABC):

--- a/graphs/src/anemoi/graphs/edges/builders/base.py
+++ b/graphs/src/anemoi/graphs/edges/builders/base.py
@@ -20,8 +20,8 @@ from torch_geometric.data import HeteroData
 from torch_geometric.data.storage import NodeStorage
 
 from anemoi.graphs.edges.builders.masking import NodeMaskingMixin
-from anemoi.graphs.utils import TORCH_CLUSTER_AVAILABLE
-from anemoi.graphs.utils import TORCH_CLUSTER_INSTRUCTIONS
+from anemoi.graphs.utils import PYG_AVAILABLE
+from anemoi.graphs.utils import PYG_INSTRUCTIONS
 from anemoi.graphs.utils import concat_edges
 from anemoi.graphs.utils import get_distributed_device
 from anemoi.utils.config import DotDict
@@ -169,11 +169,11 @@ class BaseDistanceEdgeBuilders(BaseEdgeBuilder, NodeMaskingMixin, ABC):
         """
         source_coords, target_coords = self.get_cartesian_node_coordinates(source_nodes, target_nodes)
 
-        if TORCH_CLUSTER_AVAILABLE:
+        if PYG_AVAILABLE:
             edge_index = self._compute_edge_index_pyg(source_coords, target_coords)
             edge_index = self.undo_masking_edge_index(edge_index, source_nodes, target_nodes)
         else:
-            LOGGER.warning(TORCH_CLUSTER_INSTRUCTIONS)
+            LOGGER.warning(PYG_INSTRUCTIONS)
             adj_matrix = self._compute_adj_matrix_sklearn(source_coords, target_coords)
             adj_matrix = self.undo_masking_adj_matrix(adj_matrix, source_nodes, target_nodes)
             edge_index = torch.from_numpy(np.stack([adj_matrix.col, adj_matrix.row], axis=0))

--- a/graphs/src/anemoi/graphs/edges/builders/base.py
+++ b/graphs/src/anemoi/graphs/edges/builders/base.py
@@ -17,6 +17,7 @@ from importlib.util import find_spec
 import numpy as np
 import torch
 from hydra.utils import instantiate
+from torch_geometric import __version__ as PYG_VERSION
 from torch_geometric.data import HeteroData
 from torch_geometric.data.storage import NodeStorage
 
@@ -35,6 +36,17 @@ You can install it using:
     TORCH_VERSION=$(python -c "import torch; print(torch.__version__)")
     pip install torch-cluster -f https://data.pyg.org/whl/torch-${TORCH_VERSION}.html
 """
+
+if PYG_VERSION >= "2.8":
+    TORCH_CLUSTER_AVAILABLE = find_spec("pyg_lib") is not None
+    TORCH_CLUSTER_INSTRUCTIONS = r"""The 'pyg-lib' library is not installed.
+    Installing 'pyg-lib' can significantly improve performance for graph creation.
+    You can install it using:
+        TORCH_VERSION=$(python -c "import torch; print(torch.__version__)")
+        pip install pyg-lib -f https://data.pyg.org/whl/torch-${TORCH_VERSION}.html
+    *NOTE* `torch-cluster` has been deprecated in favor of `pyg-lib` in PyG 2.8,
+        so if you are using PyG 2.8 or later, please install `pyg-lib` instead of `torch-cluster`.
+    """
 
 
 class BaseEdgeBuilder(ABC):

--- a/graphs/src/anemoi/graphs/edges/builders/cutoff.py
+++ b/graphs/src/anemoi/graphs/edges/builders/cutoff.py
@@ -9,7 +9,6 @@
 
 
 import logging
-from importlib.util import find_spec
 
 import numpy as np
 import torch
@@ -22,9 +21,6 @@ from torch_geometric.nn import radius
 from anemoi.graphs import EARTH_RADIUS
 from anemoi.graphs.edges.builders.base import BaseDistanceEdgeBuilders
 from anemoi.graphs.utils import get_grid_reference_distance
-
-TORCH_CLUSTER_AVAILABLE = find_spec("torch_cluster") is not None
-
 
 LOGGER = logging.getLogger(__name__)
 

--- a/graphs/src/anemoi/graphs/generate/masks.py
+++ b/graphs/src/anemoi/graphs/generate/masks.py
@@ -9,7 +9,6 @@
 
 
 import logging
-from importlib.util import find_spec
 
 import numpy as np
 import torch
@@ -19,11 +18,10 @@ from torch_geometric.data import HeteroData
 from anemoi.graphs import EARTH_RADIUS
 from anemoi.graphs.generate.transforms import latlon_rad_to_cartesian
 from anemoi.graphs.generate.transforms import latlon_rad_to_cartesian_np
+from anemoi.graphs.utils import TORCH_CLUSTER_AVAILABLE
 from anemoi.graphs.utils import get_distributed_device
 
 LOGGER = logging.getLogger(__name__)
-
-TORCH_CLUSTER_AVAILABLE = find_spec("torch_cluster") is not None
 
 
 class _TorchClusterAreaMaskBackend:

--- a/graphs/src/anemoi/graphs/generate/masks.py
+++ b/graphs/src/anemoi/graphs/generate/masks.py
@@ -18,14 +18,14 @@ from torch_geometric.data import HeteroData
 from anemoi.graphs import EARTH_RADIUS
 from anemoi.graphs.generate.transforms import latlon_rad_to_cartesian
 from anemoi.graphs.generate.transforms import latlon_rad_to_cartesian_np
-from anemoi.graphs.utils import TORCH_CLUSTER_AVAILABLE
+from anemoi.graphs.utils import PYG_AVAILABLE
 from anemoi.graphs.utils import get_distributed_device
 
 LOGGER = logging.getLogger(__name__)
 
 
-class _TorchClusterAreaMaskBackend:
-    """Torch-cluster radius backend (CPU/GPU depending on distributed device)."""
+class _PYGAreaMaskBackend:
+    """PyG radius backend (CPU/GPU depending on distributed device)."""
 
     def __init__(self, device: torch.device | str):
         LOGGER.debug("Initializing %s on device %s", self.__class__.__name__, device)
@@ -117,7 +117,7 @@ class AreaMaskBuilder:
     """Area mask builder using radius queries on unit-sphere chord distances.
 
     The public API is backend-agnostic. At runtime, a dedicated backend is selected:
-    - torch-cluster backend when available
+    - PyG backend when available
     - scipy cKDTree backend otherwise
 
     Methods
@@ -145,8 +145,8 @@ class AreaMaskBuilder:
         self.mask_attr_name = mask_attr_name
 
         self.device = get_distributed_device()
-        if TORCH_CLUSTER_AVAILABLE:
-            self._backend = _TorchClusterAreaMaskBackend(device=self.device)
+        if PYG_AVAILABLE:
+            self._backend = _PYGAreaMaskBackend(device=self.device)
         else:
             self._backend = _KDTreeAreaMaskBackend()
 

--- a/graphs/src/anemoi/graphs/utils.py
+++ b/graphs/src/anemoi/graphs/utils.py
@@ -18,8 +18,8 @@ from torch_geometric import __version__ as PYG_VERSION
 from anemoi.graphs.generate.transforms import latlon_rad_to_cartesian
 
 if PYG_VERSION >= "2.8":
-    TORCH_CLUSTER_AVAILABLE = find_spec("pyg_lib") is not None
-    TORCH_CLUSTER_INSTRUCTIONS = r"""The 'pyg-lib' library is not installed.
+    PYG_AVAILABLE = find_spec("pyg_lib") is not None
+    PYG_INSTRUCTIONS = r"""The 'pyg-lib' library is not installed.
     Installing 'pyg-lib' can significantly improve performance for graph creation.
     You can install it using:
         TORCH_VERSION=$(python -c "import torch; print(torch.__version__)")
@@ -28,8 +28,8 @@ if PYG_VERSION >= "2.8":
         so if you are using PyG 2.8 or later, please install `pyg-lib` instead of `torch-cluster`.
     """
 else:
-    TORCH_CLUSTER_AVAILABLE = find_spec("torch_cluster") is not None
-    TORCH_CLUSTER_INSTRUCTIONS = r"""The 'torch-cluster' library is not installed.
+    PYG_AVAILABLE = find_spec("torch_cluster") is not None
+    PYG_INSTRUCTIONS = r"""The 'torch-cluster' library is not installed.
     Installing 'torch-cluster' can significantly improve performance for graph creation.
     You can install it using:
         TORCH_VERSION=$(python -c "import torch; print(torch.__version__)")

--- a/graphs/src/anemoi/graphs/utils.py
+++ b/graphs/src/anemoi/graphs/utils.py
@@ -9,11 +9,32 @@
 
 
 from enum import Enum
+from importlib.util import find_spec
 
 import torch
 from sklearn.neighbors import NearestNeighbors
+from torch_geometric import __version__ as PYG_VERSION
 
 from anemoi.graphs.generate.transforms import latlon_rad_to_cartesian
+
+if PYG_VERSION >= "2.8":
+    TORCH_CLUSTER_AVAILABLE = find_spec("pyg_lib") is not None
+    TORCH_CLUSTER_INSTRUCTIONS = r"""The 'pyg-lib' library is not installed.
+    Installing 'pyg-lib' can significantly improve performance for graph creation.
+    You can install it using:
+        TORCH_VERSION=$(python -c "import torch; print(torch.__version__)")
+        pip install pyg-lib -f https://data.pyg.org/whl/torch-${TORCH_VERSION}.html
+    *NOTE* `torch-cluster` has been deprecated in favor of `pyg-lib` in PyG 2.8,
+        so if you are using PyG 2.8 or later, please install `pyg-lib` instead of `torch-cluster`.
+    """
+else:
+    TORCH_CLUSTER_AVAILABLE = find_spec("torch_cluster") is not None
+    TORCH_CLUSTER_INSTRUCTIONS = r"""The 'torch-cluster' library is not installed.
+    Installing 'torch-cluster' can significantly improve performance for graph creation.
+    You can install it using:
+        TORCH_VERSION=$(python -c "import torch; print(torch.__version__)")
+        pip install torch-cluster -f https://data.pyg.org/whl/torch-${TORCH_VERSION}.html
+    """
 
 
 def get_distributed_device() -> torch.device:

--- a/graphs/tests/edges/test_edge_builder_backend_parity.py
+++ b/graphs/tests/edges/test_edge_builder_backend_parity.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2024 Anemoi contributors.
+# (C) Copyright 2026 Anemoi contributors.
 #
 # This software is licensed under the terms of the Apache Licence Version 2.0
 # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.

--- a/graphs/tests/edges/test_edge_builder_backend_parity.py
+++ b/graphs/tests/edges/test_edge_builder_backend_parity.py
@@ -7,7 +7,7 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
-"""Parity tests: torch-cluster (pyg) vs scikit-learn (sklearn) edge builders.
+"""Parity tests: torch-cluster / pyg-lib (pyg) vs scikit-learn (sklearn) edge builders.
 
 These tests verify that the two code paths produce identical edge sets.
 They are skipped automatically when torch-cluster / pyg-lib is not installed.
@@ -22,10 +22,10 @@ from anemoi.graphs.edges.builders.cutoff import CutOffEdges
 from anemoi.graphs.edges.builders.cutoff import ReversedCutOffEdges
 from anemoi.graphs.edges.builders.knn import KNNEdges
 from anemoi.graphs.edges.builders.knn import ReversedKNNEdges
-from anemoi.graphs.utils import TORCH_CLUSTER_AVAILABLE
+from anemoi.graphs.utils import PYG_AVAILABLE
 
 pytestmark = pytest.mark.skipif(
-    not TORCH_CLUSTER_AVAILABLE,
+    not PYG_AVAILABLE,
     reason="torch-cluster / pyg-lib not installed; skipping parity tests",
 )
 
@@ -128,7 +128,7 @@ def test_cutoff_pyg_vs_sklearn(edge_builder_cls, cutoff_factor, graph_with_nodes
 def test_cutoff_full_pipeline_agrees(edge_builder_cls, graph_with_nodes: HeteroData):
     """Full compute_edge_index with pyg backend and via sklearn conversion produce same edges.
 
-    Patches the TORCH_CLUSTER_AVAILABLE flag to force both paths on the same graph.
+    Patches the PYG_AVAILABLE flag to force both paths on the same graph.
     """
     import anemoi.graphs.edges.builders.base as _base_module
     import anemoi.graphs.utils as _utils_module
@@ -137,13 +137,13 @@ def test_cutoff_full_pipeline_agrees(edge_builder_cls, graph_with_nodes: HeteroD
     source_nodes, target_nodes = builder.prepare_node_data(graph_with_nodes)
 
     # --- pyg path ---
-    _base_module.TORCH_CLUSTER_AVAILABLE = True
-    _utils_module.TORCH_CLUSTER_AVAILABLE = True
+    _base_module.PYG_AVAILABLE = True
+    _utils_module.PYG_AVAILABLE = True
     pyg_edge_index = builder.compute_edge_index(source_nodes, target_nodes)
 
     # --- sklearn path ---
-    _base_module.TORCH_CLUSTER_AVAILABLE = False
-    _utils_module.TORCH_CLUSTER_AVAILABLE = False
+    _base_module.PYG_AVAILABLE = False
+    _utils_module.PYG_AVAILABLE = False
     sklearn_edge_index = builder.compute_edge_index(source_nodes, target_nodes)
 
     pyg_set = _edge_set_from_index(pyg_edge_index)

--- a/graphs/tests/edges/test_edge_builder_backend_parity.py
+++ b/graphs/tests/edges/test_edge_builder_backend_parity.py
@@ -1,0 +1,161 @@
+# (C) Copyright 2024 Anemoi contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Parity tests: torch-cluster (pyg) vs scikit-learn (sklearn) edge builders.
+
+These tests verify that the two code paths produce identical edge sets.
+They are skipped automatically when torch-cluster / pyg-lib is not installed.
+"""
+
+import numpy as np
+import pytest
+import torch
+from torch_geometric.data import HeteroData
+
+from anemoi.graphs.edges.builders.cutoff import CutOffEdges
+from anemoi.graphs.edges.builders.cutoff import ReversedCutOffEdges
+from anemoi.graphs.edges.builders.knn import KNNEdges
+from anemoi.graphs.edges.builders.knn import ReversedKNNEdges
+from anemoi.graphs.utils import TORCH_CLUSTER_AVAILABLE
+
+pytestmark = pytest.mark.skipif(
+    not TORCH_CLUSTER_AVAILABLE,
+    reason="torch-cluster / pyg-lib not installed; skipping parity tests",
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _edge_set_from_index(edge_index: torch.Tensor) -> frozenset:
+    """Convert a (2, E) edge-index tensor to a frozenset of (src, tgt) tuples."""
+    arr = edge_index.cpu().numpy()
+    return frozenset(zip(arr[0].tolist(), arr[1].tolist()))
+
+
+def _edge_set_from_adj(adj_matrix) -> frozenset:
+    """Convert a scipy coo_matrix (row=target, col=source) to a frozenset of (src, tgt) tuples."""
+    return frozenset(zip(adj_matrix.col.tolist(), adj_matrix.row.tolist()))
+
+
+# ---------------------------------------------------------------------------
+# KNN parity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("edge_builder_cls", [KNNEdges, ReversedKNNEdges])
+@pytest.mark.parametrize("k", [1, 2, 3])
+def test_knn_pyg_vs_sklearn(edge_builder_cls, k, graph_with_nodes: HeteroData):
+    """KNN edges from pyg and sklearn must be identical sets."""
+    builder = edge_builder_cls("test_nodes", "test_nodes", num_nearest_neighbours=k)
+    source_nodes, target_nodes = builder.prepare_node_data(graph_with_nodes)
+    src_coords, tgt_coords = builder.get_cartesian_node_coordinates(source_nodes, target_nodes)
+
+    pyg_index = builder._compute_edge_index_pyg(src_coords, tgt_coords)
+    sklearn_adj = builder._compute_adj_matrix_sklearn(src_coords, tgt_coords)
+
+    pyg_set = _edge_set_from_index(pyg_index)
+    sklearn_set = _edge_set_from_adj(sklearn_adj)
+
+    assert pyg_set == sklearn_set, (
+        f"{edge_builder_cls.__name__}(k={k}): pyg produced {len(pyg_set)} edges, "
+        f"sklearn produced {len(sklearn_set)} edges; "
+        f"symmetric diff = {pyg_set.symmetric_difference(sklearn_set)}"
+    )
+
+
+@pytest.mark.parametrize("edge_builder_cls", [KNNEdges, ReversedKNNEdges])
+def test_knn_edge_count(edge_builder_cls, graph_with_nodes: HeteroData):
+    """Each target node must have exactly k edges in both backends."""
+    k = 3
+    builder = edge_builder_cls("test_nodes", "test_nodes", num_nearest_neighbours=k)
+    source_nodes, target_nodes = builder.prepare_node_data(graph_with_nodes)
+    src_coords, tgt_coords = builder.get_cartesian_node_coordinates(source_nodes, target_nodes)
+
+    pyg_index = builder._compute_edge_index_pyg(src_coords, tgt_coords)
+    sklearn_adj = builder._compute_adj_matrix_sklearn(src_coords, tgt_coords)
+
+    n_target = tgt_coords.shape[0]
+
+    # pyg: edge_index[1] contains target node indices
+    pyg_tgt_counts = np.bincount(pyg_index[1].cpu().numpy(), minlength=n_target)
+    # sklearn: adj_matrix.row contains target node indices
+    sklearn_tgt_counts = np.bincount(sklearn_adj.row, minlength=n_target)
+
+    np.testing.assert_array_equal(
+        pyg_tgt_counts,
+        sklearn_tgt_counts,
+        err_msg=f"{edge_builder_cls.__name__}: per-target-node edge counts differ",
+    )
+
+
+# ---------------------------------------------------------------------------
+# CutOff parity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("edge_builder_cls", [CutOffEdges, ReversedCutOffEdges])
+@pytest.mark.parametrize("cutoff_factor", [0.5, 1.0])
+def test_cutoff_pyg_vs_sklearn(edge_builder_cls, cutoff_factor, graph_with_nodes: HeteroData):
+    """CutOff edges from pyg and sklearn must be identical sets."""
+    # max_num_neighbours set high to avoid backend-specific truncation differences
+    builder = edge_builder_cls(
+        "test_nodes", "test_nodes", cutoff_factor=cutoff_factor, max_num_neighbours=512
+    )
+    source_nodes, target_nodes = builder.prepare_node_data(graph_with_nodes)
+    src_coords, tgt_coords = builder.get_cartesian_node_coordinates(source_nodes, target_nodes)
+
+    pyg_index = builder._compute_edge_index_pyg(src_coords, tgt_coords)
+    sklearn_adj = builder._compute_adj_matrix_sklearn(src_coords, tgt_coords)
+
+    pyg_set = _edge_set_from_index(pyg_index)
+    sklearn_set = _edge_set_from_adj(sklearn_adj)
+
+    assert pyg_set == sklearn_set, (
+        f"{edge_builder_cls.__name__}(factor={cutoff_factor}): "
+        f"pyg produced {len(pyg_set)} edges, sklearn produced {len(sklearn_set)} edges; "
+        f"symmetric diff = {pyg_set.symmetric_difference(sklearn_set)}"
+    )
+
+
+@pytest.mark.parametrize("edge_builder_cls", [CutOffEdges, ReversedCutOffEdges])
+def test_cutoff_full_pipeline_agrees(edge_builder_cls, graph_with_nodes: HeteroData):
+    """Full compute_edge_index with pyg backend and via sklearn conversion produce same edges.
+
+    Patches the TORCH_CLUSTER_AVAILABLE flag to force both paths on the same graph.
+    """
+    import anemoi.graphs.edges.builders.base as _base_module
+    import anemoi.graphs.utils as _utils_module
+
+    builder = edge_builder_cls("test_nodes", "test_nodes", cutoff_factor=0.5, max_num_neighbours=512)
+    source_nodes, target_nodes = builder.prepare_node_data(graph_with_nodes)
+
+    # --- pyg path ---
+    _base_module.TORCH_CLUSTER_AVAILABLE = True
+    _utils_module.TORCH_CLUSTER_AVAILABLE = True
+    pyg_edge_index = builder.compute_edge_index(
+         source_nodes, target_nodes
+    )
+
+    # --- sklearn path ---
+    _base_module.TORCH_CLUSTER_AVAILABLE = False
+    _utils_module.TORCH_CLUSTER_AVAILABLE = False
+    sklearn_edge_index = builder.compute_edge_index(
+         source_nodes, target_nodes
+    )
+
+    pyg_set = _edge_set_from_index(pyg_edge_index)
+    sklearn_set = _edge_set_from_index(sklearn_edge_index)
+
+    assert pyg_set == sklearn_set, (
+        f"{edge_builder_cls.__name__} full pipeline: "
+        f"symmetric diff = {pyg_set.symmetric_difference(sklearn_set)}"
+    )

--- a/graphs/tests/edges/test_edge_builder_backend_parity.py
+++ b/graphs/tests/edges/test_edge_builder_backend_parity.py
@@ -107,9 +107,7 @@ def test_knn_edge_count(edge_builder_cls, graph_with_nodes: HeteroData):
 def test_cutoff_pyg_vs_sklearn(edge_builder_cls, cutoff_factor, graph_with_nodes: HeteroData):
     """CutOff edges from pyg and sklearn must be identical sets."""
     # max_num_neighbours set high to avoid backend-specific truncation differences
-    builder = edge_builder_cls(
-        "test_nodes", "test_nodes", cutoff_factor=cutoff_factor, max_num_neighbours=512
-    )
+    builder = edge_builder_cls("test_nodes", "test_nodes", cutoff_factor=cutoff_factor, max_num_neighbours=512)
     source_nodes, target_nodes = builder.prepare_node_data(graph_with_nodes)
     src_coords, tgt_coords = builder.get_cartesian_node_coordinates(source_nodes, target_nodes)
 
@@ -141,21 +139,16 @@ def test_cutoff_full_pipeline_agrees(edge_builder_cls, graph_with_nodes: HeteroD
     # --- pyg path ---
     _base_module.TORCH_CLUSTER_AVAILABLE = True
     _utils_module.TORCH_CLUSTER_AVAILABLE = True
-    pyg_edge_index = builder.compute_edge_index(
-         source_nodes, target_nodes
-    )
+    pyg_edge_index = builder.compute_edge_index(source_nodes, target_nodes)
 
     # --- sklearn path ---
     _base_module.TORCH_CLUSTER_AVAILABLE = False
     _utils_module.TORCH_CLUSTER_AVAILABLE = False
-    sklearn_edge_index = builder.compute_edge_index(
-         source_nodes, target_nodes
-    )
+    sklearn_edge_index = builder.compute_edge_index(source_nodes, target_nodes)
 
     pyg_set = _edge_set_from_index(pyg_edge_index)
     sklearn_set = _edge_set_from_index(sklearn_edge_index)
 
     assert pyg_set == sklearn_set, (
-        f"{edge_builder_cls.__name__} full pipeline: "
-        f"symmetric diff = {pyg_set.symmetric_difference(sklearn_set)}"
+        f"{edge_builder_cls.__name__} full pipeline: " f"symmetric diff = {pyg_set.symmetric_difference(sklearn_set)}"
     )

--- a/graphs/tests/generate/test_area_mask_backend_parity.py
+++ b/graphs/tests/generate/test_area_mask_backend_parity.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2024 Anemoi contributors.
+# (C) Copyright 2026 Anemoi contributors.
 #
 # This software is licensed under the terms of the Apache Licence Version 2.0
 # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.

--- a/graphs/tests/generate/test_area_mask_backend_parity.py
+++ b/graphs/tests/generate/test_area_mask_backend_parity.py
@@ -1,0 +1,171 @@
+# (C) Copyright 2024 Anemoi contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Parity tests: _TorchClusterAreaMaskBackend vs _KDTreeAreaMaskBackend.
+
+Verifies that both mask backends produce identical boolean masks for the same
+reference coordinates and query points.  Tests are skipped when torch-cluster /
+pyg-lib is not installed.
+"""
+
+import numpy as np
+import pytest
+import torch
+from torch_geometric.data import HeteroData
+
+from anemoi.graphs import EARTH_RADIUS
+from anemoi.graphs.generate.masks import AreaMaskBuilder
+from anemoi.graphs.generate.masks import _KDTreeAreaMaskBackend
+from anemoi.graphs.generate.masks import _TorchClusterAreaMaskBackend
+from anemoi.graphs.utils import TORCH_CLUSTER_AVAILABLE
+
+pytestmark = pytest.mark.skipif(
+    not TORCH_CLUSTER_AVAILABLE,
+    reason="torch-cluster / pyg-lib not installed; skipping parity tests",
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_backends(coords_rad: torch.Tensor) -> tuple[_TorchClusterAreaMaskBackend, _KDTreeAreaMaskBackend]:
+    """Fit both backends to the same reference coordinates and return them."""
+    tc = _TorchClusterAreaMaskBackend(device="cpu")
+    kd = _KDTreeAreaMaskBackend()
+    tc.fit(coords_rad)
+    kd.fit(coords_rad)
+    return tc, kd
+
+
+# ---------------------------------------------------------------------------
+# Direct backend parity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("margin_radius_km", [50, 100, 500])
+def test_backends_agree_on_reference_coords(margin_radius_km, graph_with_nodes: HeteroData):
+    """Both backends must agree when queried with the reference coordinates.
+
+    Every reference point should be within the margin of itself, so the mask
+    should be all-True regardless of backend.
+    """
+    coords_rad = graph_with_nodes["test_nodes"].x
+    chord_threshold = float(2 * np.sin(margin_radius_km / (2 * EARTH_RADIUS)))
+
+    tc, kd = _make_backends(coords_rad)
+
+    tc_mask = tc.get_mask(coords_rad, chord_threshold)
+    kd_mask = kd.get_mask(coords_rad, chord_threshold)
+
+    assert tc_mask.dtype == torch.bool
+    assert kd_mask.dtype == torch.bool
+    assert tc_mask.shape == kd_mask.shape
+    assert torch.equal(tc_mask, kd_mask), (
+        f"margin={margin_radius_km} km: "
+        f"TC={tc_mask.tolist()}, KD={kd_mask.tolist()}"
+    )
+
+
+def test_backends_agree_on_numpy_query(graph_with_nodes: HeteroData):
+    """Both backends must agree when the query is passed as a numpy array."""
+    coords_rad = graph_with_nodes["test_nodes"].x
+    chord_threshold = float(2 * np.sin(100.0 / (2 * EARTH_RADIUS)))
+
+    tc, kd = _make_backends(coords_rad)
+
+    query_np = coords_rad.cpu().numpy()
+    tc_mask = tc.get_mask(query_np, chord_threshold)
+    kd_mask = kd.get_mask(query_np, chord_threshold)
+
+    assert torch.equal(tc_mask, kd_mask)
+
+
+def test_backends_agree_distant_query(graph_with_nodes: HeteroData):
+    """With a tiny radius and far-away query points, masks should both be all-False."""
+    coords_rad = graph_with_nodes["test_nodes"].x
+    # 1 km radius – tight enough that distant nodes are excluded
+    chord_threshold = float(2 * np.sin(1.0 / (2 * EARTH_RADIUS)))
+
+    tc, kd = _make_backends(coords_rad)
+
+    # Query at the north pole (far from any node in the fixture)
+    north_pole = torch.tensor([[(float(torch.pi) / 2), 0.0]])
+    tc_mask = tc.get_mask(north_pole, chord_threshold)
+    kd_mask = kd.get_mask(north_pole, chord_threshold)
+
+    assert torch.equal(tc_mask, kd_mask)
+    assert not tc_mask.any(), "Expected no matches near north pole with 1 km radius"
+
+
+@pytest.mark.parametrize("margin_radius_km", [50, 200, 1000])
+def test_backends_agree_partial_overlap(margin_radius_km):
+    """Both backends agree on a mix of inside/outside query points."""
+    rng = np.random.default_rng(42)
+    # Reference: 20 random points on the unit sphere (lat/lon in radians)
+    ref_lats = rng.uniform(-np.pi / 2, np.pi / 2, 20)
+    ref_lons = rng.uniform(0, 2 * np.pi, 20)
+    ref_coords = torch.from_numpy(np.stack([ref_lats, ref_lons], axis=1)).float()
+
+    # Query: same points + 20 extra random ones
+    q_lats = rng.uniform(-np.pi / 2, np.pi / 2, 20)
+    q_lons = rng.uniform(0, 2 * np.pi, 20)
+    query_coords = torch.from_numpy(
+        np.concatenate([np.stack([ref_lats, ref_lons], axis=1), np.stack([q_lats, q_lons], axis=1)], axis=0)
+    ).float()
+
+    chord_threshold = float(2 * np.sin(margin_radius_km / (2 * EARTH_RADIUS)))
+
+    tc, kd = _make_backends(ref_coords)
+
+    tc_mask = tc.get_mask(query_coords, chord_threshold)
+    kd_mask = kd.get_mask(query_coords, chord_threshold)
+
+    assert tc_mask.dtype == torch.bool
+    assert tc_mask.shape == kd_mask.shape
+    assert torch.equal(tc_mask, kd_mask), (
+        f"margin={margin_radius_km} km: "
+        f"TC={tc_mask.tolist()}, KD={kd_mask.tolist()}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# High-level AreaMaskBuilder parity (patches TORCH_CLUSTER_AVAILABLE)
+# ---------------------------------------------------------------------------
+
+
+def test_area_mask_builder_full_pipeline_agrees(graph_with_nodes: HeteroData):
+    """AreaMaskBuilder with each backend must produce the same mask.
+
+    Patches the TORCH_CLUSTER_AVAILABLE flag to exercise both branches of the
+    AreaMaskBuilder constructor.
+    """
+    import anemoi.graphs.generate.masks as _masks_module
+    import anemoi.graphs.utils as _utils_module
+
+    query_coords = graph_with_nodes["test_nodes"].x.cpu().numpy()
+
+    # Force torch-cluster backend
+    _masks_module.TORCH_CLUSTER_AVAILABLE = True
+    _utils_module.TORCH_CLUSTER_AVAILABLE = True
+    builder_tc = AreaMaskBuilder("test_nodes", margin_radius_km=100)
+    builder_tc.fit(graph_with_nodes)
+    mask_tc = builder_tc.get_mask(query_coords)
+
+    # Force KDTree backend
+    _masks_module.TORCH_CLUSTER_AVAILABLE = False
+    _utils_module.TORCH_CLUSTER_AVAILABLE = False
+    builder_kd = AreaMaskBuilder("test_nodes", margin_radius_km=100)
+    builder_kd.fit(graph_with_nodes)
+    mask_kd = builder_kd.get_mask(query_coords)
+
+    assert torch.equal(mask_tc, mask_kd), (
+        f"AreaMaskBuilder full pipeline: TC={mask_tc.tolist()}, KD={mask_kd.tolist()}"
+    )

--- a/graphs/tests/generate/test_area_mask_backend_parity.py
+++ b/graphs/tests/generate/test_area_mask_backend_parity.py
@@ -7,7 +7,7 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
-"""Parity tests: _TorchClusterAreaMaskBackend vs _KDTreeAreaMaskBackend.
+"""Parity tests: _PYGAreaMaskBackend vs _KDTreeAreaMaskBackend.
 
 Verifies that both mask backends produce identical boolean masks for the same
 reference coordinates and query points.  Tests are skipped when torch-cluster /
@@ -22,11 +22,11 @@ from torch_geometric.data import HeteroData
 from anemoi.graphs import EARTH_RADIUS
 from anemoi.graphs.generate.masks import AreaMaskBuilder
 from anemoi.graphs.generate.masks import _KDTreeAreaMaskBackend
-from anemoi.graphs.generate.masks import _TorchClusterAreaMaskBackend
-from anemoi.graphs.utils import TORCH_CLUSTER_AVAILABLE
+from anemoi.graphs.generate.masks import _PYGAreaMaskBackend
+from anemoi.graphs.utils import PYG_AVAILABLE
 
 pytestmark = pytest.mark.skipif(
-    not TORCH_CLUSTER_AVAILABLE,
+    not PYG_AVAILABLE,
     reason="torch-cluster / pyg-lib not installed; skipping parity tests",
 )
 
@@ -36,13 +36,13 @@ pytestmark = pytest.mark.skipif(
 # ---------------------------------------------------------------------------
 
 
-def _make_backends(coords_rad: torch.Tensor) -> tuple[_TorchClusterAreaMaskBackend, _KDTreeAreaMaskBackend]:
+def _make_backends(coords_rad: torch.Tensor) -> tuple[_PYGAreaMaskBackend, _KDTreeAreaMaskBackend]:
     """Fit both backends to the same reference coordinates and return them."""
-    tc = _TorchClusterAreaMaskBackend(device="cpu")
+    pyg = _PYGAreaMaskBackend(device="cpu")
     kd = _KDTreeAreaMaskBackend()
-    tc.fit(coords_rad)
+    pyg.fit(coords_rad)
     kd.fit(coords_rad)
-    return tc, kd
+    return pyg, kd
 
 
 # ---------------------------------------------------------------------------
@@ -60,16 +60,16 @@ def test_backends_agree_on_reference_coords(margin_radius_km, graph_with_nodes: 
     coords_rad = graph_with_nodes["test_nodes"].x
     chord_threshold = float(2 * np.sin(margin_radius_km / (2 * EARTH_RADIUS)))
 
-    tc, kd = _make_backends(coords_rad)
+    pyg, kd = _make_backends(coords_rad)
 
-    tc_mask = tc.get_mask(coords_rad, chord_threshold)
+    pyg_mask = pyg.get_mask(coords_rad, chord_threshold)
     kd_mask = kd.get_mask(coords_rad, chord_threshold)
 
-    assert tc_mask.dtype == torch.bool
+    assert pyg_mask.dtype == torch.bool
     assert kd_mask.dtype == torch.bool
-    assert tc_mask.shape == kd_mask.shape
-    assert torch.equal(tc_mask, kd_mask), (
-        f"margin={margin_radius_km} km: " f"TC={tc_mask.tolist()}, KD={kd_mask.tolist()}"
+    assert pyg_mask.shape == kd_mask.shape
+    assert torch.equal(pyg_mask, kd_mask), (
+        f"margin={margin_radius_km} km: " f"PYG={pyg_mask.tolist()}, KD={kd_mask.tolist()}"
     )
 
 
@@ -78,13 +78,13 @@ def test_backends_agree_on_numpy_query(graph_with_nodes: HeteroData):
     coords_rad = graph_with_nodes["test_nodes"].x
     chord_threshold = float(2 * np.sin(100.0 / (2 * EARTH_RADIUS)))
 
-    tc, kd = _make_backends(coords_rad)
+    pyg, kd = _make_backends(coords_rad)
 
     query_np = coords_rad.cpu().numpy()
-    tc_mask = tc.get_mask(query_np, chord_threshold)
+    pyg_mask = pyg.get_mask(query_np, chord_threshold)
     kd_mask = kd.get_mask(query_np, chord_threshold)
 
-    assert torch.equal(tc_mask, kd_mask)
+    assert torch.equal(pyg_mask, kd_mask)
 
 
 def test_backends_agree_distant_query(graph_with_nodes: HeteroData):
@@ -93,15 +93,15 @@ def test_backends_agree_distant_query(graph_with_nodes: HeteroData):
     # 1 km radius – tight enough that distant nodes are excluded
     chord_threshold = float(2 * np.sin(1.0 / (2 * EARTH_RADIUS)))
 
-    tc, kd = _make_backends(coords_rad)
+    pyg, kd = _make_backends(coords_rad)
 
     # Query at the north pole (far from any node in the fixture)
-    north_pole = torch.tensor([[(float(torch.pi) / 2), 0.0]])
-    tc_mask = tc.get_mask(north_pole, chord_threshold)
+    north_pole = torch.tensor([[(float(torch.pi) / 2), 0.0]], dtype=coords_rad.dtype)
+    pyg_mask = pyg.get_mask(north_pole, chord_threshold)
     kd_mask = kd.get_mask(north_pole, chord_threshold)
 
-    assert torch.equal(tc_mask, kd_mask)
-    assert not tc_mask.any(), "Expected no matches near north pole with 1 km radius"
+    assert torch.equal(pyg_mask, kd_mask)
+    assert not pyg_mask.any(), "Expected no matches near north pole with 1 km radius"
 
 
 @pytest.mark.parametrize("margin_radius_km", [50, 200, 1000])
@@ -122,27 +122,27 @@ def test_backends_agree_partial_overlap(margin_radius_km):
 
     chord_threshold = float(2 * np.sin(margin_radius_km / (2 * EARTH_RADIUS)))
 
-    tc, kd = _make_backends(ref_coords)
+    pyg, kd = _make_backends(ref_coords)
 
-    tc_mask = tc.get_mask(query_coords, chord_threshold)
+    pyg_mask = pyg.get_mask(query_coords, chord_threshold)
     kd_mask = kd.get_mask(query_coords, chord_threshold)
 
-    assert tc_mask.dtype == torch.bool
-    assert tc_mask.shape == kd_mask.shape
-    assert torch.equal(tc_mask, kd_mask), (
-        f"margin={margin_radius_km} km: " f"TC={tc_mask.tolist()}, KD={kd_mask.tolist()}"
+    assert pyg_mask.dtype == torch.bool
+    assert pyg_mask.shape == kd_mask.shape
+    assert torch.equal(pyg_mask, kd_mask), (
+        f"margin={margin_radius_km} km: " f"PYG={pyg_mask.tolist()}, KD={kd_mask.tolist()}"
     )
 
 
 # ---------------------------------------------------------------------------
-# High-level AreaMaskBuilder parity (patches TORCH_CLUSTER_AVAILABLE)
+# High-level AreaMaskBuilder parity (patches PYG_AVAILABLE)
 # ---------------------------------------------------------------------------
 
 
 def test_area_mask_builder_full_pipeline_agrees(graph_with_nodes: HeteroData):
     """AreaMaskBuilder with each backend must produce the same mask.
 
-    Patches the TORCH_CLUSTER_AVAILABLE flag to exercise both branches of the
+    Patches the PYG_AVAILABLE flag to exercise both branches of the
     AreaMaskBuilder constructor.
     """
     import anemoi.graphs.generate.masks as _masks_module
@@ -151,17 +151,19 @@ def test_area_mask_builder_full_pipeline_agrees(graph_with_nodes: HeteroData):
     query_coords = graph_with_nodes["test_nodes"].x.cpu().numpy()
 
     # Force torch-cluster backend
-    _masks_module.TORCH_CLUSTER_AVAILABLE = True
-    _utils_module.TORCH_CLUSTER_AVAILABLE = True
-    builder_tc = AreaMaskBuilder("test_nodes", margin_radius_km=100)
-    builder_tc.fit(graph_with_nodes)
-    mask_tc = builder_tc.get_mask(query_coords)
+    _masks_module.PYG_AVAILABLE = True
+    _utils_module.PYG_AVAILABLE = True
+    builder_pyg = AreaMaskBuilder("test_nodes", margin_radius_km=100)
+    builder_pyg.fit(graph_with_nodes)
+    mask_pyg = builder_pyg.get_mask(query_coords)
 
     # Force KDTree backend
-    _masks_module.TORCH_CLUSTER_AVAILABLE = False
-    _utils_module.TORCH_CLUSTER_AVAILABLE = False
+    _masks_module.PYG_AVAILABLE = False
+    _utils_module.PYG_AVAILABLE = False
     builder_kd = AreaMaskBuilder("test_nodes", margin_radius_km=100)
     builder_kd.fit(graph_with_nodes)
     mask_kd = builder_kd.get_mask(query_coords)
 
-    assert torch.equal(mask_tc, mask_kd), f"AreaMaskBuilder full pipeline: TC={mask_tc.tolist()}, KD={mask_kd.tolist()}"
+    assert torch.equal(
+        mask_pyg, mask_kd
+    ), f"AreaMaskBuilder full pipeline: PYG={mask_pyg.tolist()}, KD={mask_kd.tolist()}"

--- a/graphs/tests/generate/test_area_mask_backend_parity.py
+++ b/graphs/tests/generate/test_area_mask_backend_parity.py
@@ -69,8 +69,7 @@ def test_backends_agree_on_reference_coords(margin_radius_km, graph_with_nodes: 
     assert kd_mask.dtype == torch.bool
     assert tc_mask.shape == kd_mask.shape
     assert torch.equal(tc_mask, kd_mask), (
-        f"margin={margin_radius_km} km: "
-        f"TC={tc_mask.tolist()}, KD={kd_mask.tolist()}"
+        f"margin={margin_radius_km} km: " f"TC={tc_mask.tolist()}, KD={kd_mask.tolist()}"
     )
 
 
@@ -131,8 +130,7 @@ def test_backends_agree_partial_overlap(margin_radius_km):
     assert tc_mask.dtype == torch.bool
     assert tc_mask.shape == kd_mask.shape
     assert torch.equal(tc_mask, kd_mask), (
-        f"margin={margin_radius_km} km: "
-        f"TC={tc_mask.tolist()}, KD={kd_mask.tolist()}"
+        f"margin={margin_radius_km} km: " f"TC={tc_mask.tolist()}, KD={kd_mask.tolist()}"
     )
 
 
@@ -166,6 +164,4 @@ def test_area_mask_builder_full_pipeline_agrees(graph_with_nodes: HeteroData):
     builder_kd.fit(graph_with_nodes)
     mask_kd = builder_kd.get_mask(query_coords)
 
-    assert torch.equal(mask_tc, mask_kd), (
-        f"AreaMaskBuilder full pipeline: TC={mask_tc.tolist()}, KD={mask_kd.tolist()}"
-    )
+    assert torch.equal(mask_tc, mask_kd), f"AreaMaskBuilder full pipeline: TC={mask_tc.tolist()}, KD={mask_kd.tolist()}"

--- a/graphs/tests/generate/test_mask_builder.py
+++ b/graphs/tests/generate/test_mask_builder.py
@@ -15,7 +15,7 @@ from torch_geometric.data import HeteroData
 
 from anemoi.graphs import EARTH_RADIUS
 from anemoi.graphs.generate.masks import AreaMaskBuilder
-from anemoi.graphs.utils import TORCH_CLUSTER_AVAILABLE
+from anemoi.graphs.utils import PYG_AVAILABLE
 
 
 def test_init():
@@ -62,7 +62,7 @@ def test_fit(graph_with_nodes: HeteroData, mask: str):
     mask_builder.fit(graph_with_nodes)
 
     assert getattr(mask_builder._backend, "_ref_vectors") is not None
-    if TORCH_CLUSTER_AVAILABLE:
+    if PYG_AVAILABLE:
         assert mask_builder._backend._ref_vectors.shape[1] == 3
         assert isinstance(mask_builder._backend._ref_vectors, torch.Tensor)
     else:

--- a/graphs/tests/generate/test_mask_builder.py
+++ b/graphs/tests/generate/test_mask_builder.py
@@ -14,8 +14,8 @@ from scipy.spatial import cKDTree
 from torch_geometric.data import HeteroData
 
 from anemoi.graphs import EARTH_RADIUS
-from anemoi.graphs.generate.masks import TORCH_CLUSTER_AVAILABLE
 from anemoi.graphs.generate.masks import AreaMaskBuilder
+from anemoi.graphs.utils import TORCH_CLUSTER_AVAILABLE
 
 
 def test_init():


### PR DESCRIPTION
## Description
pytorch geometric 2.8 deprecated the torch-cluster library, in favour of pyg-lib. the api is the same, we just need to change how the library is checked.

Currently it checks for torch-cluster if PyG <= 2.7.0 and pyg-lib if PyG >= 2.8.0. This is in order to support multiple versions of PyG, because PyG 2.8 only supports a limited range of PyTorch versions (2.9,2.10,2.11,2.12).


if you try import torch-cluster when using PyG 2.8 you get the following error. This PR fixes this by using pyg-lib  instead
```
  File "/perm/naco/venvs/triton-flash-attn/lib/python3.12/site-packages/anemoi/graphs/create.py", line 69, in update_graph
    graph = edge_builder.update_graph(graph, attrs_config=None)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/perm/naco/venvs/triton-flash-attn/lib/python3.12/site-packages/anemoi/graphs/edges/builders/base.py", line 141, in update_graph
    graph = self.register_edges(graph)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/perm/naco/venvs/triton-flash-attn/lib/python3.12/site-packages/anemoi/graphs/edges/builders/base.py", line 87, in register_edges
    edge_index = self.get_edge_index(graph)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/perm/naco/venvs/triton-flash-attn/lib/python3.12/site-packages/anemoi/graphs/edges/builders/base.py", line 71, in get_edge_index
    edge_index = self.compute_edge_index(source_nodes, target_nodes)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/perm/naco/venvs/triton-flash-attn/lib/python3.12/site-packages/anemoi/graphs/edges/builders/cutoff.py", line 242, in compute_edge_index
    return super().compute_edge_index(source_nodes=source_nodes, target_nodes=target_nodes)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/perm/naco/venvs/triton-flash-attn/lib/python3.12/site-packages/anemoi/graphs/edges/builders/base.py", line 181, in compute_edge_index
    edge_index = self._compute_edge_index_pyg(source_coords, target_coords)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/perm/naco/venvs/triton-flash-attn/lib/python3.12/site-packages/anemoi/graphs/edges/builders/cutoff.py", line 159, in _compute_edge_index_pyg
    edge_index = radius(source_coords, target_coords, r=self.radius, max_num_neighbors=self.max_num_neighbours)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/perm/naco/venvs/triton-flash-attn/lib/python3.12/site-packages/torch_geometric/nn/pool/__init__.py", line 261, in radius
    raise ImportError("'radius' requires 'pyg-lib>=0.6.0'")
ImportError: 'radius' requires 'pyg-lib>=0.6.0'
```