### PR TITLE
for downscaling: InterpolationConnection 

### DIFF
--- a/models/src/anemoi/models/layers/residual.py
+++ b/models/src/anemoi/models/layers/residual.py
@@ -293,6 +293,137 @@ class TruncatedConnection(BaseResidualConnection):
         return self._expand_time(x, n_step_output)
 
 
+class InterpolationConnection(BaseResidualConnection):
+    """Cross-grid interpolation residual connection.
+
+    Applies a single sparse projection to map a *source* dataset's grid onto a *target*
+    grid (e.g. low-resolution input -> high-resolution target). Used for residual
+    downscaling, where the model learns ``target - interp(source)``. Unlike
+    :class:`TruncatedConnection` (a down-then-up projection on the same node set), this is
+    a single cross-grid projection, so the output grid size differs from the input.
+
+    Graph-sourced weights are the primary path: the interpolation geometry is declared as
+    ordinary graph edges (e.g. ``[input, to, output]``), so the graph remains the single
+    source of truth and the projection weights travel with the checkpoint.
+    ``interpolation_file_path`` is the alternative source, for pre-computed projection
+    matrices supplied as an ``.npz`` file.
+
+    Parameters
+    ----------
+    graph : HeteroData, optional
+        Graph containing the source -> target interpolation edges.
+    edges_name : tuple[str, str, str], optional
+        Pre-resolved ``(src, relation, dst)`` edge type for the interpolation edges.
+    edge_weight_attribute : str, optional
+        Edge attribute used as projection weights.
+    src_node_weight_attribute : str, optional
+        Source-node attribute used as additional projection weights.
+    autocast : bool, default False
+        Whether to use automatic mixed precision in the sparse projection.
+    row_normalize : bool, default False
+        Whether to row-normalize the interpolation weights.
+    interpolation_file_path : str, optional
+        Alternative to ``edges_name``: path to the ``.npz`` file containing the
+        source-grid -> target-grid interpolation matrix.
+
+    Examples
+    --------
+    >>> # Graph-based path (edge name supplied by ProjectionCreator)
+    >>> conn = InterpolationConnection(
+    ...     graph=graph,
+    ...     edges_name=("input", "to", "output"),
+    ...     edge_weight_attribute="gauss_weight",
+    ... )
+    >>> x = torch.randn(2, 3, 1, 3, 4)  # (batch, time, ensemble, source grid, features)
+    >>> out = conn(x)
+    >>> print(out.shape)
+    torch.Size([2, 3, 1, 5, 4])
+
+    >>> # File-based path
+    >>> conn = InterpolationConnection(interpolation_file_path="source_to_target.npz")
+    >>> out = conn(x)
+    >>> print(out.shape)
+    torch.Size([2, 3, 1, 5, 4])
+    """
+
+    def __init__(
+        self,
+        graph: Optional[HeteroData] = None,
+        edges_name: Optional[tuple[str, str, str]] = None,
+        edge_weight_attribute: Optional[str] = None,
+        src_node_weight_attribute: Optional[str] = None,
+        interpolation_file_path: Optional[str] = None,
+        autocast: bool = False,
+        row_normalize: bool = False,
+        **_,
+    ) -> None:
+        super().__init__()
+
+        has_edges = edges_name is not None
+        has_file = interpolation_file_path is not None
+        if has_edges == has_file:
+            msg = (
+                "InterpolationConnection requires exactly one of 'edges_name' (graph-sourced) or "
+                "'interpolation_file_path' (file-sourced) to be provided, got "
+                f"edges_name={edges_name!r} and interpolation_file_path={interpolation_file_path!r}."
+            )
+            raise ValueError(msg)
+        if has_edges and graph is None:
+            msg = "InterpolationConnection requires 'graph' to be provided when 'edges_name' is given."
+            raise ValueError(msg)
+
+        self.provider = ProjectionGraphProvider(
+            graph=graph,
+            edges_name=edges_name,
+            edge_weight_attribute=edge_weight_attribute,
+            src_node_weight_attribute=src_node_weight_attribute,
+            file_path=interpolation_file_path,
+            row_normalize=row_normalize,
+        )
+        self.projector = SparseProjector(autocast=autocast)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        grid_shard_sizes=None,
+        model_comm_group=None,
+        n_step_output: int | None = None,
+    ) -> torch.Tensor:
+        """Project every loaded timestep from the source grid onto the target grid.
+
+        Time alignment is a data/task responsibility. This layer deliberately does
+        not select, repeat, or otherwise reinterpret trajectory steps.
+        """
+        batch_size = x.shape[0]
+        time_size = x.shape[1]
+
+        x = einops.rearrange(x, "batch time ensemble grid features -> (batch time ensemble) grid features")
+        channel_shard_sizes = get_shard_sizes(x, -1, model_comm_group)
+        if grid_shard_sizes is not None:  # grid sharding -> channel sharding
+            x = all_to_all_transpose(x, -1, channel_shard_sizes, -2, grid_shard_sizes, model_comm_group)
+
+        x = self.projector(x, self.provider.get_edges(device=x.device))
+
+        # The target grid differs from the source grid, so re-shard on the output grid size.
+        output_grid_shard_sizes = get_shard_sizes(x, -2, model_comm_group)
+        if grid_shard_sizes is not None:  # channel sharding -> grid sharding
+            x = all_to_all_transpose(x, -2, output_grid_shard_sizes, -1, channel_shard_sizes, model_comm_group)
+        x = einops.rearrange(
+            x,
+            "(batch time ensemble) grid features -> batch time ensemble grid features",
+            batch=batch_size,
+            time=time_size,
+        )
+
+        if n_step_output is not None and n_step_output != time_size:
+            raise ValueError(
+                "InterpolationConnection preserves the loaded time axis; "
+                f"received {time_size} loaded steps but n_step_output={n_step_output}. "
+                "Align source and target tensors before projection."
+            )
+        return x
+
+
 def _ornstein_init_theta(
     theta_init: float,
     theta_buff: float,

--- a/models/src/anemoi/models/schemas/residual.py
+++ b/models/src/anemoi/models/schemas/residual.py
@@ -142,9 +142,55 @@ class SpectralOrnsteinConnectionSchema(BaseModel):
     )
 
 
