### PR TITLE
feat: reuse processing callbacks

### DIFF
--- a/training/src/anemoi/training/diagnostics/callbacks/plot.py
+++ b/training/src/anemoi/training/diagnostics/callbacks/plot.py
@@ -735,9 +735,10 @@ class PlotLoss(BasePerBatchPlotCallback):
         batch: dict[str, torch.Tensor],
         batch_idx: int,
         epoch: int,
+        processed_cache: dict | None = None,
     ) -> None:
         logger = trainer.logger
-        _ = batch_idx
+        _ = batch_idx, processed_cache
 
         if self.latlons is None:
             self.latlons = {}

--- a/training/src/anemoi/training/diagnostics/callbacks/plot.py
+++ b/training/src/anemoi/training/diagnostics/callbacks/plot.py
@@ -408,6 +408,7 @@ class BasePerBatchPlotCallback(BasePlotCallback):
                 batch,
                 batch_idx,
                 epoch=trainer.current_epoch,
+                processed_cache={},
                 **plot_kwargs,
                 **kwargs,
             )
@@ -763,6 +764,10 @@ class PlotLoss(BasePerBatchPlotCallback):
                     RuntimeWarning,
                 )
 
+            sort_by_parameter_group, colors, xticks, legend_patches = self.sort_and_color_by_parameter_group(
+                parameter_names,
+            )
+
             for i, task_kwargs in enumerate(pl_module.task.steps("validation")):
                 y_hat = outputs.predictions[i][dataset_name]
                 y_true = pl_module.task.get_targets(
@@ -783,9 +788,6 @@ class PlotLoss(BasePerBatchPlotCallback):
                     .numpy(),
                 )
 
-                sort_by_parameter_group, colors, xticks, legend_patches = self.sort_and_color_by_parameter_group(
-                    parameter_names,
-                )
                 loss = loss[argsort_indices]
                 fig = plot_loss(loss[sort_by_parameter_group], colors, xticks, legend_patches)
 
@@ -876,8 +878,13 @@ class BasePlotAdditionalMetrics(BasePerBatchPlotCallback):
         outputs: TrainingStepOutput,
         batch: dict[str, torch.Tensor],
         members: int | list[int] | None = 0,
+        processed_cache: dict | None = None,
     ) -> tuple[np.ndarray, np.ndarray]:
         """Process the data and output tensors for plotting one dataset specified by dataset_name.
+
+        Results are cached in ``processed_cache`` when provided, keyed by ``(dataset_name, members)``.
+        Subsequent calls with the same key return the cached result without recomputation, avoiding
+        redundant post-processing when multiple callbacks process the same batch.
 
         Parameters
         ----------
@@ -893,11 +900,16 @@ class BasePlotAdditionalMetrics(BasePerBatchPlotCallback):
         members : int | list[int] | None, optional
             Ensemble members to select. Only used when the plot adapter is ensemble-aware.
             None returns all members. Default is 0 (first member).
+        processed_cache : dict | None, optional
+            Optional dict for caching computed results across callbacks within the same batch.
+            Should be created fresh per batch (e.g. in ``on_validation_batch_end``) so that
+            it is not shared across batches. Safe for async execution since each batch
+            invocation captures its own dict. Default is None (no caching).
 
         Returns
         -------
         tuple[np.ndarray, np.ndarray]
-            The data and output tensors for plotting.
+            The post-processed input data and output tensor for plotting.
         """
         if self.latlons is None:
             self.latlons = {}
@@ -910,6 +922,11 @@ class BasePlotAdditionalMetrics(BasePerBatchPlotCallback):
             outputs.predictions,
             list,
         ), "outputs.predictions must be a list of per-step dicts."
+
+        members_key = tuple(members) if isinstance(members, list) else members
+        cache_key = (dataset_name, members_key)
+        if processed_cache is not None and cache_key in processed_cache:
+            return processed_cache[cache_key]
 
         # prepare input and output tensors for plotting one dataset specified by dataset_name
         feature_indices = pl_module.data_indices[dataset_name].data.output.full
@@ -926,7 +943,10 @@ class BasePlotAdditionalMetrics(BasePerBatchPlotCallback):
         )
         data = data.numpy()
 
-        return data, output_tensor
+        result = (data, output_tensor)
+        if processed_cache is not None:
+            processed_cache[cache_key] = result
+        return result
 
     def process_output_tensor(
         self,
@@ -1060,6 +1080,7 @@ class PlotSample(BasePlotAdditionalMetrics):
         batch_idx: int,
         epoch: int,
         auxiliary_output: dict[str, torch.Tensor] | None = None,
+        processed_cache: dict | None = None,
     ) -> None:
         logger = trainer.logger
 
