### PR TITLE
fix(training): By default, explicitly run on gpu 

### DIFF
--- a/training/docs/introduction/installing.rst
+++ b/training/docs/introduction/installing.rst
@@ -61,7 +61,7 @@ functionality:
    .. code:: bash
 
       pip install torch torchvision --index-url https://download.pytorch.org/whl/cu126
-   
+
    For full instructions on installing PyTorch with CUDA support, see the
    `PyTorch installation guide <https://pytorch.org/get-started/locally/>`__.
 

--- a/training/docs/introduction/installing.rst
+++ b/training/docs/introduction/installing.rst
@@ -45,6 +45,26 @@ functionality:
    python -m pip install "anemoi-training[profile]" # Install optional dependencies for profiling gpu usage
    python -m pip install "anemoi-training[docs]" # Install optional dependencies for generating docs
 
+.. warning::
+
+   After installation, verify that your PyTorch build has CUDA (or ROCm) support:
+
+   .. code:: bash
+      # Run on a GPU node
+      python -c 'import torch; print(torch.cuda.is_available())'
+
+   If this returns ``False``, GPU training will not work. A common cause is
+   installing the default ``torch`` wheel, which **on aarch64 systems does not
+   include CUDA support**. In that case, reinstall PyTorch with the
+   appropriate index URL, for example:
+
+   .. code:: bash
+
+      pip install torch torchvision --index-url https://download.pytorch.org/whl/cu126
+   
+   For full instructions on installing PyTorch with CUDA support, see the
+   `PyTorch installation guide <https://pytorch.org/get-started/locally/>`__.
+
 .. literalinclude:: ../../pyproject.toml
    :language: toml
    :start-at: [project.optional-dependencies.all]

--- a/training/docs/introduction/installing.rst
+++ b/training/docs/introduction/installing.rst
@@ -47,7 +47,7 @@ functionality:
 
 .. warning::
 
-   After installation, verify that your PyTorch build has CUDA (or ROCm) support:
+   After installation, verify that your PyTorch build has CUDA or ROCm support:
 
    .. code:: bash
       # Run on a GPU node

--- a/training/src/anemoi/training/config/system/hardware/example.yaml
+++ b/training/src/anemoi/training/config/system/hardware/example.yaml
@@ -1,5 +1,5 @@
 # number of GPUs per node and number of nodes (for DDP)
-accelerator: auto
+accelerator: cuda # Run on GPU (for historical reasons, this is still called "cuda" even though it also works for AMD GPUs)
 num_gpus_per_node: 1
 num_nodes: 1
 num_gpus_per_model: 1

--- a/training/src/anemoi/training/config/system/hardware/slurm.yaml
+++ b/training/src/anemoi/training/config/system/hardware/slurm.yaml
@@ -1,5 +1,5 @@
 # number of GPUs per node and number of nodes (for DDP)
-accelerator: auto
+accelerator: cuda  # Run on GPU (for historical reasons, this is still called "cuda" even though it also works for AMD GPUs)
 num_gpus_per_node: ${oc.decode:${oc.env:SLURM_GPUS_PER_NODE}}
 num_nodes: ${oc.decode:${oc.env:SLURM_NNODES}}
 num_gpus_per_model: 1

--- a/training/src/anemoi/training/schemas/system.py
+++ b/training/src/anemoi/training/schemas/system.py
@@ -25,7 +25,7 @@ class HardwareSchema(BaseModel):
     accelerator: Annotated[
         str,
         AfterValidator(partial(allowed_values, values=["cpu", "gpu", "auto", "cuda", "tpu"])),
-    ] = "auto"
+    ] = "cuda"
     "Accelerator to use for training."
     num_gpus_per_node: NonNegativeInt = 1
     "Number of GPUs per node."

--- a/training/src/anemoi/training/train/train.py
+++ b/training/src/anemoi/training/train/train.py
@@ -560,7 +560,7 @@ class AnemoiTrainer(ABC):
             msg = (
                 "GPU accelerator requested but running on GPUs is not possible. "
                 "Possible reasons include no GPUs being available on the node,"
-                " or PyTorch not being installed with CUDA/ROCm support. "
+                "or PyTorch not being installed with CUDA/ROCm support. "
                 "*Note* on aarch64 systems, the default torch wheel does not have CUDA/ROCm support."
                 "To install PyTorch with CUDA support on aarch64, you should pass the index-url argument to pip install"
                 "e.g. `pip install torch torchvision --index-url https://download.pytorch.org/whl/cu126`"

--- a/training/src/anemoi/training/train/train.py
+++ b/training/src/anemoi/training/train/train.py
@@ -552,6 +552,22 @@ class AnemoiTrainer(ABC):
 
         if self.config.system.hardware.accelerator == "cpu":
             LOGGER.info("WARNING: Accelerator set to CPU, this should only be used for debugging.")
+        # For GPU, check if 'cuda' is available
+        # For historical reasons, on AMD GPUs the API is still called 'cuda' even though ROCm is used.
+        if (
+            self.config.system.hardware.accelerator == "gpu" or self.config.system.hardware.accelerator == "cuda"
+        ) and not torch.cuda.is_available():
+            msg = (
+                "GPU accelerator requested but running on GPUs is not possible. "
+                "Possible reasons include no GPUs being available on the node,"
+                " or PyTorch not being installed with CUDA/ROCm support. "
+                "*Note* on aarch64 systems, the default torch wheel does not have CUDA/ROCm support."
+                "To install PyTorch with CUDA support on aarch64, you should pass the index-url argument to pip install"
+                "e.g. `pip install torch torchvision --index-url https://download.pytorch.org/whl/cu126`"
+                "Please check your setup and run "
+                "`python -c 'import torch; print(torch.cuda.is_available())'` to confirm GPU support.",
+            )
+            raise RuntimeError(msg)
         return self.config.system.hardware.accelerator
 
     def _log_information(self) -> None:


### PR DESCRIPTION
## Description
small PR to change the default accelerator from 'auto' to 'GPU'. This is to prevent users from accidentally running on CPU (the existing check if users are running on CPU does not fire if the 'auto' accelerator resolves to 'CPU').

Accidentally running on CPU can happen easily if torch does not support cuda. On Arm systems the default torch install does not support cuda, so this is becoming a more common issue. Users end up silently running on CPU with terrible throughput

Now, when a user starts training anemoi will default to running on GPU. If the the torch install does not support running on GPUs, a helpful error message is given telling them how to fix their install.

<!-- readthedocs-preview anemoi-training start -->
----
📚 Documentation preview 📚: https://anemoi-training--1209.org.readthedocs.build/en/1209/

<!-- readthedocs-preview anemoi-training end -->

<!-- readthedocs-preview anemoi-graphs start -->
----
📚 Documentation preview 📚: https://anemoi-graphs--1209.org.readthedocs.build/en/1209/

<!-- readthedocs-preview anemoi-graphs end -->

<!-- readthedocs-preview anemoi-models start -->
----
📚 Documentation preview 📚: https://anemoi-models--1209.org.readthedocs.build/en/1209/

<!-- readthedocs-preview anemoi-models end -->