### PR TITLE
feat(training): add --config-path to config validate and unify config composition

### DIFF
--- a/training/docs/user-guide/configuring.rst
+++ b/training/docs/user-guide/configuring.rst
@@ -199,6 +199,15 @@ run using the following command:
 
    anemoi-training config validate --config-name debug.yaml
 
+By default the config is looked up on the search path described above (the
+current working directory and the packaged defaults). To validate a config
+that lives somewhere else without changing directory, point ``--config-path``
+at its directory, exactly as for ``anemoi-training train``:
+
+.. code:: bash
+
+   anemoi-training config validate --config-path /path/to/configs --config-name debug.yaml
+
 This will check that the configuration is valid and that all the
 required fields are present. If your config is correctly defined then
 the command will show an output similar to:

--- a/training/src/anemoi/training/commands/config.py
+++ b/training/src/anemoi/training/commands/config.py
@@ -15,13 +15,13 @@ import logging
 import os
 import re
 import shutil
-import tempfile
 from collections.abc import Generator
 from pathlib import Path
 from typing import Any
 
 from hydra import compose
 from hydra import initialize
+from hydra import initialize_config_dir
 from omegaconf import DictConfig
 from omegaconf import OmegaConf
 from pydantic import BaseModel
@@ -52,6 +52,7 @@ class ConfigGenerator(Command):
         validate = subparsers.add_parser("validate", help=help_msg, description=help_msg)
 
         validate.add_argument("--config-name", help="Name of the primary config file")
+        validate.add_argument("--config-path", "-i", type=Path, default=None, help="Configuration directory")
         validate.add_argument("--overwrite", "-f", action="store_true")
         validate.add_argument(
             "--mask_env_vars",
@@ -66,7 +67,7 @@ class ConfigGenerator(Command):
             help=help_msg,
             description=help_msg,
         )
-        dump.add_argument("--config-path", "-i", default=Path.cwd(), type=Path, help="Configuration directory")
+        dump.add_argument("--config-path", "-i", default=None, type=Path, help="Configuration directory")
         dump.add_argument("--config-name", "-n", default="dev", help="Name of the configuration")
         dump.add_argument("--output", "-o", default="./config.yaml", type=Path, help="Output file path")
         dump.add_argument("--overwrite", "-f", action="store_true")
@@ -89,7 +90,7 @@ class ConfigGenerator(Command):
                     the config_validation flag to false."
                 "So this command will validate the config regardless of the flag.",
             )
-            self.validate_config(args.config_name, args.mask_env_vars)
+            self.validate_config(args.config_name, args.mask_env_vars, args.config_path)
             LOGGER.info("Config files validated.")
             return
 
@@ -177,41 +178,42 @@ class ConfigGenerator(Command):
 
         return OmegaConf.create(updated_cfg)
 
-    def validate_config(self, config_name: Path | str, mask_env_vars: bool) -> None:
-        """Validates the configuration files in the given directory."""
-        with initialize(version_base=None, config_path=""):
+    def validate_config(self, config_name: Path | str, mask_env_vars: bool, config_path: Path | None = None) -> None:
+        """Validate a configuration, composed from ``config_path`` when given (see ``_initialize_hydra``)."""
+        with _initialize_hydra(config_path):
             cfg = compose(config_name=config_name)
             if mask_env_vars:
                 cfg = self._mask_slurm_env_variables(cfg)
             OmegaConf.resolve(cfg)
             BaseSchema(**cfg)
 
-    def dump_config(self, config_path: Path, name: str, output: Path) -> None:
-        """Dump config files in one YAML file."""
-        # Copy config files in temporary directory
-        with tempfile.TemporaryDirectory() as tmpdirname:
-            tmp_dir = Path(tmpdirname)
-            self.copy_files(config_path, tmp_dir)
+    def dump_config(self, config_path: Path | None, name: str, output: Path) -> None:
+        """Dump config files in one YAML file, composed from ``config_path`` when given."""
+        with _initialize_hydra(config_path):
+            cfg = compose(config_name=name)
 
-            # Move to config directory to be able to handle hydra
-            with change_directory(tmp_dir), initialize(version_base=None, config_path="./"):
-                cfg = compose(config_name=name)
-
-            # Dump configuration in output file
-            LOGGER.info("Dumping file in %s.", output)
-            with output.open("w") as f:
-                f.write(OmegaConf.to_yaml(cfg))
+        LOGGER.info("Dumping file in %s.", output)
+        with output.open("w") as f:
+            f.write(OmegaConf.to_yaml(cfg))
 
 
 @contextlib.contextmanager
-def change_directory(destination: Path) -> Generator[None, None, None]:
-    """A context manager to temporarily change the current working directory."""
-    original_directory = Path.cwd()
-    try:
-        os.chdir(destination)
-        yield
-    finally:
-        os.chdir(original_directory)
+def _initialize_hydra(config_path: Path | None) -> Generator[None, None, None]:
+    """Initialise Hydra for config composition, shared by ``validate`` and ``dump``.
+
+    With ``config_path`` the configs are composed from that directory, installed as Hydra's
+    primary (``main``) search-path entry so it takes precedence over the current working
+    directory and the packaged defaults — the same model ``@hydra.main`` gives ``train``'s
+    ``--config-path``. Without it, discovery is left to the ``AnemoiSearchPathPlugin`` (the
+    current working directory and the packaged defaults). ``initialize_config_dir`` requires
+    an absolute path.
+    """
+    if config_path is not None:
+        with initialize_config_dir(version_base=None, config_dir=str(Path(config_path).absolute())):
+            yield
+    else:
+        with initialize(version_base=None):
+            yield
 
 
 def extract_primitive_type_hints(model: type[BaseModel], prefix: str = "") -> dict[str, Any]:

--- a/training/tests/unit/commands/test_config.py
+++ b/training/tests/unit/commands/test_config.py
@@ -25,25 +25,18 @@ def config_generator() -> ConfigGenerator:
     return ConfigGenerator()
 
 
-def test_dump_config(config_generator: ConfigGenerator) -> None:
+def test_dump_config_composes_from_config_path_directory(config_generator: ConfigGenerator) -> None:
+    """`dump` composes the named config from a ``--config-path`` directory and writes the merged YAML."""
     with tempfile.TemporaryDirectory() as tmpdirname:
-        config_path = Path(tmpdirname) / "config"
-        config_path.mkdir(parents=True, exist_ok=True)
-        (config_path / "test.yaml").write_text("test: value")
+        config_dir = Path(tmpdirname) / "configs"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        (config_dir / "mycfg.yaml").write_text("foo: bar")
 
         output_path = Path(tmpdirname) / "output.yaml"
-        with (
-            mock.patch("anemoi.training.commands.config.ConfigGenerator.copy_files") as mock_copy_files,
-            mock.patch(
-                "anemoi.training.commands.config.initialize",
-            ),
-            mock.patch("anemoi.training.commands.config.compose", return_value=OmegaConf.create({"test": "value"})),
-        ):
-            config_generator.dump_config(config_path, "test", output_path)
+        config_generator.dump_config(config_dir, "mycfg", output_path)
 
-            mock_copy_files.assert_called_once_with(config_path, mock.ANY)
-            assert output_path.exists()
-            assert OmegaConf.load(output_path) == {"test": "value"}
+        assert output_path.exists()
+        assert OmegaConf.load(output_path) == {"foo": "bar"}
 
 
 def test_validate_config_uses_package_path(config_generator: ConfigGenerator) -> None:
@@ -91,6 +84,18 @@ def test_validate_config_with_mask_env_vars(config_generator: ConfigGenerator) -
 
         # Verify that _mask_slurm_env_variables was called
         mock_mask.assert_called_once()
+
+
+def test_validate_config_composes_from_config_path_directory(config_generator: ConfigGenerator) -> None:
+    """`validate` can be pointed at a config that lives in an arbitrary directory."""
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        config_dir = Path(tmpdirname)
+        (config_dir / "standalone.yaml").write_text("foo: bar")
+
+        with mock.patch("anemoi.training.commands.config.BaseSchema") as mock_schema:
+            config_generator.validate_config("standalone", mask_env_vars=False, config_path=config_dir)
+
+        mock_schema.assert_called_once_with(foo="bar")
 
 
 def test_optimizer_config_group_can_be_overridden() -> None:


### PR DESCRIPTION
## Description

Add `--config-path/-i` to `anemoi-training config validate` so a config living in any directory can be validated without first `cd`-ing into it, and route both `config validate` and `config dump` through a single Hydra-composition helper. This brings `validate` in line with `train` (which honours Hydra's `--config-path`) and `dump` (which already exposes `--config-path/-i`). Closes #1184.

## What problem does this change solve?

A new, backward-compatible feature plus an internal cleanup.

`validate` was the only config-consuming subcommand with no way to say where the config lives: it exposed only `--config-name`, `--overwrite` and `--mask_env_vars`, and composed with an empty primary path (`initialize(version_base=None, config_path="")`), so a config was reachable only through `AnemoiSearchPathPlugin` — the current working directory and the packaged defaults. Validating a config anywhere else meant changing directory first.

When `--config-path` is given, the config is now composed from that directory via Hydra's `initialize_config_dir`, which installs it as the primary (`main`) search-path entry — the same precedence `@hydra.main` gives `train`'s `--config-path`: `--config-path` > current working directory > packaged defaults (the model #1181 established). When it is omitted, behaviour is unchanged, and the misleading `config_path=""` (which did no useful work) is dropped.

```bash
anemoi-training config validate --config-path /path/to/configs --config-name debug.yaml
```

## What issue or task does this change relate to?

Closes #1184. Follows #1181, which made the user-specified `--config-path` take precedence and simplified the search-path hierarchy for `train`.

##  Additional notes ##

`validate` and `dump` now share one composition helper — `initialize_config_dir(dir)` when a `--config-path` is given, plain `initialize()` otherwise. This replaces `dump`'s previous approach of copying the directory's files into a temporary directory and `chdir`-ing into it, a workaround that existed only because Hydra's `initialize` resolves `config_path` relative to the calling module and so cannot take an arbitrary user directory. `dump`'s observable behaviour is unchanged — it still composes the named config from the given directory, or from the working directory and packaged defaults when none is given — but it no longer copies files or mutates the process working directory.

Tests: `tests/unit/commands/test_config.py` covers `validate` composing a config discovered only via `--config-path`, and `dump` composing from a `--config-path` directory. Docs: a note and example were added to `docs/user-guide/configuring.rst`.

This change was developed in tandem with AI coding agents.

---

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)


<!-- readthedocs-preview anemoi-training start -->
----
📚 Documentation preview 📚: https://anemoi-training--1216.org.readthedocs.build/en/1216/

<!-- readthedocs-preview anemoi-training end -->

<!-- readthedocs-preview anemoi-graphs start -->
----
📚 Documentation preview 📚: https://anemoi-graphs--1216.org.readthedocs.build/en/1216/

<!-- readthedocs-preview anemoi-graphs end -->

<!-- readthedocs-preview anemoi-models start -->
----
📚 Documentation preview 📚: https://anemoi-models--1216.org.readthedocs.build/en/1216/

<!-- readthedocs-preview anemoi-models end -->