@@ -1082,6 +1103,7 @@ class PlotSample(BasePlotAdditionalMetrics):
                 outputs,
                 batch,
                 members=self._get_process_members(),
+                processed_cache=processed_cache,
             )
             auxiliary_tensor = (
                 None
@@ -1122,7 +1144,8 @@ class PlotSample(BasePlotAdditionalMetrics):
                     )
                 }
 
-            for x, y_true, y_pred, tag_suffix in pl_module.plot_adapter.iter_plot_samples(data, output_tensor):
+            plot_samples = list(pl_module.plot_adapter.iter_plot_samples(data, output_tensor))
+            for x, y_true, y_pred, tag_suffix in plot_samples:
                 auxiliary = auxiliary_by_suffix.get(tag_suffix)
                 fig = self._make_figure(
                     plot_parameters_dict,
@@ -1320,12 +1343,13 @@ class PlotSpectrum(BasePlotAdditionalMetrics):
         batch: dict[str, torch.Tensor],
         batch_idx: int,
         epoch: int,
+        processed_cache: dict | None = None,
     ) -> None:
         logger = trainer.logger
 
         local_rank = pl_module.local_rank
         for dataset_name in dataset_names:
-            data, output_tensor = self.process(pl_module, dataset_name, outputs, batch)
+            data, output_tensor = self.process(pl_module, dataset_name, outputs, batch, processed_cache=processed_cache)
 
             # Apply spatial mask
             latlons, data, output_tensor = self.focus_mask.apply(
@@ -1435,6 +1459,7 @@ class PlotHistogram(BasePlotAdditionalMetrics):
         batch: dict[str, torch.Tensor],
         batch_idx: int,
         epoch: int,
+        processed_cache: dict | None = None,
     ) -> None:
         logger = trainer.logger
 
@@ -1442,7 +1467,7 @@ class PlotHistogram(BasePlotAdditionalMetrics):
 
         for dataset_name in dataset_names:
 
-            data, output_tensor = self.process(pl_module, dataset_name, outputs, batch)
+            data, output_tensor = self.process(pl_module, dataset_name, outputs, batch, processed_cache=processed_cache)
 
             # Build dictionary of indices and parameters to be plotted
             input_data = pl_module.data_indices[dataset_name].data.input.todict()

--- a/training/tests/integration/conftest.py
+++ b/training/tests/integration/conftest.py
@@ -8,11 +8,13 @@
 # nor does it submit to any jurisdiction.
 
 
+import gc
 import logging
 import os
 from pathlib import Path
 from typing import Union
 
+import psutil
 import pytest
 import torch
 from hydra import compose
@@ -27,6 +29,20 @@ from anemoi.utils.testing import GetTestData
 from anemoi.utils.testing import TemporaryDirectoryForTestData
 
 LOGGER = logging.getLogger(__name__)
+
+
+@pytest.fixture(autouse=True)
+def log_memory_usage(request: pytest.FixtureRequest) -> None:
+    """Log CPU RSS before and after each test to help debug memory leaks."""
+    process = psutil.Process()
+    rss_before = process.memory_info().rss / 1024**3
+    LOGGER.info("MEMORY [%s] before: %.2f GB RSS", request.node.name, rss_before)
+    yield
+    gc.collect()
+    rss_after = process.memory_info().rss / 1024**3
+    LOGGER.info(
+        "MEMORY [%s] after: %.2f GB RSS (delta: %+.2f GB)", request.node.name, rss_after, rss_after - rss_before,
+    )
 
 
 @pytest.fixture(autouse=True)

--- a/training/tests/integration/conftest.py
+++ b/training/tests/integration/conftest.py
@@ -41,7 +41,10 @@ def log_memory_usage(request: pytest.FixtureRequest) -> None:
     gc.collect()
     rss_after = process.memory_info().rss / 1024**3
     LOGGER.info(
-        "MEMORY [%s] after: %.2f GB RSS (delta: %+.2f GB)", request.node.name, rss_after, rss_after - rss_before,
+        "MEMORY [%s] after: %.2f GB RSS (delta: %+.2f GB)",
+        request.node.name,
+        rss_after,
+        rss_after - rss_before,
     )
 
 

