### PR TITLE
fix: missing dependency

### DIFF
--- a/models/pyproject.toml
+++ b/models/pyproject.toml
@@ -61,7 +61,7 @@ optional-dependencies.migrations = [
   "rich",
 ]
 optional-dependencies.spectral = [ "anemoi-transform>=0.1.2", "torch-dct>=0.1.6" ]
-optional-dependencies.tests = [ "anemoi-models[spectral]", "hypothesis>=6.11", "pytest>=8" ]
+optional-dependencies.tests = [ "anemoi-models[spectral]", "hypothesis>=6.11", "pytest>=8", "pytest-mock>=3" ]
 urls.Documentation = "https://anemoi-models.readthedocs.io/"
 urls.Homepage = "https://github.com/ecmwf/anemoi-models/"
 urls.Issues = "https://github.com/ecmwf/anemoi-models/issues"


### PR DESCRIPTION
## Description
in this PR we introduced a unit-test in anemoi-models that used the mocker fixture from pytest, that requires pytest-mock, https://github.com/ecmwf/anemoi-core/pull/1087. This PR fixes that problem. 

Note this is not detected in the PR because for the unit-tests we have just one environment created and pytest-mock is already a dependency in the test section in graphs and training. (https://github.com/ecmwf/anemoi-core/blob/main/.github/workflows/python-pull-request.yml)

## What problem does this change solve?
Downstream CI picked this https://github.com/ecmwf/anemoi-transform/actions/runs/28360593813/job/84075440656.

## What issue or task does this change relate to?
<!-- link to Issue Number -->

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)
