### PR TITLE
fix(training): allow mlflow filesystem tracking backend in tests

### DIFF
--- a/training/tests/conftest.py
+++ b/training/tests/conftest.py
@@ -7,11 +7,18 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
+import os
+
 # Use non-GUI backend before any test (or plot) code imports matplotlib.
 # Avoids slow backend probing (Tk/Qt) in headless/CI and speeds up plotting tests.
 import matplotlib as mpl
 
 mpl.use("Agg")
+
+# Newer mlflow releases put the filesystem tracking backend ("./mlruns") in maintenance
+# mode and raise unless this opt-out is set; the offline logger tests depend on the
+# file store. Set before any test code imports mlflow.
+os.environ.setdefault("MLFLOW_ALLOW_FILE_STORE", "true")
 
 from pathlib import Path
 from typing import Any


### PR DESCRIPTION
## What

Sets `MLFLOW_ALLOW_FILE_STORE=true` in `training/tests/conftest.py` so the offline MLflow logger tests keep working under newer mlflow releases.

## Why

A recent mlflow release puts the filesystem tracking backend (`./mlruns`) into maintenance mode and raises `MlflowException` unless the opt-out is set. This breaks five tests on every CI run since the release:

- `training/tests/unit/diagnostics/mlflow/test_mlflow_logger.py::test_offline_{logger,forked_logger,resumed_logger}`
- `training/tests/integration/test_training_cycle.py::test_config_validation_mlflow_configs[{no_pydantic,pydantic}_MLflow]`

`main` itself is affected: its last green unit-test run (2026-06-10 13:21 UTC) predates the release, and the nightly integration run failed the same night. Open PRs (#442, #998) are red with the identical failure signature. mlflow is unpinned here (transitive via `anemoi-utils[mlflow]`), so CI picks the new release while existing local environments do not.

The opt-out lives in the top-level test conftest so it covers unit and integration tests, in CI and locally, and is a no-op on older mlflow versions.

## Follow-up

Migrate the offline logger tests to a `sqlite:///` tracking backend as mlflow recommends, then remove this opt-out. The discussion lives in #1054 