### PR TITLE
feat(training): SpatialDownscaler task — integer offsets, strict same…

### DIFF
--- a/training/src/anemoi/training/config/task/spatial_downscaler.yaml
+++ b/training/src/anemoi/training/config/task/spatial_downscaler.yaml
@@ -1,0 +1,10 @@
+# Spatial downscaling: predict ``output_datasets`` from ``input_datasets`` at the
+# same valid time(s). Offsets are integers in units of the dataset frequency
+# (0 = the sample's base time); several offsets make the task multi-input /
+# multi-output, and every output offset must also be an input offset.
+_target_: anemoi.training.tasks.SpatialDownscaler
+input_datasets: [input]
+output_datasets: [output]
+input_offsets: [0]
+output_offsets: [0]
+frequency: ${data.frequency}

--- a/training/src/anemoi/training/schemas/tasks.py
+++ b/training/src/anemoi/training/schemas/tasks.py
@@ -14,6 +14,7 @@ from pydantic import Discriminator
 from pydantic import Field
 from pydantic import NonNegativeInt
 from pydantic import PositiveInt
+from pydantic import model_validator
 
 from anemoi.utils.schemas import BaseModel
 
@@ -68,7 +69,38 @@ class TemporalDownscalerSchema(BaseModel):
     "Whether to include the right boundary in the output."
 
 
+class SpatialDownscalerSchema(BaseModel):
+    """Configuration for spatial residual downscaling."""
+
+    target_: Literal["anemoi.training.tasks.SpatialDownscaler"] = Field(..., alias="_target_")
+    "Task class path for the spatial downscaling task."
+    input_datasets: list[str] = Field(..., min_length=1)
+    "Datasets supplied as spatially coarse/source inputs."
+    output_datasets: list[str] = Field(..., min_length=1)
+    "Datasets predicted as spatially fine/target outputs."
+    input_offsets: list[int] = Field(..., min_length=1)
+    "Dataset-relative integer offsets of the source state(s)."
+    output_offsets: list[int] = Field(..., min_length=1)
+    "Dataset-relative integer offsets of the target state(s). Must be a subset of `input_offsets`."
+    frequency: str = Field(example="${data.frequency}")
+    "Sampling frequency the datasets are opened with; one offset = one step of this. Use ${data.frequency}."
+
+    @model_validator(mode="after")
+    def _validate_offsets(self) -> "SpatialDownscalerSchema":
+        if len(set(self.input_offsets)) != len(self.input_offsets):
+            raise ValueError(f"input_offsets contains duplicates: {self.input_offsets}")
+        if len(set(self.output_offsets)) != len(self.output_offsets):
+            raise ValueError(f"output_offsets contains duplicates: {self.output_offsets}")
+        missing = sorted(set(self.output_offsets) - set(self.input_offsets))
+        if missing:
+            raise ValueError(
+                f"output_offsets {missing} have no matching input_offsets; "
+                f"output_offsets must be a subset of input_offsets ({sorted(set(self.input_offsets))}).",
+            )
+        return self
+
+
 TaskSchema = Annotated[
-    ForecasterSchema | AutoencoderTaskSchema | TemporalDownscalerSchema,
+    ForecasterSchema | AutoencoderTaskSchema | TemporalDownscalerSchema | SpatialDownscalerSchema,
     Discriminator("target_"),
 ]

--- a/training/src/anemoi/training/tasks/__init__.py
+++ b/training/src/anemoi/training/tasks/__init__.py
@@ -8,11 +8,13 @@
 # nor does it submit to any jurisdiction.
 
 from .forecaster import Forecaster
+from .spatial_downscaler import SpatialDownscaler
 from .temporal_downscaler import TemporalDownscaler
 from .timeless import Autoencoder
 
 __all__ = [
     "Autoencoder",
     "Forecaster",
+    "SpatialDownscaler",
     "TemporalDownscaler",
 ]

