### PR TITLE
fix: replace matplotlib.get_cmap

### DIFF
--- a/training/src/anemoi/training/diagnostics/plots.py
+++ b/training/src/anemoi/training/diagnostics/plots.py
@@ -10,11 +10,11 @@
 
 import logging
 
-import matplotlib.colormaps as mpl_colormaps
 import matplotlib.pyplot as plt
 import matplotlib.style as mplstyle
 import numpy as np
 import pandas as pd
+from matplotlib import colormaps as mpl_colormaps
 from matplotlib.collections import LineCollection
 from matplotlib.collections import PathCollection
 from matplotlib.colors import BoundaryNorm

--- a/training/src/anemoi/training/diagnostics/plots.py
+++ b/training/src/anemoi/training/diagnostics/plots.py
@@ -10,7 +10,7 @@
 
 import logging
 
-import matplotlib.cm as cm
+import matplotlib.colormaps as mpl_colormaps
 import matplotlib.pyplot as plt
 import matplotlib.style as mplstyle
 import numpy as np
@@ -542,8 +542,8 @@ def _resolve_variable_colormaps(
     tuple[Colormap, Colormap]
         (cmap, error_cmap)
     """
-    cmap = colormaps.default.get_cmap() if colormaps.get("default") else cm.get_cmap("viridis")
-    error_cmap = colormaps.error.get_cmap() if colormaps.get("error") else cm.get_cmap("bwr")
+    cmap = colormaps.default.get_cmap() if colormaps.get("default") else mpl_colormaps.get_cmap("viridis")
+    error_cmap = colormaps.error.get_cmap() if colormaps.get("error") else mpl_colormaps.get_cmap("bwr")
     for key in colormaps:
         if key not in ["default", "error"] and variable_name in colormaps[key].variables:
             cmap = colormaps[key].get_cmap()

--- a/training/src/anemoi/training/utils/custom_colormaps.py
+++ b/training/src/anemoi/training/utils/custom_colormaps.py
@@ -12,6 +12,7 @@ from abc import ABC
 from abc import abstractmethod
 
 import matplotlib.cm as cm
+from matplotlib import colormaps as mpl_colormaps
 from matplotlib.colors import Colormap
 from matplotlib.colors import ListedColormap
 
@@ -53,7 +54,7 @@ class MatplotlibColormap(CustomColormap):
         """
         super().__init__(variables)
         self.name = name
-        self.colormap = cm.get_cmap(self.name)
+        self.colormap = mpl_colormaps.get_cmap(self.name)
 
     def get_cmap(self) -> cm:
         return self.colormap


### PR DESCRIPTION
matplotlib 3.11.0 [released](https://github.com/matplotlib/matplotlib/releases/tag/v3.11.0) yesterday and integration tests are failing now, because 'cm.get_cmap' has been removed.
[nightly-integration-tests-hpc-gpu · ecmwf/anemoi-core@8521cd5](https://github.com/ecmwf/anemoi-core/actions/runs/27403412348/job/80986594455#step:3:2420)
 
 ```
Python
AttributeError: module 'matplotlib.cm' has no attribute 'get_cmap'
Traceback (most recent call last):
  File "/dev/shm/_tmpdir_.***.35537584/anemoi-core/training/src/anemoi/training/diagnostics/callbacks/plot.py", line 95, in _run
    fn(trainer, *args, **kwargs)
  File "/dev/shm/_tmpdir_.***.35537584/anemoi-core/.venv/lib/python3.12/site-packages/lightning_utilities/core/rank_zero.py", line 42, in wrapped_fn
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/dev/shm/_tmpdir_.***.35537584/anemoi-core/training/src/anemoi/training/diagnostics/callbacks/plot.py", line 1127, in _plot
    fig = self._make_figure(
          ^^^^^^^^^^^^^^^^^^
  File "/dev/shm/_tmpdir_.***.35537584/anemoi-core/training/src/anemoi/training/diagnostics/callbacks/plot.py", line 1255, in _make_figure
    return plot_predicted_ensemble(
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/dev/shm/_tmpdir_.***.35537584/anemoi-core/training/src/anemoi/training/diagnostics/plots.py", line 1271, in plot_predicted_ensemble
    cmap, error_cmap = _resolve_variable_colormaps(colormaps, variable_name)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/dev/shm/_tmpdir_.***.35537584/anemoi-core/training/src/anemoi/training/diagnostics/plots.py", line 545, in _resolve_variable_colormaps
    cmap = colormaps.default.get_cmap() if colormaps.get("default") else cm.get_cmap("viridis")
                                                                         ^^^^^^^^^^^
AttributeError: module 'matplotlib.cm' has no attribute 'get_cmap'
```