### PR TITLE
fix: config precedence

### DIFF
--- a/training/src/anemoi/training/train/evaluate.py
+++ b/training/src/anemoi/training/train/evaluate.py
@@ -98,7 +98,7 @@ class AnemoiEvaluator(AnemoiTrainer):
         LOGGER.debug("---- DONE. ----")
 
 
-@hydra.main(version_base=None, config_path="../config", config_name="config")
+@hydra.main(version_base=None, config_path=None, config_name="config")
 def evaluate(config: DictConfig) -> None:
     AnemoiEvaluator(config).evaluate()
 

--- a/training/src/anemoi/training/train/profiler.py
+++ b/training/src/anemoi/training/train/profiler.py
@@ -351,7 +351,7 @@ class AnemoiProfiler(AnemoiTrainer):
         self.export_to_logger()
 
 
-@hydra.main(version_base=None, config_path="../config", config_name="config")
+@hydra.main(version_base=None, config_path=None, config_name="config")
 def main(config: DictConfig) -> None:
     AnemoiProfiler(config).profile()
 

--- a/training/src/anemoi/training/train/train.py
+++ b/training/src/anemoi/training/train/train.py
@@ -742,7 +742,7 @@ class AnemoiTrainer(ABC):
         LOGGER.debug("---- DONE. ----")
 
 
-@hydra.main(version_base=None, config_path="../config", config_name="config")
+@hydra.main(version_base=None, config_path=None, config_name="config")
 def main(config: DictConfig) -> None:
     AnemoiTrainer(config).train()
 

