### PR TITLE
chore: Remove 'numba' from dependencies

### DIFF
--- a/training/pyproject.toml
+++ b/training/pyproject.toml
@@ -41,7 +41,6 @@ dependencies = [
   "anemoi-utils[provenance]>=0.5.1",
   "einops>=0.6.1",
   "hydra-core>=1.3",
-  "numba",
   "numpy",
   "nvidia-ml-py>=13.580.82",
   "pydantic>=2.9",


### PR DESCRIPTION
## Description
Removed 'numba' from the project dependencies, we don't use it

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)
