### PR TITLE
fix(training/profilers): ensure dir on multi GPU is created

### DIFF
--- a/training/src/anemoi/training/diagnostics/profilers.py
+++ b/training/src/anemoi/training/diagnostics/profilers.py
@@ -323,6 +323,8 @@ class BenchmarkProfiler(Profiler):
         # THE STRATEGY IS ALREADY INITIALISED AND TORCH DISTRIBUTED IS ACTIVE
         # we need to broadcast the profiler path to all ranks to save the memory traces
         self.dirpath = Path(self.broadcast_profiler_path(str(self.dirpath), 0))
+        # on non-root ranks the directory is not created yet
+        self.dirpath.mkdir(parents=True, exist_ok=True)
         self._stage = stage
         self._local_rank = local_rank
         self._create_time_profilers()
@@ -489,6 +491,7 @@ class BenchmarkProfiler(Profiler):
         return system_metrics_df
 
     def _save_report(self, df: pd.DataFrame, fname: Path) -> None:
+        fname.parent.mkdir(parents=True, exist_ok=True)
         df.to_csv(fname)
 
     def _save_model_summary(self, model_summary: str, fname: Path) -> None:

--- a/training/src/anemoi/training/train/profiler.py
+++ b/training/src/anemoi/training/train/profiler.py
@@ -167,7 +167,13 @@ class AnemoiProfiler(AnemoiTrainer):
             self.to_wandb()
 
         elif self.logger and self.logger.logger_name == "mlflow":
-            self.to_mlflow()
+            if self.config.diagnostics.log.mlflow.offline:
+                # Offline mlflow writes to a throwaway local file store with no server backing it;
+                # logging the profiler reports there has no value and the offline FileStore is only
+                # partially initialised (e.g. missing the .trash folder that log_table scans).
+                LOGGER.info("MLflow is offline; skipping profiler report logging to the local store.")
+            else:
+                self.to_mlflow()
 
     def report(self) -> str:
         """Print report to console."""
@@ -200,10 +206,6 @@ class AnemoiProfiler(AnemoiTrainer):
     def to_mlflow(self) -> None:
         """Log report into MLFlow."""
         LOGGER.info("logging to MLFlow Profiler report")
-        # Ensure the (offline) MLflow store exists and the run is materialised before logging
-        if self.mlflow_logger.save_dir is not None:
-            Path(self.mlflow_logger.save_dir).mkdir(parents=True, exist_ok=True)
-        _ = self.mlflow_logger.experiment  # force-create the run in the tracking store
         self.write_benchmark_profiler_report()
         # check this https://stackoverflow.com/questions/71151054/how-to-log- d da-table-of-metrics-into-mlflow
 

--- a/training/src/anemoi/training/train/profiler.py
+++ b/training/src/anemoi/training/train/profiler.py
@@ -200,6 +200,10 @@ class AnemoiProfiler(AnemoiTrainer):
     def to_mlflow(self) -> None:
         """Log report into MLFlow."""
         LOGGER.info("logging to MLFlow Profiler report")
+        # Ensure the (offline) MLflow store exists and the run is materialised before logging
+        if self.mlflow_logger.save_dir is not None:
+            Path(self.mlflow_logger.save_dir).mkdir(parents=True, exist_ok=True)
+        _ = self.mlflow_logger.experiment  # force-create the run in the tracking store
         self.write_benchmark_profiler_report()
         # check this https://stackoverflow.com/questions/71151054/how-to-log- d da-table-of-metrics-into-mlflow
 

--- a/training/tests/integration/test_benchmark.py
+++ b/training/tests/integration/test_benchmark.py
@@ -151,6 +151,20 @@ def test_benchmark_training_cycle(
     # Run model with profiler
     AnemoiProfiler(cfg).profile()
 
+    # Ensure we are actually running the number of ranks, we expect.
+    import torch.distributed as dist
+
+    expected_world_size = int(os.environ.get("SLURM_NTASKS", "1"))
+    if expected_world_size > 1:
+        assert dist.is_available() and dist.is_initialized(), (
+            "Expected a distributed process group across the SLURM tasks, "
+            "but torch.distributed is not initialised; the ranks did not rendezvous."
+        )
+        assert dist.get_world_size() == expected_world_size, (
+            f"Expected world_size={expected_world_size} (SLURM_NTASKS), "
+            f"but got {dist.get_world_size()}; the ranks did not form one DDP group."
+        )
+
     # determine store from benchmark config
     config_path = Path("~/.config/anemoi/anemoi-benchmark.yaml").expanduser()
     user, hostname, path = parse_benchmark_config(config_path)

--- a/training/tests/integration/test_benchmark.py
+++ b/training/tests/integration/test_benchmark.py
@@ -151,20 +151,6 @@ def test_benchmark_training_cycle(
     # Run model with profiler
     AnemoiProfiler(cfg).profile()
 
-    # Ensure we are actually running the number of ranks, we expect.
-    import torch.distributed as dist
-
-    expected_world_size = int(os.environ.get("SLURM_NTASKS", "1"))
-    if expected_world_size > 1:
-        assert dist.is_available() and dist.is_initialized(), (
-            "Expected a distributed process group across the SLURM tasks, "
-            "but torch.distributed is not initialised; the ranks did not rendezvous."
-        )
-        assert dist.get_world_size() == expected_world_size, (
-            f"Expected world_size={expected_world_size} (SLURM_NTASKS), "
-            f"but got {dist.get_world_size()}; the ranks did not form one DDP group."
-        )
-
     # determine store from benchmark config
     config_path = Path("~/.config/anemoi/anemoi-benchmark.yaml").expanduser()
     user, hostname, path = parse_benchmark_config(config_path)


### PR DESCRIPTION
## Description
<!-- What issue or task does this change relate to? -->

Fixes two bugs in the nightly benchmark tests.

One was about missing directories on rank-n nodes (n not root)

The other one was about failed logging to MLflow when `offline=True`.

Note that this is a regression in functionality for profiler offline logging. 


## What problem does this change solve?
<!-- Describe if it's a bugfix, new feature, doc update, or breaking change -->

## What issue or task does this change relate to?
<!-- link to Issue Number -->

In `profilers.py:309` we have 
```python
    @rank_zero_only
    def create_output_path(self) -> None:
        self.dirpath = Path(self.config.system.output.profiler)
        self.dirpath.mkdir(parents=True, exist_ok=True)
```
note the `@rank_zero_only`! On a shared filesystem this is not a problem, but if rank-0 and rank-n (n != 0) write to different directories, it is non-existent for rank-n.

In `profiler.py:336` we see that the path is constructed as 
```
        if self.run_id:  # when using mlflow only rank0 will have a run_id except when resuming runs
            # Multi-gpu new runs or forked runs - only rank 0
            # Multi-gpu resumed runs - all ranks
            self.config.system.output.profiler = Path(self.config.system.output.profiler, self.run_id)
```
which means, that using mlflow leads to different profile output paths for the different ranks.

This left two situations in which the bug remained unnoticed:

- No mlflow / no run_id → the path stays at the static <base>/profiler without a run-specific subdirectory. That directory is created on all ranks as part of the normal output-path setup, so every rank can write its traces there without issue.
- mlflow enabled, but rank 0 and non-root ranks resolve different paths → rank 0 writes to <base>/profiler/<run_id>/, while the other ranks (whose run_id is empty) continue writing to <base>/profiler/, which already exists. Again, nothing fails. The only consequence is that the traces end up in different locations (and most people probably only inspect the rank-0 trace anyway.)
<- Might this be related to the issues you @anaprietonem saw in memory tracing?

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
