### PR TITLE
fix: failing sht test

### DIFF
--- a/models/tests/layers/test_sht.py
+++ b/models/tests/layers/test_sht.py
@@ -60,7 +60,7 @@ def _lons_per_lat(nlat: int, grid_kind: str) -> list[int]:
     raise ValueError(f"Unknown grid_kind={grid_kind!r}")
 
 
-@pytest.fixture(params=["regular", "reduced", "octahedral"])
+@pytest.fixture
 def sht_setup(request):
     # Choose GPUs if available
     device = "cuda" if torch.cuda.is_available() else "cpu"
@@ -94,6 +94,7 @@ def sht_setup(request):
     }
 
 
+@pytest.mark.parametrize("sht_setup", ["regular", "reduced", "octahedral"], indirect=True)
 def test_idempotency_direct_inverse(sht_setup):
     """direct followed by inverse returns the original (band-limited) field."""
     truncation = sht_setup["truncation"]
@@ -111,6 +112,7 @@ def test_idempotency_direct_inverse(sht_setup):
     assert torch.allclose(before, after, rtol=tolerance)
 
 
+@pytest.mark.parametrize("sht_setup", ["regular", "reduced", "octahedral"], indirect=True)
 def test_idempotency_inverse_direct(sht_setup):
     """inverse followed by direct returns the original spectral coefficients."""
     truncation = sht_setup["truncation"]


### PR DESCRIPTION
## Description
Fix: Remove params from the sht_setup fixture and add explicit references to the tests that need all three grid types. All four tests are now consistent and compatible with pytest 8.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