+class InterpolationConnectionSchema(BaseModel):
+    """Schema for the cross-grid interpolation residual connection.
+
+    Maps a source dataset's grid onto the target grid via a single sparse interpolation
+    matrix (source -> target). Used for residual downscaling: ``target - interp(source)``.
+    Graph-sourced weights (``edges_name``) are the primary path; ``interpolation_file_path``
+    is the alternative source, for pre-computed projection matrices.
+    """
+
+    target_: Literal["anemoi.models.layers.residual.InterpolationConnection"] = Field(..., alias="_target_")
+    # Hydra merges `step` from the default SkipConnection config when _target_ is overridden; ignore it.
+    step: int = Field(-1, exclude=True)
+    edges_name: tuple[str, str, str] | None = Field(
+        None,
+        description="Pre-resolved (src, relation, dst) edge type for the interpolation edges.",
+    )
+    edge_weight_attribute: str | None = Field(
+        None,
+        description="Edge attribute used as projection weights.",
+    )
+    src_node_weight_attribute: str | None = Field(
+        None,
+        description="Source-node attribute used as additional projection weights.",
+    )
+    interpolation_file_path: str | None = Field(
+        None,
+        description="Alternative to edges_name: path to the .npz interpolation matrix mapping the "
+        "source grid onto the target grid.",
+    )
+    autocast: bool = Field(False, description="Use automatic mixed precision in the sparse projection.")
+    row_normalize: bool = Field(False, description="Row-normalize the interpolation weights.")
+
+    @model_validator(mode="after")
+    def check_exactly_one_source(self) -> Self:
+        has_edges = self.edges_name is not None
+        has_file = self.interpolation_file_path is not None
+        if has_edges == has_file:
+            msg = (
+                "InterpolationConnectionSchema requires exactly one of 'edges_name' (graph-sourced) "
+                "or 'interpolation_file_path' (file-sourced)."
+            )
+            raise ValueError(msg)
+        return self
+
+
 ResidualConnectionSchema = Annotated[
     SkipConnectionSchema
     | TruncatedConnectionSchema
+    | InterpolationConnectionSchema
     | ScalarOrnsteinConnectionSchema
     | SpectralOrnsteinConnectionSchema,
     Field(discriminator="target_"),

--- a/models/tests/layers/test_residual.py
+++ b/models/tests/layers/test_residual.py
@@ -7,13 +7,16 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
+import tempfile
 from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
+import scipy.sparse
 import torch
 from torch_geometric.data import HeteroData
 
+from anemoi.models.layers.residual import InterpolationConnection
 from anemoi.models.layers.residual import ScalarOrnsteinConnection
 from anemoi.models.layers.residual import SkipConnection
 from anemoi.models.layers.residual import SpectralOrnsteinConnection
@@ -183,6 +186,144 @@ def test_skipconnection(flat_data):
     expected_out = flat_data[:, -1, ...]
 
     assert torch.allclose(out, expected_out), "SkipConnection did not return the expected output."
+
+
+@pytest.fixture
+def interpolation_file_path():
+    with tempfile.NamedTemporaryFile(suffix=".npz") as f:
+        scipy.sparse.save_npz(f.name, scipy.sparse.csr_matrix(np.ones((5, 3), dtype=np.float32)))
+        yield f.name
+
+
+def test_interpolation_connection_preserves_loaded_time(interpolation_file_path):
+    conn = InterpolationConnection(interpolation_file_path=interpolation_file_path)
+    x = torch.randn(2, 3, 1, 3, 4)  # batch, time, ensemble, source grid, features
+
+    out = conn(x)
+
+    assert out.shape == (2, 3, 1, 5, 4)
+    expected = torch.cat([conn(x[:, time : time + 1]) for time in range(3)], dim=1)
+    assert torch.allclose(out, expected)
+
+
+def test_interpolation_connection_rejects_time_repetition(interpolation_file_path):
+    conn = InterpolationConnection(interpolation_file_path=interpolation_file_path)
+    x = torch.randn(2, 3, 1, 3, 4)
+
+    with pytest.raises(ValueError, match="preserves the loaded time axis"):
+        conn(x, n_step_output=2)
+
+
+@pytest.fixture
+def asymmetric_interpolation_file_path():
+    # A 5x3 (target x source) matrix with distinct entries. Unlike an all-ones matrix, this
+    # detects orientation / permutation errors: every target row mixes the source nodes differently.
+    matrix = np.array(
+        [
+            [1.0, 0.0, 0.0],
+            [0.0, 2.0, 0.0],
+            [0.0, 0.0, 3.0],
+            [0.5, 0.5, 0.0],
+            [0.0, 0.0, 4.0],
+        ],
+        dtype=np.float32,
+    )
+    with tempfile.NamedTemporaryFile(suffix=".npz") as f:
+        scipy.sparse.save_npz(f.name, scipy.sparse.csr_matrix(matrix))
+        yield f.name
+
+
+def test_interpolation_connection_known_asymmetric_values(asymmetric_interpolation_file_path):
+    conn = InterpolationConnection(interpolation_file_path=asymmetric_interpolation_file_path)
+
+    # Two features per node, distinct per node so a mis-oriented matmul would be caught.
+    x = torch.tensor(
+        [[[[[1.0, 10.0], [2.0, 20.0], [3.0, 30.0]]]]],  # (batch=1, time=1, ens=1, src_grid=3, feat=2)
+    )
+    out = conn(x)
+
+    assert out.shape == (1, 1, 1, 5, 2)
+    expected = torch.tensor(
+        [
+            [
+                [
+                    [
+                        [1.0, 10.0],  # 1*node0
+                        [4.0, 40.0],  # 2*node1
+                        [9.0, 90.0],  # 3*node2
+                        [1.5, 15.0],  # 0.5*node0 + 0.5*node1
+                        [12.0, 120.0],  # 4*node2
+                    ]
+                ]
+            ]
+        ]
+    )
+    assert torch.allclose(out, expected)
+
+
+@pytest.fixture
+def asymmetric_interpolation_graph():
+    # Encodes the same 5x3 (target x source) matrix as `asymmetric_interpolation_file_path`,
+    # as graph edges instead of an .npz file:
+    #   target0 = 1*source0
+    #   target1 = 2*source1
+    #   target2 = 3*source2
+    #   target3 = 0.5*source0 + 0.5*source1
+    #   target4 = 4*source2
+    graph = HeteroData()
+    graph["source"].num_nodes = 3
+    graph["target"].num_nodes = 5
+    # PyG convention: edge_index[0] = source node idx, edge_index[1] = target node idx.
+    graph["source", "to", "target"].edge_index = torch.tensor(
+        [
+            [0, 1, 2, 0, 1, 2],
+            [0, 1, 2, 3, 3, 4],
+        ]
+    )
+    graph["source", "to", "target"].weight = torch.tensor([1.0, 2.0, 3.0, 0.5, 0.5, 4.0])
+    return graph
+
+
+def test_interpolation_connection_graph_matches_file(
+    asymmetric_interpolation_file_path, asymmetric_interpolation_graph
+):
+    """Graph-sourced and file-sourced constructions must produce identical projections."""
+    conn_file = InterpolationConnection(interpolation_file_path=asymmetric_interpolation_file_path)
+    conn_graph = InterpolationConnection(
+        graph=asymmetric_interpolation_graph,
+        edges_name=("source", "to", "target"),
+        edge_weight_attribute="weight",
+    )
+
+    x = torch.tensor(
+        [[[[[1.0, 10.0], [2.0, 20.0], [3.0, 30.0]]]]],  # (batch=1, time=1, ens=1, src_grid=3, feat=2)
+    )
+    out_file = conn_file(x)
+    out_graph = conn_graph(x)
+
+    assert out_file.shape == out_graph.shape == (1, 1, 1, 5, 2)
+    assert torch.allclose(out_file, out_graph)
+
+
+def test_interpolation_connection_requires_a_source():
+    with pytest.raises(ValueError, match="exactly one"):
+        InterpolationConnection()
+
+
+def test_interpolation_connection_rejects_both_sources(
+    asymmetric_interpolation_file_path, asymmetric_interpolation_graph
+):
+    with pytest.raises(ValueError, match="exactly one"):
+        InterpolationConnection(
+            graph=asymmetric_interpolation_graph,
+            edges_name=("source", "to", "target"),
+            interpolation_file_path=asymmetric_interpolation_file_path,
+        )
+
+
+def test_interpolation_connection_edges_name_requires_graph():
+    with pytest.raises(ValueError, match="graph"):
+        InterpolationConnection(edges_name=("source", "to", "target"))
 
 
 # ── ScalarOrnsteinConnection tests ───────────────────────────────────────

--- a/models/tests/schemas/test_residual_schemas.py
+++ b/models/tests/schemas/test_residual_schemas.py
@@ -10,6 +10,7 @@
 import pytest
 from pydantic import ValidationError
 
+from anemoi.models.schemas.residual import InterpolationConnectionSchema
 from anemoi.models.schemas.residual import TruncatedConnectionSchema
 from anemoi.models.schemas.residual import TruncationConfigDiskSchema
 from anemoi.models.schemas.residual import TruncationConfigOnTheFlySchema
@@ -66,5 +67,49 @@ def test_truncated_connection_mixed_mode_rejected() -> None:
                     "truncation_up_file_path": "up.npz",
                     "truncation_down_file_path": "down.npz",
                 },