--- a/training/tests/unit/diagnostics/test_plotting_callbacks.py
+++ b/training/tests/unit/diagnostics/test_plotting_callbacks.py
@@ -484,6 +484,55 @@ def test_process_cache_shared_across_callbacks():
     assert call_count >= 2, "expected post-processor to be called on each process() call without a cache"
 
 
+def test_process_cache_ensemble_list_members():
+    """process() with members as a list (PlotEnsSample) hashes correctly and hits cache on repeat."""
+    batch_size, n_ens, nlatlon, nvar = 2, 1, 50, 3
+    pl_module = _make_pl_module_forecaster(nlatlon=nlatlon)
+
+    batch = {"data": torch.randn(batch_size, 4, n_ens, nlatlon, nvar)}
+    outputs = _step_output(
+        [
+            {"data": torch.randn(batch_size, 1, n_ens, nlatlon, nvar)},
+            {"data": torch.randn(batch_size, 1, n_ens, nlatlon, nvar)},
+        ],
+    )
+
+    call_count = 0
+    real_processor = _identity_post_processor()
+
+    def counting_processor(x, **kwargs) -> torch.Tensor | Any:
+        nonlocal call_count
+        call_count += 1
+        return real_processor(x, **kwargs)
+
+    plot_ens = PlotEnsSample(
+        sample_idx=0,
+        parameters=["a", "b"],
+        accumulation_levels_plot=[0.5],
+        members=[0, 1],
+        dataset_names=["data"],
+    )
+    plot_ens.post_processors = {"data": counting_processor}
+    plot_ens.latlons = {"data": np.zeros((nlatlon, 2))}
+
+    cache: dict = {}
+
+    # first call populates the cache
+    result_first = plot_ens.process(pl_module, "data", outputs, batch, members=[0, 1], processed_cache=cache)
+    assert len(cache) == 1, f"expected 1 cache entry for members=[0, 1], got {len(cache)}"
+    calls_after_first = call_count
+
+    # second call with the same list must hit the cache
+    result_second = plot_ens.process(pl_module, "data", outputs, batch, members=[0, 1], processed_cache=cache)
+    assert call_count == calls_after_first, "post-processor called again despite list-members cache hit"
+    assert result_first is result_second, "list-members cache hit must return the identical tuple"
+
+    # a different list gets a separate entry
+    result_other = plot_ens.process(pl_module, "data", outputs, batch, members=[0], processed_cache=cache)
+    assert result_other is not result_first, "different member lists must not share a cache entry"
+    assert len(cache) == 2, f"expected 2 cache entries after adding members=[0], got {len(cache)}"
+
+
 # ---- PlotLoss ----
 
 _PLOT_LOSS_CONFIG = {

--- a/training/tests/unit/diagnostics/test_plotting_callbacks.py
+++ b/training/tests/unit/diagnostics/test_plotting_callbacks.py
@@ -750,6 +750,59 @@ def test_plot_loss_forecaster():
         assert mock_output_figure.call_count == output_times
 
 
+def test_plot_loss_accepts_processed_cache_kwarg():
+    """PlotLoss._plot accepts and ignores processed_cache without error and still produces figures."""
+    from unittest.mock import patch
+
+    from anemoi.training.losses.mse import MSELoss
+
+    callback = PlotLoss(parameter_groups={}, dataset_names=["data"])
+    callback.latlons = {}
+
+    nvar = 3
+    output_times = 2
+    n_step_input, n_step_output = 1, 1
+    trainer = MagicMock()
+    trainer.logger = MagicMock()
+    pl_module = MagicMock()
+    pl_module.n_step_input = n_step_input
+    pl_module.n_step_output = n_step_output
+    pl_module.local_rank = 0
+    pl_module.data_indices = {"data": MagicMock()}
+    pl_module.data_indices["data"].model.output.name_to_index = {"a": 0, "b": 1, "c": 2}
+    pl_module.data_indices["data"].data.output.full = torch.arange(nvar)
+    pl_module.model.metadata = {"dataset": {"variables_metadata": None}}
+    batch_size, nlatlon = 2, 10
+    batch = {"data": torch.randn(batch_size, n_step_input + output_times * n_step_output + 1, 1, nlatlon, nvar)}
+    outputs = _step_output(
+        [{"data": torch.randn(batch_size, n_step_output, 1, nlatlon, nvar)} for _ in range(output_times)],
+    )
+    callback.loss = {"data": MSELoss()}
+    pl_module.task.steps.return_value = [{"rollout_step": i} for i in range(output_times)]
+    pl_module.task.get_targets.return_value = {"data": torch.randn(batch_size, n_step_output, 1, nlatlon, nvar)}
+    pl_module.task.get_metric_name.return_value = ""
+
+    with (
+        patch.object(callback, "_output_figure") as mock_output_figure,
+        patch(
+            "anemoi.training.diagnostics.callbacks.plot.argsort_variablename_variablelevel",
+            return_value=np.arange(nvar),
+        ),
+        patch("anemoi.training.diagnostics.callbacks.plot.plot_loss", return_value=MagicMock()),
+    ):
+        callback._plot(
+            trainer,
+            pl_module,
+            ["data"],
+            outputs,
+            batch,
+            batch_idx=0,
+            epoch=0,
+            processed_cache={},
+        )
+        assert mock_output_figure.call_count == output_times
+
+
 # ---- PlotSpectrum ----
 
 

--- a/training/tests/unit/diagnostics/test_plotting_callbacks.py
+++ b/training/tests/unit/diagnostics/test_plotting_callbacks.py
@@ -405,6 +405,110 @@ def test_process_temporal_downscaler_multi_out_squeeze():
     assert output_tensor.shape == (pl_module.task.num_output_timesteps, 1, 1, nlatlon, nvar), output_tensor.shape
 
 
+# ---- process() cache ----
+
+
+def test_process_cache_returns_same_object_on_hit():
+    """process() with a shared cache returns the identical tuple on the second call without recomputing."""
+    callback = PlotSample(
+        sample_idx=0,
+        parameters=["a", "b", "c"],
+        accumulation_levels_plot=[0.5],
+        dataset_names=["data"],
+    )
+    batch_size, n_ens, nlatlon, nvar = 2, 1, 50, 3
+    pl_module = _make_pl_module_forecaster(nlatlon=nlatlon)
+
+    batch = {"data": torch.randn(batch_size, 4, n_ens, nlatlon, nvar)}
+    outputs = _step_output(
+        [
+            {"data": torch.randn(batch_size, 1, n_ens, nlatlon, nvar)},
+            {"data": torch.randn(batch_size, 1, n_ens, nlatlon, nvar)},
+        ],
+    )
+
+    call_count = 0
+    real_processor = _identity_post_processor()
+
+    def counting_processor(x, **kwargs) -> torch.Tensor | Any:
+        nonlocal call_count
+        call_count += 1
+        return real_processor(x, **kwargs)
+
+    callback.post_processors = {"data": counting_processor}
+    callback.latlons = {"data": np.zeros((nlatlon, 2))}
+
+    cache: dict = {}
+    result_first = callback.process(pl_module, "data", outputs, batch, processed_cache=cache)
+    calls_after_first = call_count
+
+    result_second = callback.process(pl_module, "data", outputs, batch, processed_cache=cache)
+
+    # post-processor must not have been called again
+    assert call_count == calls_after_first, "post-processor called more than once despite cache hit"
+    # both calls must return the exact same tuple object
+    assert result_first is result_second, "cache hit did not return the same object"
+
+
+def test_process_no_cache_recomputes():
+    """process() without a cache recomputes on every call."""
+    callback = PlotSample(
+        sample_idx=0,
+        parameters=["a", "b", "c"],
+        accumulation_levels_plot=[0.5],
+        dataset_names=["data"],
+    )
+    batch_size, n_ens, nlatlon, nvar = 2, 1, 50, 3
+    pl_module = _make_pl_module_forecaster(nlatlon=nlatlon)
+
+    batch = {"data": torch.randn(batch_size, 4, n_ens, nlatlon, nvar)}
+    outputs = _step_output(
+        [{"data": torch.randn(batch_size, 1, n_ens, nlatlon, nvar)}],
+    )
+
+    call_count = 0
+    real_processor = _identity_post_processor()
+
+    def counting_processor(x, **kwargs) -> torch.Tensor | Any:
+        nonlocal call_count
+        call_count += 1
+        return real_processor(x, **kwargs)
+
+    callback.post_processors = {"data": counting_processor}
+    callback.latlons = {"data": np.zeros((nlatlon, 2))}
+
+    callback.process(pl_module, "data", outputs, batch)
+    callback.process(pl_module, "data", outputs, batch)
+
+    assert call_count >= 2, "expected post-processor to be called on each process() without a cache"
+
+
+def test_process_cache_isolated_per_members():
+    """process() caches results separately for different members values."""
+    callback = PlotSample(
+        sample_idx=0,
+        parameters=["a", "b", "c"],
+        accumulation_levels_plot=[0.5],
+        dataset_names=["data"],
+    )
+    batch_size, n_ens, nlatlon, nvar = 2, 1, 50, 3
+    pl_module = _make_pl_module_forecaster(nlatlon=nlatlon)
+
+    batch = {"data": torch.randn(batch_size, 4, n_ens, nlatlon, nvar)}
+    outputs = _step_output(
+        [{"data": torch.randn(batch_size, 1, n_ens, nlatlon, nvar)}],
+    )
+    callback.post_processors = {"data": _identity_post_processor()}
+    callback.latlons = {"data": np.zeros((nlatlon, 2))}
+
+    cache: dict = {}
+    result_m0 = callback.process(pl_module, "data", outputs, batch, members=0, processed_cache=cache)
+    result_m1 = callback.process(pl_module, "data", outputs, batch, members=None, processed_cache=cache)
+
+    assert result_m0 is not result_m1, "different members values must not share a cache entry"
+    assert len(cache) == 2, f"expected 2 cache entries, got {len(cache)}"
+
+
 # ---- PlotLoss ----
 
 _PLOT_LOSS_CONFIG = {

--- a/training/tests/unit/diagnostics/test_plotting_callbacks.py
+++ b/training/tests/unit/diagnostics/test_plotting_callbacks.py
@@ -408,14 +408,15 @@ def test_process_temporal_downscaler_multi_out_squeeze():
 # ---- process() cache ----
 
 
-def test_process_cache_returns_same_object_on_hit():
-    """process() with a shared cache returns the identical tuple on the second call without recomputing."""
-    callback = PlotSample(
-        sample_idx=0,
-        parameters=["a", "b", "c"],
-        accumulation_levels_plot=[0.5],
-        dataset_names=["data"],
-    )
+def test_process_cache_shared_across_callbacks():
+    """A shared processed_cache avoids redundant post-processing across PlotSample, PlotSpectrum, PlotHistogram.
+
+    Verifies:
+    - post-processor called once per (dataset, members) pair despite N callbacks
+    - cache hit returns the identical tuple object (not a copy)
+    - different members values get separate cache entries
+    - no cache (None) falls back to recomputing on every call
+    """
     batch_size, n_ens, nlatlon, nvar = 2, 1, 50, 3
     pl_module = _make_pl_module_forecaster(nlatlon=nlatlon)
 
@@ -435,78 +436,52 @@ def test_process_cache_returns_same_object_on_hit():
         call_count += 1
         return real_processor(x, **kwargs)
 
-    callback.post_processors = {"data": counting_processor}
-    callback.latlons = {"data": np.zeros((nlatlon, 2))}
+    shared_post_processors = {"data": counting_processor}
+    shared_latlons = {"data": np.zeros((nlatlon, 2))}
+
+    plot_sample = PlotSample(
+        sample_idx=0,
+        parameters=["a", "b"],
+        accumulation_levels_plot=[0.5],
+        dataset_names=["data"],
+    )
+    plot_spectrum = PlotSpectrum(sample_idx=0, parameters=["a", "b"], min_delta=0.0, dataset_names=["data"])
+    plot_histogram = PlotHistogram(
+        sample_idx=0,
+        parameters=["a", "b"],
+        precip_and_related_fields=[],
+        dataset_names=["data"],
+    )
+
+    for cb in (plot_sample, plot_spectrum, plot_histogram):
+        cb.post_processors = shared_post_processors
+        cb.latlons = shared_latlons
 
     cache: dict = {}
-    result_first = callback.process(pl_module, "data", outputs, batch, processed_cache=cache)
+
+    # --- shared cache: post-processor must fire only once across all three callbacks ---
+    result_sample = plot_sample.process(pl_module, "data", outputs, batch, processed_cache=cache)
     calls_after_first = call_count
 
-    result_second = callback.process(pl_module, "data", outputs, batch, processed_cache=cache)
+    result_spectrum = plot_spectrum.process(pl_module, "data", outputs, batch, processed_cache=cache)
+    result_histogram = plot_histogram.process(pl_module, "data", outputs, batch, processed_cache=cache)
 
-    # post-processor must not have been called again
-    assert call_count == calls_after_first, "post-processor called more than once despite cache hit"
-    # both calls must return the exact same tuple object
-    assert result_first is result_second, "cache hit did not return the same object"
+    assert (
+        call_count == calls_after_first
+    ), f"post-processor called {call_count - calls_after_first} extra time(s) on cache hits"
+    assert result_sample is result_spectrum is result_histogram, "cache hits must return the identical tuple object"
+    assert len(cache) == 1, f"expected 1 cache entry for (dataset, members=0), got {len(cache)}"
 
+    # --- different members value gets a separate entry, not a cache hit ---
+    result_all_members = plot_sample.process(pl_module, "data", outputs, batch, members=None, processed_cache=cache)
+    assert result_all_members is not result_sample, "different members must not share a cache entry"
+    assert len(cache) == 2, f"expected 2 cache entries after adding members=None, got {len(cache)}"
 
-def test_process_no_cache_recomputes():
-    """process() without a cache recomputes on every call."""
-    callback = PlotSample(
-        sample_idx=0,
-        parameters=["a", "b", "c"],
-        accumulation_levels_plot=[0.5],
-        dataset_names=["data"],
-    )
-    batch_size, n_ens, nlatlon, nvar = 2, 1, 50, 3
-    pl_module = _make_pl_module_forecaster(nlatlon=nlatlon)
-
-    batch = {"data": torch.randn(batch_size, 4, n_ens, nlatlon, nvar)}
-    outputs = _step_output(
-        [{"data": torch.randn(batch_size, 1, n_ens, nlatlon, nvar)}],
-    )
-
+    # --- no cache: recomputes on every call ---
     call_count = 0
-    real_processor = _identity_post_processor()
-
-    def counting_processor(x, **kwargs) -> torch.Tensor | Any:
-        nonlocal call_count
-        call_count += 1
-        return real_processor(x, **kwargs)
-
-    callback.post_processors = {"data": counting_processor}
-    callback.latlons = {"data": np.zeros((nlatlon, 2))}
-
-    callback.process(pl_module, "data", outputs, batch)
-    callback.process(pl_module, "data", outputs, batch)
-
-    assert call_count >= 2, "expected post-processor to be called on each process() without a cache"
-
-
-def test_process_cache_isolated_per_members():
-    """process() caches results separately for different members values."""
-    callback = PlotSample(
-        sample_idx=0,
-        parameters=["a", "b", "c"],
-        accumulation_levels_plot=[0.5],
-        dataset_names=["data"],
-    )
-    batch_size, n_ens, nlatlon, nvar = 2, 1, 50, 3
-    pl_module = _make_pl_module_forecaster(nlatlon=nlatlon)
-
-    batch = {"data": torch.randn(batch_size, 4, n_ens, nlatlon, nvar)}
-    outputs = _step_output(
-        [{"data": torch.randn(batch_size, 1, n_ens, nlatlon, nvar)}],
-    )
-    callback.post_processors = {"data": _identity_post_processor()}
-    callback.latlons = {"data": np.zeros((nlatlon, 2))}
-
-    cache: dict = {}
-    result_m0 = callback.process(pl_module, "data", outputs, batch, members=0, processed_cache=cache)
-    result_m1 = callback.process(pl_module, "data", outputs, batch, members=None, processed_cache=cache)
-
-    assert result_m0 is not result_m1, "different members values must not share a cache entry"
-    assert len(cache) == 2, f"expected 2 cache entries, got {len(cache)}"
+    plot_sample.process(pl_module, "data", outputs, batch)
+    plot_sample.process(pl_module, "data", outputs, batch)
+    assert call_count >= 2, "expected post-processor to be called on each process() call without a cache"
 
 
 # ---- PlotLoss ----


### PR DESCRIPTION
## Description
This PR is a simplification of https://github.com/ecmwf/anemoi-core/issues/1135, where we noticed some issues with the memory management raised during the execution of the integration tests. Main changes:
Introduce a cross-callback process() cachet . `on_validation_batch_end` creates a fresh processed_cache={} per batch and passes it through to each _plot() call. BasePlotAdditionalMetrics.process() reads from and writes to this cache keyed on (dataset_name, members). Subsequent callbacks calling process() for the same dataset/members pair get the already-computed (data, output_tensor) tuple without re-running post-processors. The cache dict is not stored on self, it is local to each batch invocation, so there is no memory accumulation between batches and no shared mutable state between concurrent async invocations.

this PR is co-developed and based on the work of @VeraChristina 

## What problem does this change solve?
Continuation of the callbacks refactor and improvement. This PR is focused on solving https://github.com/ecmwf/anemoi-core/issues/1135

## What issue or task does this change relate to?
https://github.com/ecmwf/anemoi-core/issues/1135

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)
