### PR TITLE
fix(graphs): AICON hidden to hidden topology

### DIFF
--- a/graphs/src/anemoi/graphs/generate/icon_mesh.py
+++ b/graphs/src/anemoi/graphs/generate/icon_mesh.py
@@ -126,7 +126,8 @@ class ICONMultiMesh:
     def multi_mesh_edges(self) -> np.ndarray:
         """Returns the multi-mesh edges as an arrays of vertex indices."""
         # concatenate edge-vertex lists (= edges of the multi-level mesh):
-        return np.concatenate([edges for edges in self.edge_vertices], axis=0)
+        edges = np.concatenate([edges for edges in self.edge_vertices], axis=0)
+        return np.concatenate([edges, np.fliplr(edges)])
 
     def _read_vertices_data(self):
         LOGGER.debug(f"{type(self).__name__}: read vertices data from ICON grid file '{self.grid_filename}'")

--- a/training/tests/integration/aicon/test_cicd_aicon_04_icon-dream_medium.py
+++ b/training/tests/integration/aicon/test_cicd_aicon_04_icon-dream_medium.py
@@ -73,13 +73,16 @@ def aicon_config_with_grid(aicon_config_with_tmp_dir: DictConfig, get_test_data:
 
 @pytest.fixture
 @typechecked
-def trained_aicon(aicon_config_with_grid: DictConfig) -> tuple[AnemoiTrainer, float, float]:
+def trained_aicon(aicon_config_with_grid: DictConfig) -> tuple[AnemoiTrainer, float, float, int]:
     """Train AICON and return testable objects."""
     trainer = AnemoiTrainer(aicon_config_with_grid)
     initial_sum = float(torch.tensor(list(map(torch.sum, trainer.model.parameters()))).sum())
     trainer.train()
     final_sum = float(torch.tensor(list(map(torch.sum, trainer.model.parameters()))).sum())
-    return trainer, initial_sum, final_sum
+    nhidden_mesh_edges = trainer.model.model.graph_data["hidden", "to", "hidden"]["edge_index"].shape[
+        1
+    ]  # no. of hidden mesh edges
+    return trainer, initial_sum, final_sum, nhidden_mesh_edges
 
 
 @typechecked
@@ -152,8 +155,18 @@ def test_aicon_metadata(aicon_config_with_grid: DictConfig) -> None:
 @pytest.mark.slow
 @typechecked
 def test_aicon_training(trained_aicon: tuple) -> None:
-    _, initial_sum, final_sum = trained_aicon
+    _, initial_sum, final_sum, nhidden_mesh_edges = trained_aicon
     assert initial_sum != final_sum
+
+    # calculate number of multi-mesh edges for global ICON grid RnBm
+    n = 3
+    m = 4  # max_level_multimesh
+    nedges_hidden_total = 0
+    for k in range(m):
+        # no. of mesh edges for level k:
+        nedges_hidden_total += 30 * n**2 * 4**k
+    nedges_hidden_total *= 2  # bidirectional edges
+    assert nhidden_mesh_edges == nedges_hidden_total
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixed setup of hidden mesh: The duplication of the bidrectional hidden mesh edges was lost during the refactoring in PR  https://github.com/ecmwf/anemoi-core/pull/627.

With this fix, the hidden mesh edges are again defined as bidirectional, meaning that every hidden-mesh connection in TorchGeometric is duplicated (original implementation was [here](https://github.com/ecmwf/anemoi-core/blob/c7b4d38484f079a0865c24d942ea29f49eaf09f8/graphs/src/anemoi/graphs/generate/icon_mesh.py#L96)).

The AICON integration test now holds a consistency check for the expected number of hidden mesh edges.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