--- a/training/tests/unit/hydra/test_search_path_plugins.py
+++ b/training/tests/unit/hydra/test_search_path_plugins.py
@@ -142,8 +142,7 @@ def test_cwd_beats_package_without_config_path(monkeypatch: pytest.MonkeyPatch, 
 
 
 def test_package_as_main_beats_cwd(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """Documents the bug: when config_path='../config' is used, the package is registered
-    as provider=main *before* the plugin runs, so it beats the CWD.
+    """Documents the bug: when config_path='../config' is used, package beats CWD.
 
     This test asserts the broken behaviour to make clear why config_path=None is required.
     If this test ever starts *failing* (i.e. the plugin somehow fixes it internally),

--- a/training/tests/unit/hydra/test_search_path_plugins.py
+++ b/training/tests/unit/hydra/test_search_path_plugins.py
@@ -66,3 +66,89 @@ def test_config_path_wins_and_home_env_paths_removed(monkeypatch: pytest.MonkeyP
     assert providers.index("main") < providers.index("anemoi-cwd-searchpath-plugin")
     # Packaged configs remain the lowest-priority fallback.
     assert providers[-1] == "anemoi-package-searchpath-plugin"
+
+
+def _make_search_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, *, config_path: str | None = None) -> list[str]:
+    """Helper: build a search path as the real code does and return the provider list.
+
+    Parameters
+    ----------
+    config_path:
+        Simulates ``--config-path``.  When *None* the entry point uses
+        ``config_path=None`` (our fix) so no primary path is pre-populated.
+    """
+    cwd = tmp_path / "cwd"
+    cwd.mkdir(exist_ok=True)
+    monkeypatch.chdir(cwd)
+
+    search_path = ConfigSearchPathImpl()
+    if config_path is not None:
+        # Mimic what Hydra does when the user passes --config-path.
+        search_path.append(provider="main", path=config_path)
+
+    AnemoiSearchPathPlugin().manipulate_search_path(search_path)
+    return [entry.provider for entry in search_path.get_path()]
+
+
+def test_cwd_beats_package_defaults(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Priority 2 > 3: CWD must come before the packaged defaults when no --config-path is given.
+
+    With ``config_path=None`` in ``@hydra.main`` there is no "main" entry in the
+    search path before the plugin runs, so the plugin is the sole authority on
+    ordering.
+    """
+    providers = _make_search_path(monkeypatch, tmp_path, config_path=None)
+
+    assert "anemoi-cwd-searchpath-plugin" in providers, "CWD was not added to the search path"
+    assert "anemoi-package-searchpath-plugin" in providers, "Package fallback was not added"
+    assert providers.index("anemoi-cwd-searchpath-plugin") < providers.index(
+        "anemoi-package-searchpath-plugin"
+    ), "CWD must come before package defaults (priority 2 > 3)"
+
+
+def test_config_path_beats_cwd(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Priority 1 > 2: an explicit --config-path must come before CWD."""
+    user_config = tmp_path / "my_configs"
+    user_config.mkdir()
+
+    providers = _make_search_path(monkeypatch, tmp_path, config_path=str(user_config))
+
+    assert "main" in providers, "--config-path (main) was not in the search path"
+    assert "anemoi-cwd-searchpath-plugin" in providers, "CWD was not added to the search path"
+    assert providers.index("main") < providers.index(
+        "anemoi-cwd-searchpath-plugin"
+    ), "--config-path must come before CWD (priority 1 > 2)"
+
+
+def test_config_path_beats_package(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Priority 1 > 3: an explicit --config-path must come before the packaged defaults."""
+    user_config = tmp_path / "my_configs"
+    user_config.mkdir()
+
+    providers = _make_search_path(monkeypatch, tmp_path, config_path=str(user_config))
+
+    assert "main" in providers, "--config-path (main) was not in the search path"
+    assert "anemoi-package-searchpath-plugin" in providers, "Package fallback was not added"
+    assert providers.index("main") < providers.index(
+        "anemoi-package-searchpath-plugin"
+    ), "--config-path must come before package defaults (priority 1 > 3)"
+
+
+def test_full_priority_order(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """End-to-end: config-path (1) > CWD (2) > package defaults (3)."""
+    user_config = tmp_path / "my_configs"
+    user_config.mkdir()
+
+    providers = _make_search_path(monkeypatch, tmp_path, config_path=str(user_config))
+
+    assert "main" in providers
+    assert "anemoi-cwd-searchpath-plugin" in providers
+    assert "anemoi-package-searchpath-plugin" in providers
+
+    pos_config_path = providers.index("main")
+    pos_cwd = providers.index("anemoi-cwd-searchpath-plugin")
+    pos_package = providers.index("anemoi-package-searchpath-plugin")
+
+    assert pos_config_path < pos_cwd < pos_package, (
+        f"Expected config-path ({pos_config_path}) < CWD ({pos_cwd}) < package ({pos_package})"
+    )

--- a/training/tests/unit/hydra/test_search_path_plugins.py
+++ b/training/tests/unit/hydra/test_search_path_plugins.py
@@ -86,7 +86,9 @@ def _get_hydra_main_config_path(source_file: Path) -> str | None:
                 continue
             for kw in decorator.keywords:
                 if kw.arg == "config_path":
-                    return None if isinstance(kw.value, ast.Constant) and kw.value.value is None else ast.unparse(kw.value)
+                    return (
+                        None if isinstance(kw.value, ast.Constant) and kw.value.value is None else ast.unparse(kw.value)
+                    )
     return "NOT_FOUND"
 
 
@@ -134,9 +136,9 @@ def test_cwd_beats_package_without_config_path(monkeypatch: pytest.MonkeyPatch, 
 
     assert "anemoi-cwd-searchpath-plugin" in providers, "CWD not added to search path"
     assert "anemoi-package-searchpath-plugin" in providers, "Package fallback not added"
-    assert providers.index("anemoi-cwd-searchpath-plugin") < providers.index("anemoi-package-searchpath-plugin"), (
-        "CWD must come before package defaults (priority 2 > 3)"
-    )
+    assert providers.index("anemoi-cwd-searchpath-plugin") < providers.index(
+        "anemoi-package-searchpath-plugin",
+    ), "CWD must come before package defaults (priority 2 > 3)"
 
 
 def test_package_as_main_beats_cwd(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/training/tests/unit/hydra/test_search_path_plugins.py
+++ b/training/tests/unit/hydra/test_search_path_plugins.py
@@ -102,7 +102,7 @@ def test_cwd_beats_package_defaults(monkeypatch: pytest.MonkeyPatch, tmp_path: P
     assert "anemoi-cwd-searchpath-plugin" in providers, "CWD was not added to the search path"
     assert "anemoi-package-searchpath-plugin" in providers, "Package fallback was not added"
     assert providers.index("anemoi-cwd-searchpath-plugin") < providers.index(
-        "anemoi-package-searchpath-plugin"
+        "anemoi-package-searchpath-plugin",
     ), "CWD must come before package defaults (priority 2 > 3)"
 
 
@@ -116,7 +116,7 @@ def test_config_path_beats_cwd(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) 
     assert "main" in providers, "--config-path (main) was not in the search path"
     assert "anemoi-cwd-searchpath-plugin" in providers, "CWD was not added to the search path"
     assert providers.index("main") < providers.index(
-        "anemoi-cwd-searchpath-plugin"
+        "anemoi-cwd-searchpath-plugin",
     ), "--config-path must come before CWD (priority 1 > 2)"
 
 
@@ -130,7 +130,7 @@ def test_config_path_beats_package(monkeypatch: pytest.MonkeyPatch, tmp_path: Pa
     assert "main" in providers, "--config-path (main) was not in the search path"
     assert "anemoi-package-searchpath-plugin" in providers, "Package fallback was not added"
     assert providers.index("main") < providers.index(
-        "anemoi-package-searchpath-plugin"
+        "anemoi-package-searchpath-plugin",
     ), "--config-path must come before package defaults (priority 1 > 3)"
 
 
@@ -149,6 +149,6 @@ def test_full_priority_order(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) ->
     pos_cwd = providers.index("anemoi-cwd-searchpath-plugin")
     pos_package = providers.index("anemoi-package-searchpath-plugin")
 
-    assert pos_config_path < pos_cwd < pos_package, (
-        f"Expected config-path ({pos_config_path}) < CWD ({pos_cwd}) < package ({pos_package})"
-    )
+    assert (
+        pos_config_path < pos_cwd < pos_package
+    ), f"Expected config-path ({pos_config_path}) < CWD ({pos_cwd}) < package ({pos_package})"

--- a/training/tests/unit/hydra/test_search_path_plugins.py
+++ b/training/tests/unit/hydra/test_search_path_plugins.py
@@ -8,6 +8,8 @@
 # nor does it submit to any jurisdiction.
 
 
+import ast
+import importlib.util
 from pathlib import Path
 
 import pytest
@@ -68,87 +70,96 @@ def test_config_path_wins_and_home_env_paths_removed(monkeypatch: pytest.MonkeyP
     assert providers[-1] == "anemoi-package-searchpath-plugin"
 
 
-def _make_search_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, *, config_path: str | None = None) -> list[str]:
-    """Helper: build a search path as the real code does and return the provider list.
+def _get_hydra_main_config_path(source_file: Path) -> str | None:
+    """Parse *source_file* and return the ``config_path`` value passed to ``@hydra.main``, or None if absent."""
+    tree = ast.parse(source_file.read_text())
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef):
+            continue
+        for decorator in node.decorator_list:
+            # Match `hydra.main(...)` or plain `main(...)`
+            if not (isinstance(decorator, ast.Call) and isinstance(decorator.func, (ast.Attribute, ast.Name))):
+                continue
+            func = decorator.func
+            name = func.attr if isinstance(func, ast.Attribute) else func.id
+            if name != "main":
+                continue
+            for kw in decorator.keywords:
+                if kw.arg == "config_path":
+                    return None if isinstance(kw.value, ast.Constant) and kw.value.value is None else ast.unparse(kw.value)
+    return "NOT_FOUND"
 
-    Parameters
-    ----------
-    config_path:
-        Simulates ``--config-path``.  When *None* the entry point uses
-        ``config_path=None`` (our fix) so no primary path is pre-populated.
+
+_ENTRY_POINTS = ["train/train.py", "train/evaluate.py", "train/profiler.py"]
+
+
+@pytest.mark.parametrize("entry_point", _ENTRY_POINTS)
+def test_entry_points_use_config_path_none(entry_point: str) -> None:
+    """Regression test: every @hydra.main entry point must use config_path=None.
+
+    With config_path="../config" the package is registered as provider=main
+    *before* AnemoiSearchPathPlugin runs, giving the package higher priority
+    than the CWD.  Setting config_path=None removes that pre-population so the
+    plugin is the sole authority on search-path ordering.
+    """
+    src_root = Path(importlib.util.find_spec("anemoi.training").origin).parent
+    source_file = src_root / entry_point
+    assert source_file.exists(), f"Entry point not found: {source_file}"
+
+    config_path_value = _get_hydra_main_config_path(source_file)
+    assert config_path_value is None, (
+        f"{entry_point}: @hydra.main must use config_path=None, "
+        f"but found config_path={config_path_value!r}. "
+        "A non-None config_path pre-populates the package as provider=main before "
+        "the search-path plugin runs, causing the package to take precedence over "
+        "the user's CWD overrides."
+    )
+
+
+def test_cwd_beats_package_without_config_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Priority 2 > 3: CWD must appear before packaged defaults when no --config-path is given.
+
+    Simulates the real startup: no primary path pre-populated (config_path=None
+    in @hydra.main), then the plugin runs.
     """
     cwd = tmp_path / "cwd"
-    cwd.mkdir(exist_ok=True)
+    cwd.mkdir()
     monkeypatch.chdir(cwd)
 
     search_path = ConfigSearchPathImpl()
-    if config_path is not None:
-        # Mimic what Hydra does when the user passes --config-path.
-        search_path.append(provider="main", path=config_path)
-
+    # No provider=main entry — this is what config_path=None produces.
     AnemoiSearchPathPlugin().manipulate_search_path(search_path)
-    return [entry.provider for entry in search_path.get_path()]
+
+    providers = [entry.provider for entry in search_path.get_path()]
+
+    assert "anemoi-cwd-searchpath-plugin" in providers, "CWD not added to search path"
+    assert "anemoi-package-searchpath-plugin" in providers, "Package fallback not added"
+    assert providers.index("anemoi-cwd-searchpath-plugin") < providers.index("anemoi-package-searchpath-plugin"), (
+        "CWD must come before package defaults (priority 2 > 3)"
+    )
 
 
-def test_cwd_beats_package_defaults(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """Priority 2 > 3: CWD must come before the packaged defaults when no --config-path is given.
+def test_package_as_main_beats_cwd(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Documents the bug: when config_path='../config' is used, the package is registered
+    as provider=main *before* the plugin runs, so it beats the CWD.
 
-    With ``config_path=None`` in ``@hydra.main`` there is no "main" entry in the
-    search path before the plugin runs, so the plugin is the sole authority on
-    ordering.
+    This test asserts the broken behaviour to make clear why config_path=None is required.
+    If this test ever starts *failing* (i.e. the plugin somehow fixes it internally),
+    the config_path=None change in the entry points may no longer be necessary.
     """
-    providers = _make_search_path(monkeypatch, tmp_path, config_path=None)
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    monkeypatch.chdir(cwd)
 
-    assert "anemoi-cwd-searchpath-plugin" in providers, "CWD was not added to the search path"
-    assert "anemoi-package-searchpath-plugin" in providers, "Package fallback was not added"
-    assert providers.index("anemoi-cwd-searchpath-plugin") < providers.index(
-        "anemoi-package-searchpath-plugin",
-    ), "CWD must come before package defaults (priority 2 > 3)"
+    search_path = ConfigSearchPathImpl()
+    # Simulate @hydra.main(config_path="../config"): package is pre-populated as main.
+    search_path.append(provider="main", path="pkg://anemoi.training/config")
+    AnemoiSearchPathPlugin().manipulate_search_path(search_path)
 
+    providers = [entry.provider for entry in search_path.get_path()]
 
-def test_config_path_beats_cwd(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """Priority 1 > 2: an explicit --config-path must come before CWD."""
-    user_config = tmp_path / "my_configs"
-    user_config.mkdir()
-
-    providers = _make_search_path(monkeypatch, tmp_path, config_path=str(user_config))
-
-    assert "main" in providers, "--config-path (main) was not in the search path"
-    assert "anemoi-cwd-searchpath-plugin" in providers, "CWD was not added to the search path"
-    assert providers.index("main") < providers.index(
-        "anemoi-cwd-searchpath-plugin",
-    ), "--config-path must come before CWD (priority 1 > 2)"
-
-
-def test_config_path_beats_package(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """Priority 1 > 3: an explicit --config-path must come before the packaged defaults."""
-    user_config = tmp_path / "my_configs"
-    user_config.mkdir()
-
-    providers = _make_search_path(monkeypatch, tmp_path, config_path=str(user_config))
-
-    assert "main" in providers, "--config-path (main) was not in the search path"
-    assert "anemoi-package-searchpath-plugin" in providers, "Package fallback was not added"
-    assert providers.index("main") < providers.index(
-        "anemoi-package-searchpath-plugin",
-    ), "--config-path must come before package defaults (priority 1 > 3)"
-
-
-def test_full_priority_order(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """End-to-end: config-path (1) > CWD (2) > package defaults (3)."""
-    user_config = tmp_path / "my_configs"
-    user_config.mkdir()
-
-    providers = _make_search_path(monkeypatch, tmp_path, config_path=str(user_config))
-
-    assert "main" in providers
-    assert "anemoi-cwd-searchpath-plugin" in providers
-    assert "anemoi-package-searchpath-plugin" in providers
-
-    pos_config_path = providers.index("main")
-    pos_cwd = providers.index("anemoi-cwd-searchpath-plugin")
-    pos_package = providers.index("anemoi-package-searchpath-plugin")
-
-    assert (
-        pos_config_path < pos_cwd < pos_package
-    ), f"Expected config-path ({pos_config_path}) < CWD ({pos_cwd}) < package ({pos_package})"
+    # The package (as "main") comes before CWD — this is the bug.
+    assert providers.index("main") < providers.index("anemoi-cwd-searchpath-plugin"), (
+        "Expected the bug: package registered as main should beat CWD. "
+        "If this assertion fails the plugin itself now handles this case."
+    )


### PR DESCRIPTION
## What problem does this change solve?
The documented Hydra config search-path hierarchy for anemoi-training is:

1. --config-path (highest priority)
2. Current working directory (CWD)
3. Packaged default configs (lowest priority / fallback)

In practice, this hierarchy was not respected. All three @hydra.main entry points (train.py, evaluate.py, profiler.py) used config_path="../config", which caused Hydra to register pkg://anemoi.training/config as the primary search path entry (position 2) — before AnemoiSearchPathPlugin ran. Since the plugin only appends CWD and the package fallback, the final order was:

## Description
Change config_path="../config" → config_path=None on all three @hydra.main decorators. With no primary path pre-populated, the plugin becomes the single authority on search path ordering, producing the correct layout:

The packaged config.yaml and all config group defaults are still found via the fallback at position 4.

Three new tests added to test_search_path_plugins.py to check this functionality does not break again



This meant user config overrides in CWD (e.g. diagnostics/log/mlflow.yaml) were silently ignored in favour of the packaged defaults, even though the documentation promised the opposite.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)
