### PR TITLE
chore(training): update S3 source tests to use ObjectStorageConfig

### DIFF
--- a/training/pyproject.toml
+++ b/training/pyproject.toml
@@ -87,7 +87,7 @@ optional-dependencies.remote = [
   "aiohttp>=3.8",
 ]
 optional-dependencies.s3 = [
-  "anemoi-utils[s3]>=0.4.37",
+  "anemoi-utils[s3]>=0.5.7",
 ]
 optional-dependencies.tests = [
   "anemoi-graphs[tri]",                                     # required to load the gnn checkpoint as part of the tests

--- a/training/tests/unit/checkpoint/sources/test_s3.py
+++ b/training/tests/unit/checkpoint/sources/test_s3.py
@@ -22,6 +22,8 @@ from anemoi.training.checkpoint.exceptions import CheckpointNotFoundError
 from anemoi.training.checkpoint.exceptions import CheckpointSourceError
 from anemoi.training.checkpoint.sources.base import CheckpointSource
 from anemoi.training.checkpoint.sources.s3 import S3Source
+from anemoi.utils.settings_schema.object_storage import ObjectStorageBucketConfig
+from anemoi.utils.settings_schema.object_storage import ObjectStorageConfig
 
 
 def _fake_anemoi_utils_s3(download_impl: object) -> ModuleType:
@@ -152,17 +154,16 @@ async def test_s3_source_downloads_from_real_public_bucket(
     # Non-secret options live in settings.toml; credential keys (even empty
     # reset values) must live in settings.secrets.toml per anemoi-utils
     # config policy.
-    bucket_section = '[object-storage."noaa-ghcn-pds"]'
-    settings_body = f'{bucket_section}\nendpoint_url = ""\nregion = "us-east-1"\nskip_signature = true\n'
-    secrets_body = f'{bucket_section}\naccess_key_id = ""\nsecret_access_key = ""\n'
-
-    config_dir = tmp_path / ".config" / "anemoi"
-    config_dir.mkdir(parents=True)
-    (config_dir / "settings.toml").write_text(settings_body)
-    secrets_path = config_dir / "settings.secrets.toml"
-    secrets_path.write_text(secrets_body)
-    secrets_path.chmod(0o600)  # anemoi-utils refuses to read a world-readable secrets file
-    monkeypatch.setenv("HOME", str(tmp_path))
+    object_storage = ObjectStorageConfig(type="s3", endpoint_url=None, access_key_id=None, secret_access_key=None)
+    bucket_config = ObjectStorageBucketConfig(
+        endpoint_url=None,
+        access_key_id="",  # type: ignore[reportArgumentType]
+        secret_access_key="",  # type: ignore[reportArgumentType]
+        skip_signature=True,
+        region="us-east-1",
+    )
+    setattr(object_storage, "noaa-ghcn-pds", bucket_config)
+    monkeypatch.setattr("anemoi.utils.settings.SETTINGS.object_storage", object_storage)
 
     # The NOAA file is a CSV, not a torch checkpoint - only exercise the
     # download path, not the torch.load step. Calling _download_from_s3


### PR DESCRIPTION
> [!WARNING]
> Requires https://github.com/ecmwf/anemoi-utils/pull/305

## Description
Fix for an s3 test broken by utils pydantic migration

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