+            }
+        )
+
+
+def test_interpolation_connection_has_no_trajectory_step_field() -> None:
+    schema = InterpolationConnectionSchema(
+        **{
+            "_target_": "anemoi.models.layers.residual.InterpolationConnection",
+            "interpolation_file_path": "source-to-target.npz",
+        }
+    )
+
+    assert "step" not in schema.model_dump()
+
+
+def test_interpolation_connection_graph_sourced_valid() -> None:
+    schema = InterpolationConnectionSchema(
+        **{
+            "_target_": "anemoi.models.layers.residual.InterpolationConnection",
+            "edges_name": ("source", "to", "target"),
+            "edge_weight_attribute": "gauss_weight",
+        }
+    )
+
+    assert schema.interpolation_file_path is None
+    assert schema.edges_name == ("source", "to", "target")
+
+
+def test_interpolation_connection_rejects_both_sources() -> None:
+    with pytest.raises(ValidationError, match="exactly one"):
+        InterpolationConnectionSchema(
+            **{
+                "_target_": "anemoi.models.layers.residual.InterpolationConnection",
+                "interpolation_file_path": "source-to-target.npz",
+                "edges_name": ("source", "to", "target"),
+            }
+        )
+
+
+def test_interpolation_connection_rejects_neither_source() -> None:
+    with pytest.raises(ValidationError, match="exactly one"):
+        InterpolationConnectionSchema(
+            **{
+                "_target_": "anemoi.models.layers.residual.InterpolationConnection",
             }
         )


### PR DESCRIPTION
For downscaling

A single sparse projection mapping a source dataset's grid onto a target grid (e.g. low-res input -> high-res target), for residual downscaling (target - interp(source)). Unlike TruncatedConnection (same-grid down-then-up), the output grid differs from the input grid; the loaded time axis is preserved and never reinterpreted. Includes known-value asymmetric-matrix tests (orientation-sensitive) and schema.