--- a/training/src/anemoi/training/tasks/spatial_downscaler.py
+++ b/training/src/anemoi/training/tasks/spatial_downscaler.py
@@ -1,0 +1,114 @@
+# (C) Copyright 2026 Anemoi contributors.
+#
+# This software is licensed under the terms of the Apache Licence 2.0.
+
+from __future__ import annotations
+
+import torch
+
+from anemoi.models.data_indices.collection import IndexCollection
+from anemoi.training.tasks.base import BaseTask
+from anemoi.utils.dates import frequency_to_string
+from anemoi.utils.dates import frequency_to_timedelta
+
+
+class SpatialDownscaler(BaseTask):
+    """Spatial-downscaling task: predict high-resolution target datasets from
+    lower-resolution (and same-grid conditioning) input datasets at matched valid times.
+
+    There is no rollout and no input advancement. A sample is the set of
+    ``input_datasets`` and ``output_datasets`` read at the configured integer
+    offsets -- multi-input / multi-output when several offsets are given -- and
+    every output offset must also be an input offset, so each predicted state
+    has a source state at the same valid time.
+
+    Offsets are integers in units of ``frequency``, the sampling frequency the
+    datasets are opened with. Configure it as ``frequency: ${data.frequency}``
+    so it always matches the data (the same pattern as ``Forecaster.timestep``).
+    """
+
+    name: str = "spatial-downscaler"
+
+    def __init__(
+        self,
+        input_datasets: list[str],
+        output_datasets: list[str],
+        input_offsets: list[int],
+        output_offsets: list[int],
+        frequency: str,
+        **_kwargs,
+    ) -> None:
+        self.input_datasets = tuple(input_datasets)
+        self.output_datasets = tuple(output_datasets)
+        # Types, non-emptiness and uniqueness are enforced by the pydantic task schema at config
+        # time. The one invariant with physics content is re-checked here because tasks are also
+        # constructed programmatically: outputs must be a subset of inputs, no fallback of any kind.
+        missing = sorted(set(output_offsets) - set(input_offsets))
+        if missing:
+            raise ValueError(
+                f"SpatialDownscaler output_offsets {missing} have no matching input_offsets; "
+                f"output_offsets must be a subset of input_offsets ({sorted(set(input_offsets))})."
+            )
+
+        self._integer_input_offsets: list[int] = sorted(input_offsets)
+        self._integer_output_offsets: list[int] = sorted(output_offsets)
+        self._frequency = frequency_to_timedelta(frequency)
+
+        super().__init__(
+            input_offsets=[offset * self._frequency for offset in self._integer_input_offsets],
+            output_offsets=[offset * self._frequency for offset in self._integer_output_offsets],
+        )
+
+    def output_to_input_positions(self) -> list[int]:
+        """For each output offset (in output order), return its position among the input offsets.
+
+        Strict same-offset helper: an output offset with no matching input
+        offset raises ``ValueError``. The ``__init__`` invariant already makes
+        this unreachable in practice; this is defense-in-depth, not a fallback.
+        """
+        positions = []
+        for offset in self._integer_output_offsets:
+            try:
+                positions.append(self._integer_input_offsets.index(offset))
+            except ValueError as exc:
+                raise ValueError(
+                    f"SpatialDownscaler output offset {offset} has no matching input offset "
+                    f"in {self._integer_input_offsets}.",
+                ) from exc
+        return positions
+
+    def get_inputs(
+        self,
+        batch: dict[str, torch.Tensor],
+        data_indices: dict[str, IndexCollection],
+        **kwargs,
+    ) -> dict[str, torch.Tensor]:
+        inputs = super().get_inputs(batch, data_indices, **kwargs)
+        # A dataset missing from the batch raises KeyError(name) here -- loud enough.
+        return {name: inputs[name] for name in self.input_datasets}
+
+    def get_targets(self, batch: dict[str, torch.Tensor], **kwargs) -> dict[str, torch.Tensor]:
+        targets = super().get_targets(batch, **kwargs)
+        return {name: targets[name] for name in self.output_datasets}
+
+    def _get_timestep_for_metadata(self) -> str:
+        return frequency_to_string(self._frequency)
+
+    def fill_metadata(self, md_dict: dict) -> None:
+        """Fill the metadata dictionary with task-specific information.
+
+        Extends ``BaseTask.fill_metadata`` by recording the integer
+        dataset-relative offsets and the dataset roles, which are not
+        expressible in the base ``timesteps`` dict (which only carries
+        physical timedeltas).
+        """
+        super().fill_metadata(md_dict)
+
+        dataset_names = md_dict["metadata_inference"]["dataset_names"]
+        for dataset_name in dataset_names:
+            timesteps = md_dict["metadata_inference"][dataset_name]["timesteps"]
+            timesteps["input_offsets"] = self._integer_input_offsets
+            timesteps["output_offsets"] = self._integer_output_offsets
+
+        md_dict["input_datasets"] = list(self.input_datasets)
+        md_dict["output_datasets"] = list(self.output_datasets)

--- a/training/src/anemoi/training/tasks/spatial_downscaler.py
+++ b/training/src/anemoi/training/tasks/spatial_downscaler.py
@@ -47,7 +47,7 @@ class SpatialDownscaler(BaseTask):
         if missing:
             raise ValueError(
                 f"SpatialDownscaler output_offsets {missing} have no matching input_offsets; "
-                f"output_offsets must be a subset of input_offsets ({sorted(set(input_offsets))})."
+                f"output_offsets must be a subset of input_offsets ({sorted(set(input_offsets))}).",
             )
 
         self._integer_input_offsets: list[int] = sorted(input_offsets)

