### PR TITLE
fix(models): portable triton checkpoints

### DIFF
--- a/models/src/anemoi/models/triton/gt.py
+++ b/models/src/anemoi/models/triton/gt.py
@@ -11,13 +11,18 @@ import torch
 
 # check if triton is installed
 # If pytorch is installed on CPU then torch is not available
+TRITON_AVAILABLE = True
 try:
     import triton
     import triton.language as tl
 except ImportError:
-    raise ValueError(
-        "Error. The 'triton' backend was selected for the GraphTransformer but Triton is not installed. To use this backend please install Triton. Otherwise, select a different backend for the GraphTransformer in the models config."
-    )
+    TRITON_AVAILABLE = False
+
+    # Triton is not available
+    # functions annotated with '@triton.jit' will fail
+    # Therefore, we create a fake no-op annotation
+    from anemoi.models.triton.utils import fake_tl_type as tl
+    from anemoi.models.triton.utils import fake_triton_annotation as triton
 
 
 @triton.jit
@@ -382,6 +387,11 @@ class GraphTransformerFunction(torch.autograd.Function):
     """Custom autograd for GraphTransformer using Triton kernels."""
 
     def __init__(self):
+        if not TRITON_AVAILABLE:
+            raise ValueError(
+                "Error. The 'triton' backend was selected for the GraphTransformer but Triton is not installed. To use this backend please install Triton. Otherwise, select a different backend for the GraphTransformer in the models config."
+            )
+
         if not torch.cuda.is_available():
             raise ValueError(
                 "Error. The 'triton' backend was selected for the GraphTransformer but 'torch.cuda.is_available()' returned 'False'. The 'triton' backend is currently only supported on GPUs. To run on other device types, please select a different backend for the GraphTransformer in the models config. If you intend to run on GPUs, please ensure your torch install supports running on GPUs."

--- a/models/src/anemoi/models/triton/gt.py
+++ b/models/src/anemoi/models/triton/gt.py
@@ -27,6 +27,7 @@ except ImportError:
 if TRITON_AVAILABLE:
     from anemoi.models.triton.utils import torch_dtype_to_triton
 
+
 @triton.jit
 def build_masks_and_offsets(H: tl.constexpr, C: tl.constexpr, H_pad: tl.constexpr, C_pad: tl.constexpr):
     """Pads H and C to the nearest power of 2 if needed.

--- a/models/src/anemoi/models/triton/gt.py
+++ b/models/src/anemoi/models/triton/gt.py
@@ -24,6 +24,8 @@ except ImportError:
     from anemoi.models.triton.utils import fake_tl_type as tl
     from anemoi.models.triton.utils import fake_triton_annotation as triton
 
+if TRITON_AVAILABLE:
+    from anemoi.models.triton.utils import torch_dtype_to_triton
 
 @triton.jit
 def build_masks_and_offsets(H: tl.constexpr, C: tl.constexpr, H_pad: tl.constexpr, C_pad: tl.constexpr):
@@ -434,16 +436,6 @@ class GraphTransformerFunction(torch.autograd.Function):
         N_src = k.shape[0]
 
         # Infer gradient dtype from incoming gradient tensor
-        def torch_dtype_to_triton(dtype):
-            if dtype == torch.float16:
-                return tl.float16
-            elif dtype == torch.bfloat16:
-                return tl.bfloat16
-            elif dtype == torch.float32:
-                return tl.float32
-            else:
-                raise ValueError(f"Unsupported dtype: {dtype}")
-
         grad_dtype = torch_dtype_to_triton(d_out.dtype)
 
         # Allocate grads and intermediates

--- a/models/src/anemoi/models/triton/utils.py
+++ b/models/src/anemoi/models/triton/utils.py
@@ -52,7 +52,7 @@ class FakeTLType:
     """
 
     constexpr = object
-    #similarly, guard against 'tl.float16' etc. invocations
+    # similarly, guard against 'tl.float16' etc. invocations
     float16 = object
     bfloat16 = object
     float32 = object
@@ -126,8 +126,11 @@ def is_triton_available():
 
     return triton_available and gpus_present
 
+
 def torch_dtype_to_triton(dtype):
-    """ Converts from torch dtype to corresponding triton type."""
+    """Converts from torch dtype to corresponding triton type."""
+    import triton.language as tl
+
     if dtype == torch.float16:
         return tl.float16
     elif dtype == torch.bfloat16:
@@ -136,4 +139,3 @@ def torch_dtype_to_triton(dtype):
         return tl.float32
     else:
         raise ValueError(f"Unsupported dtype: {dtype}")
-

--- a/models/src/anemoi/models/triton/utils.py
+++ b/models/src/anemoi/models/triton/utils.py
@@ -52,6 +52,10 @@ class FakeTLType:
     """
 
     constexpr = object
+    #similarly, guard against 'tl.float16' etc. invocations
+    float16 = object
+    bfloat16 = object
+    float32 = object
 
 
 fake_triton_annotation = FakeTritonAnnotation()
@@ -121,3 +125,15 @@ def is_triton_available():
     gpus_present = torch.cuda.is_available()
 
     return triton_available and gpus_present
+
+def torch_dtype_to_triton(dtype):
+    """ Converts from torch dtype to corresponding triton type."""
+    if dtype == torch.float16:
+        return tl.float16
+    elif dtype == torch.bfloat16:
+        return tl.bfloat16
+    elif dtype == torch.float32:
+        return tl.float32
+    else:
+        raise ValueError(f"Unsupported dtype: {dtype}")
+

--- a/models/src/anemoi/models/triton/utils.py
+++ b/models/src/anemoi/models/triton/utils.py
@@ -22,6 +22,42 @@ from anemoi.models.distributed.khop_edges import sort_edge_index_by_dst
 ANEMOI_DEBUG_SHARDING = os.environ.get("ANEMOI_DEBUG_SHARDING", "") != ""
 
 
+class FakeTritonAnnotation:
+    """Fake triton annotation.
+
+    Triton functions are annotated with '@triton.jit'. When
+    Triton is not installed, this annotation will cause an
+    error when the file is loaded.
+    Therefore this fake annotation can be imported instead
+    when Triton is not available.
+    It is simply the identity operation, returning the
+    annotated function.
+    """
+
+    @staticmethod
+    def jit(fn=None, *args, **kwargs):
+        # Identity operation
+        if fn is None:
+            return lambda f: f
+        return fn
+
+
+class FakeTLType:
+    """fake tl namespace
+
+    Triton functions contain 'tl.constexpr' type hints.
+    When Triton is not installed, this type hint will
+    throw the compiler. This fake class can be imported
+    instead to avoid the import error.
+    """
+
+    constexpr = object
+
+
+fake_triton_annotation = FakeTritonAnnotation()
+fake_tl_type = FakeTLType()
+
+
 def edge_index_to_csc(
     edge_index: Adj,
     num_nodes: Optional[Tuple[int, int]] = None,


### PR DESCRIPTION
## Description
If you train a model using triton, you can't load a triton checkpoint in inference if your inference env does not have triton.

the issue is it tries to import the triton file e.g. `gt.py` which imports triton, and has triton type annotations.

This PR represents one possible solution. it moves the triton import into the GT init, and it creates fake `@triton.jit` and `tl.constexpr` type hints to use if triton is not available. this allows the file to be imported during inference if your env doesn't have triton.

This PR in combination with `export ANEMOI_INFERENCE_GRAPHTRANSFORMER_ATTENTION_BACKEND='pyg'` to run inference with a triton-trained checkpoint, without triton installed in your env.
FYI you don't need to retrain your model, just add this code to your inference env

relies on [this PR](https://github.com/ecmwf/anemoi-core/commit/c1d83955eda1d75001d09f2b686fb0a388218ab6) to make the env vars actually work. so you need models >= 0.15.0 or to cherrypick that PR into your code

if people like this approach there's some more things to do
- [ ] fix flash attention loading
- [ ] docs showing how to run inference with a triton-checkpoint
- [ ] make sure the triton unit tests pass
- [ ] add pytest which mocks triton not being installed and tries to import gt.py