--- a/training/tests/unit/tasks/test_spatial_downscaler.py
+++ b/training/tests/unit/tasks/test_spatial_downscaler.py
@@ -22,8 +22,7 @@ def _task(input_offsets: list[int], output_offsets: list[int], **kwargs) -> Spat
 
 def _index_collection_for(names: tuple[str, ...]) -> dict[str, SimpleNamespace]:
     return {
-        name: SimpleNamespace(data=SimpleNamespace(input=SimpleNamespace(full=torch.tensor([0]))))
-        for name in names
+        name: SimpleNamespace(data=SimpleNamespace(input=SimpleNamespace(full=torch.tensor([0])))) for name in names
     }
 
 

--- a/training/tests/unit/tasks/test_spatial_downscaler.py
+++ b/training/tests/unit/tasks/test_spatial_downscaler.py
@@ -1,0 +1,197 @@
+# (C) Copyright 2026 Anemoi contributors.
+
+import datetime
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from anemoi.training.data.relative_time_indices import compute_relative_date_indices
+from anemoi.training.tasks import SpatialDownscaler
+
+
+def _task(input_offsets: list[int], output_offsets: list[int], **kwargs) -> SpatialDownscaler:
+    defaults = {
+        "input_datasets": ["input"],
+        "output_datasets": ["output"],
+        "frequency": "6h",
+    }
+    defaults.update(kwargs)
+    return SpatialDownscaler(input_offsets=input_offsets, output_offsets=output_offsets, **defaults)
+
+
+def _index_collection_for(names: tuple[str, ...]) -> dict[str, SimpleNamespace]:
+    return {
+        name: SimpleNamespace(data=SimpleNamespace(input=SimpleNamespace(full=torch.tensor([0]))))
+        for name in names
+    }
+
+
+# ── Construction: the four supported offset forms ─────────────────────────────
+
+
+OFFSET_CASES = [
+    # (input_offsets, output_offsets, expected_input_positions, expected_output_positions, expected_output_to_input)
+    ([0], [0], [0], [0], [0]),
+    ([0, 1], [0, 1], [0, 1], [0, 1], [0, 1]),
+    ([-1, 0, 1, 2], [0, 1], [0, 1, 2, 3], [1, 2], [1, 2]),
+    ([-1, 0, 1], [0], [0, 1, 2], [1], [1]),
+]
+
+
+@pytest.mark.parametrize(
+    ("input_offsets", "output_offsets", "expected_input_positions", "expected_output_positions", "expected_o2i"),
+    OFFSET_CASES,
+)
+def test_construction_and_batch_positions(
+    input_offsets: list[int],
+    output_offsets: list[int],
+    expected_input_positions: list[int],
+    expected_output_positions: list[int],
+    expected_o2i: list[int],
+) -> None:
+    task = _task(input_offsets, output_offsets)
+
+    assert task.get_batch_input_indices() == expected_input_positions
+    assert task.get_batch_output_indices() == expected_output_positions
+    assert task.output_to_input_positions() == expected_o2i
+
+
+def test_offsets_are_frequency_multiples() -> None:
+    """Integer offsets become physical offsets at construction: offset x frequency."""
+    task = _task([-1, 0, 1], [0], frequency="6h")
+
+    assert task.get_input_offsets() == [
+        datetime.timedelta(hours=-6),
+        datetime.timedelta(hours=0),
+        datetime.timedelta(hours=6),
+    ]
+    assert task.get_output_offsets() == [datetime.timedelta(hours=0)]
+    assert task._get_timestep_for_metadata() == "6h"
+
+
+def test_relative_date_indices_equal_the_configured_integers() -> None:
+    """The round trip: integers x frequency // frequency == the same integers.
+
+    ``compute_relative_date_indices`` is the existing helper that turns task offsets into
+    dataset row positions; with this task the positions ARE the configured integers.
+    """
+    task = _task([-1, 0, 1, 2], [0, 1])
+    readers = {
+        "input": SimpleNamespace(frequency=datetime.timedelta(hours=6)),
+        "output": SimpleNamespace(frequency=datetime.timedelta(hours=6)),
+    }
+
+    relative_date_indices = compute_relative_date_indices(task, readers)
+
+    expected = [-1, 0, 1, 2]
+    assert relative_date_indices == {"input": expected, "output": expected}
+
+
+def test_incompatible_frequency_fails_in_existing_helper() -> None:
+    """A task frequency the data cannot represent fails loudly in the existing helper."""
+    task = _task([-1, 0, 1], [0], frequency="6h")
+    readers = {"input": SimpleNamespace(frequency=datetime.timedelta(hours=4))}
+
+    with pytest.raises(ValueError, match="not compatible"):
+        compute_relative_date_indices(task, readers)
+
+
+# ── Invariant violations ───────────────────────────────────────────────────────
+
+
+def test_output_offset_not_in_inputs_raises() -> None:
+    with pytest.raises(ValueError, match="output_offsets"):
+        _task([0, 1], [2])
+
+
+# Types, non-emptiness and uniqueness are enforced by the pydantic task schema (SpatialDownscalerSchema),
+# not re-checked in __init__. The subset invariant is the one check kept in the task itself — see
+# ``test_output_offset_not_in_inputs_raises``.
+
+
+# ── Role selection ──────────────────────────────────────────────────────────
+
+
+def test_get_inputs_and_get_targets_select_named_roles_in_order() -> None:
+    task = _task([-1, 0, 1, 2], [0, 1], input_datasets=["input", "output"])
+    n_time = 4  # len of the offset union [-1, 0, 1, 2]
+    batch = {
+        "input": torch.arange(n_time).reshape(1, n_time, 1, 1).float(),
+        "output": torch.arange(n_time, 2 * n_time).reshape(1, n_time, 1, 1).float(),
+    }
+    data_indices = _index_collection_for(("input", "output"))
+
+    inputs = task.get_inputs(batch, data_indices)
+    targets = task.get_targets(batch)
+
+    assert list(inputs) == ["input", "output"]
+    assert list(targets) == ["output"]
+    # 4 input positions (all of them), 2 output positions (indices 1,2 within the union)
+    assert inputs["input"].shape[1] == 4
+    assert targets["output"].shape[1] == 2
+
+
+def test_get_inputs_missing_dataset_raises_key_error() -> None:
+    task = _task([0], [0], input_datasets=["input", "missing"])
+    batch = {
+        "input": torch.zeros(1, 1, 1, 1),
+        "output": torch.zeros(1, 1, 1, 1),
+    }
+    data_indices = _index_collection_for(("input", "output"))
+
+    with pytest.raises(KeyError, match="missing"):
+        task.get_inputs(batch, data_indices)
+
+
+def test_get_targets_missing_dataset_raises_key_error() -> None:
+    task = _task([0], [0], output_datasets=["missing"])
+    batch = {"input": torch.zeros(1, 1, 1, 1)}
+
+    with pytest.raises(KeyError, match="missing"):
+        task.get_targets(batch)
+
+
+# ── fill_metadata ────────────────────────────────────────────────────────────
+
+
+def test_fill_metadata_records_integer_offsets_and_roles() -> None:
+    task = _task([-1, 0, 1, 2], [0, 1], input_datasets=["input", "output"])
+
+    md_dict = {
+        "metadata_inference": {
+            "dataset_names": ["input", "output"],
+            "input": {},
+            "output": {},
+        },
+    }
+
+    task.fill_metadata(md_dict)
+
+    assert md_dict["task"] == "spatial-downscaler"
+    assert md_dict["input_datasets"] == ["input", "output"]
+    assert md_dict["output_datasets"] == ["output"]
+    for dataset_name in ("input", "output"):
+        timesteps = md_dict["metadata_inference"][dataset_name]["timesteps"]
+        assert timesteps["input_offsets"] == [-1, 0, 1, 2]
+        assert timesteps["output_offsets"] == [0, 1]
+        assert timesteps["timestep"] == "6h"
+
+
+def test_schema_rejects_empty_lists() -> None:
+    """Non-emptiness is owned by the config-time schema, not the task."""
+    from pydantic import ValidationError
+
+    from anemoi.training.schemas.tasks import SpatialDownscalerSchema
+
+    base = {
+        "_target_": "anemoi.training.tasks.SpatialDownscaler",
+        "input_datasets": ["input"],
+        "output_datasets": ["output"],
+        "input_offsets": [0],
+        "output_offsets": [0],
+        "frequency": "6h",
+    }
+    for field in ("input_datasets", "output_datasets", "input_offsets", "output_offsets"):
+        with pytest.raises(ValidationError):
+            SpatialDownscalerSchema(**{**base, field: []})


### PR DESCRIPTION

A single-valid-time task for spatial downscaling with named dataset roles (input_datasets condition the target; output_datasets are predicted); 

multi-input / multi-output when several offsets are given. 

Offsets are integer and dataset-relative — one offset is one step of 'frequency', so it always matches the frequency the datasets are opened with

The invariant set(output_offsets) <= set(input_offsets) is enforced so every predicted state has a source state at the same valid time for residuals computation

Integer offsets and dataset roles are recorded in checkpoint metadata.


