### PR TITLE
refactor(graphs): graph creation from anemoi-training

### DIFF
--- a/graphs/src/anemoi/graphs/builders.py
+++ b/graphs/src/anemoi/graphs/builders.py
@@ -54,38 +54,6 @@ def _knn_edge_cfg(
     }
 
 
-def _expand_smoother_config(cfg: dict | Any) -> dict[str, dict]:
-    """Return an explicit ``{name: spec}`` smoothers dict from cfg.
-
-    Accepts either an already-explicit ``smoothers`` mapping or a compact
-    geometric-progression spec (``num_scales``, ``base_num_nearest_neighbours``,
-    ``base_sigma``, …).
-    """
-    if OmegaConf.is_config(cfg):
-        cfg = OmegaConf.to_container(cfg, resolve=True)
-
-    smoothers = cfg.get("smoothers")
-    if smoothers:
-        return dict(smoothers)
-
-    num_scales = cfg.get("num_scales")
-    if num_scales is None:
-        return {}
-
-    base_neighbours = cfg["base_num_nearest_neighbours"]
-    base_sigma = cfg["base_sigma"]
-    scale_factor = cfg.get("scale_factor", 2)
-
-    smoothers = {}
-    for i in range(num_scales):
-        factor = scale_factor**i
-        smoothers[f"smooth_{factor}x"] = {
-            "num_nearest_neighbours": base_neighbours * factor,
-            "sigma": round(base_sigma * factor, 5),
-        }
-    return smoothers
-
-
 def build_node_to_node_projection_subgraph(
     graph_data: HeteroData,
     source_node_name: str,

--- a/graphs/src/anemoi/graphs/create.py
+++ b/graphs/src/anemoi/graphs/create.py
@@ -187,14 +187,3 @@ def load_graph_from_file(graph_filename: Path) -> HeteroData:
 
     LOGGER.info("Loading graph data from %s", graph_filename)
     return torch.load(graph_filename, map_location=map_location, weights_only=False)
-
-
-def validate_loaded_graph(graph_data: HeteroData, required_dataset_names: list[str]) -> None:
-    """Ensure the loaded graph contains the required dataset node types."""
-    missing = [n for n in required_dataset_names if n not in graph_data.node_types]
-    if missing:
-        msg = (
-            "Loaded graph is missing dataset node types required by the dataloader. "
-            f"Missing {missing}; available nodes are {graph_data.node_types}."
-        )
-        raise ValueError(msg)

--- a/graphs/src/anemoi/graphs/projection_helpers.py
+++ b/graphs/src/anemoi/graphs/projection_helpers.py
@@ -10,42 +10,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
-
-from omegaconf import DictConfig
-from torch_geometric.data import HeteroData
-
 DEFAULT_DATASET_NAME = "data"
 DEFAULT_EDGE_RELATION_NAME = "to"
 DEFAULT_EDGE_WEIGHT_ATTRIBUTE = "gauss_weight"
 DEFAULT_GAUSSIAN_NORM = "l1"
-
-
-def get_graph_node_names(
-    graph_or_config: HeteroData | DictConfig | Mapping,
-) -> set[str]:
-    """Return the node-type names visible in a built graph or graph config."""
-    if isinstance(graph_or_config, HeteroData):
-        return set(graph_or_config.node_types)
-
-    if isinstance(graph_or_config, Mapping):
-        nodes = graph_or_config.get("nodes", {})
-    else:
-        nodes = getattr(graph_or_config, "nodes", {})
-
-    return set(nodes.keys()) if nodes else set()
-
-
-def uses_fused_dataset_graph(graph_or_config: HeteroData | DictConfig | Mapping, dataset_names: list[str]) -> bool:
-    """Return whether the graph has one node group per dataset.
-
-    In this form each dataset name is itself a node group in the graph,
-    rather than reusing a single generic ``data`` node group.
-    """
-    if not dataset_names:
-        return False
-    node_names = get_graph_node_names(graph_or_config)
-    if not set(dataset_names).issubset(node_names):
-        return False
-
-    return dataset_names != [DEFAULT_DATASET_NAME] or DEFAULT_DATASET_NAME not in node_names

--- a/models/src/anemoi/models/models/base.py
+++ b/models/src/anemoi/models/models/base.py
@@ -21,8 +21,6 @@ from torch import nn
 from torch.distributed.distributed_c10d import ProcessGroup
 from torch_geometric.data import HeteroData
 
-from anemoi.graphs.projection_helpers import DEFAULT_DATASET_NAME
-from anemoi.graphs.projection_helpers import uses_fused_dataset_graph
 from anemoi.models.distributed.graph import gather_tensor
 from anemoi.models.distributed.graph import shard_tensor
 from anemoi.models.distributed.shapes import DatasetShardSizes
@@ -243,13 +241,11 @@ class BaseGraphModel(nn.Module):
 
     def _build_residual(self, residual_config: DotDict) -> None:
         self.residual = torch.nn.ModuleDict()
-        fused = uses_fused_dataset_graph(self._graph_data, self.dataset_names)
         for dataset_name in self.dataset_names:
-            data_node_name = dataset_name if fused else DEFAULT_DATASET_NAME
             self.residual[dataset_name] = instantiate(
                 residual_config,
                 graph=self._graph_data,
-                data_node_name=data_node_name,
+                data_node_name=dataset_name,
                 statistics=self.statistics[dataset_name],
                 data_indices=self.data_indices[dataset_name],
                 dataset_name=dataset_name,

--- a/training/src/anemoi/training/data/data_reader.py
+++ b/training/src/anemoi/training/data/data_reader.py
@@ -19,10 +19,10 @@ from rich.tree import Tree
 
 from anemoi.datasets import open_dataset
 from anemoi.training.data.usable_indices import get_usable_indices
-from anemoi.training.utils.time_indices import TimeIndices
 from anemoi.training.utils.configs import _as_dict
 from anemoi.training.utils.configs import _normalize_dataset_config
 from anemoi.training.utils.configs import _normalize_reader_config
+from anemoi.training.utils.time_indices import TimeIndices
 
 LOGGER = logging.getLogger(__name__)
 

--- a/training/src/anemoi/training/data/data_reader.py
+++ b/training/src/anemoi/training/data/data_reader.py
@@ -14,73 +14,17 @@ from functools import cached_property
 import numpy as np
 import torch
 from einops import rearrange
-from omegaconf import DictConfig
 from rich.console import Console
 from rich.tree import Tree
 
 from anemoi.datasets import open_dataset
 from anemoi.training.data.usable_indices import get_usable_indices
 from anemoi.training.utils.time_indices import TimeIndices
+from anemoi.training.utils.configs import _as_dict
+from anemoi.training.utils.configs import _normalize_dataset_config
+from anemoi.training.utils.configs import _normalize_reader_config
 
 LOGGER = logging.getLogger(__name__)
-
-
-def _as_dict(value: str | dict | DictConfig) -> str | dict:
-    """Convert DictConfig payloads to plain dicts."""
-    return dict(value) if isinstance(value, DictConfig) else value
-
-
-def _normalize_dataset_config(dataset_config: str | dict | DictConfig) -> str | dict:
-    """Normalize dataset payload to the open_dataset dictionary contract."""
-    dataset_config = _as_dict(dataset_config)
-    if not isinstance(dataset_config, dict):
-        return dataset_config
-
-    if "dataset" not in dataset_config:
-        msg = "dataset_config must contain the 'dataset' key."
-        raise ValueError(msg)
-
-    if dataset_config["dataset"] is None:
-        msg = "dataset_config.dataset cannot be None."
-        raise ValueError(msg)
-
-    invalid_inner_keys = {"start", "end"} & set(dataset_config)
-    if invalid_inner_keys:
-        invalid = ", ".join(sorted(invalid_inner_keys))
-        msg = f"dataset_config cannot contain [{invalid}]. Use outer keys 'start' and 'end' instead."
-        raise ValueError(msg)
-
-    # Keep only explicitly set options to avoid passing None-valued kwargs
-    # (e.g. select=None), which can trigger downstream subset selection issues.
-    return {key: value for key, value in dataset_config.items() if value is not None}
-
-
-def _normalize_reader_config(dataset_config: dict | DictConfig) -> dict:
-    """Validate and normalize reader configuration."""
-    normalized = dict(dataset_config)
-
-    if "dataset" in normalized:
-        msg = (
-            "Invalid dataloader dataset schema: use 'dataset_config' (outer key) "
-            "and 'dataset' inside it. The legacy outer 'dataset' key is no longer supported."
-        )
-        raise ValueError(msg)
-
-    base_dataset_config = normalized.pop("dataset_config", None)
-    if base_dataset_config is None:
-        msg = "Missing required 'dataset_config' in dataset reader configuration."
-        raise ValueError(msg)
-
-    allowed_keys = {"start", "end", "trajectory"}
-    unknown_keys = set(normalized) - allowed_keys
-    if unknown_keys:
-        unknown = ", ".join(sorted(unknown_keys))
-        allowed = ", ".join(sorted({"dataset_config", *allowed_keys}))
-        msg = f"Unknown dataset reader option(s) [{unknown}]. Allowed top-level keys: {allowed}."
-        raise ValueError(msg)
-
-    normalized["dataset_config"] = base_dataset_config
-    return normalized
 
 
 class BaseAnemoiReader:
@@ -95,17 +39,19 @@ class BaseAnemoiReader:
 
     def __init__(
         self,
-        dataset: str | dict | None = None,
         dataset_config: str | dict | None = None,
         start: datetime.datetime | int | None = None,
         end: datetime.datetime | int | None = None,
     ):
         """Initialize Anemoi data reader."""
-        source = dataset_config if dataset_config is not None else dataset
-        if source is None:
-            msg = "Either dataset or dataset_config must be provided."
+        if dataset_config is None:
+            msg = "Error: dataset_config must be provided."
             raise ValueError(msg)
-        self.data = open_dataset(_normalize_dataset_config(source), start=start, end=end)
+
+        dataset_config = _normalize_dataset_config(dataset_config)
+
+        self.data = open_dataset(dataset_config, start=start, end=end)
+
         #: Sampling config used by :meth:`compute_anchors`.
         #: ``{"stride": 1}`` keeps every valid position;
         #: ``{"stride": None}`` uses stride = window size (non-overlapping).
@@ -355,21 +301,19 @@ class TrajectoryDataset(BaseAnemoiReader):
 
     def __init__(
         self,
-        dataset: str | dict | None = None,
         dataset_config: str | dict | None = None,
         start: datetime.datetime | int | None = None,
         end: datetime.datetime | int | None = None,
         sampling: dict | None = None,
     ) -> None:
-        source = dataset_config if dataset_config is not None else dataset
-        if source is None:
-            msg = "Either dataset or dataset_config must be provided."
+        if dataset_config is None:
+            msg = "Error: dataset_config must be provided."
             raise ValueError(msg)
 
+        dataset_config = _normalize_dataset_config(dataset_config)
         # Trajectory datasets derive their step frequency from the dataset itself.
         # Passing data.frequency would be misleading and is not supported.
-        source_dict = _as_dict(source) if not isinstance(source, str) else {}
-        if isinstance(source_dict, dict) and source_dict.get("frequency") is not None:
+        if isinstance(dataset_config, dict) and dataset_config.get("frequency") is not None:
             msg = (
                 "TrajectoryDataset does not accept a 'frequency' in dataset_config. "
                 "The step frequency is read directly from the dataset. "
@@ -384,7 +328,7 @@ class TrajectoryDataset(BaseAnemoiReader):
             open_kwargs["base_start"] = start
         if end is not None:
             open_kwargs["base_end"] = end
-        self.data = open_dataset(_normalize_dataset_config(source), **open_kwargs)
+        self.data = open_dataset(dataset_config, **open_kwargs)
         self.default_sampling = sampling if sampling is not None else {"stride": None}
 
     @property

--- a/training/src/anemoi/training/data/data_reader.py
+++ b/training/src/anemoi/training/data/data_reader.py
@@ -270,14 +270,13 @@ class NativeGridDataset(BaseAnemoiReader):
 
     def __init__(
         self,
-        dataset: str | dict | None = None,
         dataset_config: str | dict | None = None,
         start: datetime.datetime | int | None = None,
         end: datetime.datetime | int | None = None,
         sampling: dict | None = None,
     ) -> None:
         """Initialize NativeGridDataset."""
-        super().__init__(dataset=dataset, dataset_config=dataset_config, start=start, end=end)
+        super().__init__(dataset_config=dataset_config, start=start, end=end)
         if sampling is not None:
             self.default_sampling = sampling
 

--- a/training/src/anemoi/training/losses/multiscale.py
+++ b/training/src/anemoi/training/losses/multiscale.py
@@ -17,7 +17,7 @@ import torch
 from torch.distributed.distributed_c10d import ProcessGroup
 from torch_geometric.data import HeteroData
 
-from anemoi.graphs.builders import _expand_smoother_config
+from anemoi.training.utils.configs import _expand_smoother_config
 from anemoi.graphs.builders import build_smoother_subgraph
 from anemoi.graphs.projection_helpers import DEFAULT_DATASET_NAME
 from anemoi.graphs.projection_helpers import DEFAULT_EDGE_WEIGHT_ATTRIBUTE

--- a/training/src/anemoi/training/losses/multiscale.py
+++ b/training/src/anemoi/training/losses/multiscale.py
@@ -17,7 +17,6 @@ import torch
 from torch.distributed.distributed_c10d import ProcessGroup
 from torch_geometric.data import HeteroData
 
-from anemoi.training.utils.configs import _expand_smoother_config
 from anemoi.graphs.builders import build_smoother_subgraph
 from anemoi.graphs.projection_helpers import DEFAULT_DATASET_NAME
 from anemoi.graphs.projection_helpers import DEFAULT_EDGE_WEIGHT_ATTRIBUTE
@@ -28,6 +27,7 @@ from anemoi.models.layers.graph_provider import ProjectionGraphProvider
 from anemoi.models.layers.sparse_projector import SparseProjector
 from anemoi.training.losses.base import BaseLoss
 from anemoi.training.losses.base import BaseLossWrapper
+from anemoi.training.utils.configs import _expand_smoother_config
 
 LOGGER = logging.getLogger(__name__)
 

--- a/training/src/anemoi/training/train/methods/base.py
+++ b/training/src/anemoi/training/train/methods/base.py
@@ -26,7 +26,6 @@ from timm.scheduler.scheduler import Scheduler as TimmScheduler
 from torch_geometric.data import HeteroData
 
 from anemoi.graphs.projection_helpers import DEFAULT_DATASET_NAME
-from anemoi.graphs.projection_helpers import uses_fused_dataset_graph
 from anemoi.models.data_indices.collection import IndexCollection
 from anemoi.models.distributed.balanced_partition import get_balanced_partition_sizes
 from anemoi.models.distributed.balanced_partition import get_partition_range
@@ -239,9 +238,6 @@ class BaseTrainingModule(pl.LightningModule, ABC):
 
             self.target_dataset_names.append(dataset_name)
 
-            fused = uses_fused_dataset_graph(graph_data, self.dataset_names)
-            data_node_name = dataset_name if fused else DEFAULT_DATASET_NAME
-
             # Create dataset-specific metadata extractor
             metadata_extractor = ExtractVariableGroupAndLevel(
                 variable_groups=dataset_variable_groups[dataset_name],
@@ -275,7 +271,7 @@ class BaseTrainingModule(pl.LightningModule, ABC):
                 dataset_scalers,
                 data_indices[dataset_name],
                 graph_data=graph_data,
-                data_node_name=data_node_name,
+                data_node_name=dataset_name,
             )
 
             # Check unit compatibility between predicted and target variables
@@ -287,7 +283,7 @@ class BaseTrainingModule(pl.LightningModule, ABC):
                 scalers=dataset_scalers,
                 data_indices=data_indices[dataset_name],
                 graph_data=graph_data,
-                data_node_name=data_node_name,
+                data_node_name=dataset_name,
             )
             self._scaling_values_log[dataset_name] = print_variable_scaling(
                 self.loss[dataset_name],

--- a/training/src/anemoi/training/train/train.py
+++ b/training/src/anemoi/training/train/train.py
@@ -40,20 +40,18 @@ from anemoi.training.diagnostics.logger import get_wandb_logger
 from anemoi.training.schemas.base_schema import BaseSchema
 from anemoi.training.schemas.base_schema import UnvalidatedBaseSchema
 from anemoi.training.schemas.base_schema import convert_to_omegaconf
-from anemoi.training.schemas.dataloader import DatasetConfigSchema
 from anemoi.training.tasks.base import BaseTask
 from anemoi.training.utils.checkpoint import freeze_submodule_by_name
 from anemoi.training.utils.checkpoint import transfer_learning_loading
+from anemoi.training.utils.configs import get_missing_graph_config
 from anemoi.training.utils.hydra import instantiate_with_runtime_kwargs
 from anemoi.training.utils.jsonify import map_config_to_primitives
 from anemoi.training.utils.seeding import get_base_seed
 from anemoi.utils.provenance import gather_provenance_info
-from anemoi.training.utils.configs import get_missing_graph_config
 
 LOGGER = logging.getLogger(__name__)
 
 PL_VERSION = version.parse(pl.__version__)
-
 
 
 class AnemoiTrainer(ABC):
@@ -186,21 +184,20 @@ class AnemoiTrainer(ABC):
             raise FileNotFoundError(msg)
 
         graph_config = OmegaConf.create(OmegaConf.to_container(graph_cfg, resolve=False))
-        if overwrite: 
+        if overwrite:
             # Don't load anything. Create the full graph from scratch.
             return GraphCreator(graph_config).create(save_path=save_path, overwrite=True)
 
-        else: 
-            # not overwrite. Load the graph and create any missing nodes/edges from the config
-            graph = load_graph_from_file(save_path)
+        # not overwrite. Load the graph and create any missing nodes/edges from the config
+        graph = load_graph_from_file(save_path)
 
-            missing_graph_config = get_missing_graph_config(graph_config, graph.node_types, graph.edge_types)
+        missing_graph_config = get_missing_graph_config(graph_config, graph.node_types, graph.edge_types)
 
-            graph_creator = GraphCreator(missing_graph_config)
-            graph = graph_creator.update_graph(graph)
-            graph = graph_creator.clean(graph)
-            graph = graph_creator.post_process(graph)
-            return graph
+        graph_creator = GraphCreator(missing_graph_config)
+        graph = graph_creator.update_graph(graph)
+        graph = graph_creator.clean(graph)
+        graph = graph_creator.post_process(graph)
+        return graph
 
     def _validate_transfer_learning_datasets(
         self,

--- a/training/src/anemoi/training/train/train.py
+++ b/training/src/anemoi/training/train/train.py
@@ -196,8 +196,7 @@ class AnemoiTrainer(ABC):
         graph_creator = GraphCreator(missing_graph_config)
         graph = graph_creator.update_graph(graph)
         graph = graph_creator.clean(graph)
-        graph = graph_creator.post_process(graph)
-        return graph
+        return graph_creator.post_process(graph)
 
     def _validate_transfer_learning_datasets(
         self,

--- a/training/src/anemoi/training/train/train.py
+++ b/training/src/anemoi/training/train/train.py
@@ -31,11 +31,7 @@ from torch_geometric.data import HeteroData
 
 from anemoi.graphs.create import GraphCreator
 from anemoi.graphs.create import load_graph_from_file
-from anemoi.graphs.create import validate_loaded_graph
-from anemoi.graphs.projection_helpers import DEFAULT_DATASET_NAME
-from anemoi.graphs.projection_helpers import uses_fused_dataset_graph
 from anemoi.models.utils.compile import mark_for_compilation
-from anemoi.models.utils.config import get_multiple_datasets_config
 from anemoi.training.data.datamodule import AnemoiDatasetsDataModule
 from anemoi.training.diagnostics.callbacks import CallbacksContext
 from anemoi.training.diagnostics.callbacks import get_callbacks
@@ -51,10 +47,12 @@ from anemoi.training.utils.hydra import instantiate_with_runtime_kwargs
 from anemoi.training.utils.jsonify import map_config_to_primitives
 from anemoi.training.utils.seeding import get_base_seed
 from anemoi.utils.provenance import gather_provenance_info
+from anemoi.training.utils.configs import get_missing_graph_config
 
 LOGGER = logging.getLogger(__name__)
 
 PL_VERSION = version.parse(pl.__version__)
+
 
 
 class AnemoiTrainer(ABC):
@@ -175,72 +173,33 @@ class AnemoiTrainer(ABC):
         return None
 
     @cached_property
-    def _dataset_names(self) -> list[str]:
-        """Dataset names derived from the dataloader training config."""
-        return list(get_multiple_datasets_config(self.config.dataloader.training).keys())
-
-    @cached_property
     def graph_data(self) -> HeteroData:
         """Graph data built or loaded for the current trainer config."""
-        dataset_names = self._dataset_names
         graph_cfg = self.config.graph
         graph_path = self.config.system.input.graph
         save_path = Path(graph_path) if graph_path else None
-
-        # Existing-graph mode: path given but no nodes/edges defined — load as-is.
-        is_existing = (
-            graph_path is not None
-            and not graph_cfg.overwrite
-            and not getattr(graph_cfg, "nodes", None)
-            and not getattr(graph_cfg, "edges", None)
-        )
-        if is_existing:
-            if not save_path.exists():
-                msg = f"Existing graph file not found: {save_path}"
-                raise FileNotFoundError(msg)
-            graph = load_graph_from_file(save_path)
-            fused = uses_fused_dataset_graph(graph, dataset_names)
-            required = dataset_names if fused else [DEFAULT_DATASET_NAME]
-            validate_loaded_graph(graph, required)
-            return graph
-
-        # Build mode: expand config and create graph via GraphCreator.
-        graph_config = OmegaConf.create(OmegaConf.to_container(graph_cfg, resolve=False))
-
-        if not uses_fused_dataset_graph(graph_cfg, dataset_names):
-            if len(dataset_names) == 1:
-                dataset_configs = get_multiple_datasets_config(self.config.dataloader.training)
-                dataset_name = dataset_names[0]
-                reader_cfg = dataset_configs[dataset_name].dataset_config
-                dataset_path = reader_cfg["dataset"] if isinstance(reader_cfg, (DictConfig, dict)) else reader_cfg
-                if dataset_path is None:
-                    msg = f"Dataset source is None for dataset '{dataset_name}'."
-                    raise ValueError(msg)
-                data_node_cfg = graph_config.get("nodes", {}).get(DEFAULT_DATASET_NAME)
-                if (
-                    data_node_cfg is not None
-                    and hasattr(data_node_cfg, "node_builder")
-                    and hasattr(data_node_cfg.node_builder, "dataset")
-                ):
-                    data_node_cfg.node_builder.dataset = dataset_path
-            else:
-                msg = (
-                    "Multiple datasets require a fused graph config with one node group per dataset. "
-                    f"Received datasets {dataset_names} but graph nodes "
-                    f"{list(graph_cfg.nodes.keys())}."
-                )
-                raise ValueError(msg)
-
-        # Try loading existing saved graph before rebuilding.
         overwrite = graph_cfg.get("overwrite", False)
-        if save_path and save_path.exists() and not overwrite:
-            fused = uses_fused_dataset_graph(graph_cfg, dataset_names)
-            required = dataset_names if fused else [DEFAULT_DATASET_NAME]
-            graph = load_graph_from_file(save_path)
-            validate_loaded_graph(graph, required)
-            return graph
 
-        return GraphCreator(graph_config).create(save_path=save_path, overwrite=overwrite)
+        if overwrite and (graph_path is None or not save_path.exists()):
+            msg = "Graph overwrite requested but no graph file exists to overwrite."
+            raise FileNotFoundError(msg)
+
+        graph_config = OmegaConf.create(OmegaConf.to_container(graph_cfg, resolve=False))
+        if overwrite: 
+            # Don't load anything. Create the full graph from scratch.
+            return GraphCreator(graph_config).create(save_path=save_path, overwrite=True)
+
+        else: 
+            # not overwrite. Load the graph and create any missing nodes/edges from the config
+            graph = load_graph_from_file(save_path)
+
+            missing_graph_config = get_missing_graph_config(graph_config, graph.node_types, graph.edge_types)
+
+            graph_creator = GraphCreator(missing_graph_config)
+            graph = graph_creator.update_graph(graph)
+            graph = graph_creator.clean(graph)
+            graph = graph_creator.post_process(graph)
+            return graph
 
     def _validate_transfer_learning_datasets(
         self,

--- a/training/src/anemoi/training/utils/configs.py
+++ b/training/src/anemoi/training/utils/configs.py
@@ -8,10 +8,10 @@
 # nor does it submit to any jurisdiction.
 
 import logging
+
 from omegaconf import DictConfig
 
 LOGGER = logging.getLogger(__name__)
-
 
 
 def _as_dict(value: str | dict | DictConfig) -> str | dict:

--- a/training/src/anemoi/training/utils/configs.py
+++ b/training/src/anemoi/training/utils/configs.py
@@ -89,3 +89,35 @@ def get_missing_graph_config(graph_config, current_nodes: list[str], current_edg
             missing_graph_config["edges"].append(edges)
 
     return missing_graph_config
+
+
+def _expand_smoother_config(cfg: dict | Any) -> dict[str, dict]:
+    """Return an explicit ``{name: spec}`` smoothers dict from cfg.
+
+    Accepts either an already-explicit ``smoothers`` mapping or a compact
+    geometric-progression spec (``num_scales``, ``base_num_nearest_neighbours``,
+    ``base_sigma``, …).
+    """
+    if OmegaConf.is_config(cfg):
+        cfg = OmegaConf.to_container(cfg, resolve=True)
+
+    smoothers = cfg.get("smoothers")
+    if smoothers:
+        return dict(smoothers)
+
+    num_scales = cfg.get("num_scales")
+    if num_scales is None:
+        return {}
+
+    base_neighbours = cfg["base_num_nearest_neighbours"]
+    base_sigma = cfg["base_sigma"]
+    scale_factor = cfg.get("scale_factor", 2)
+
+    smoothers = {}
+    for i in range(num_scales):
+        factor = scale_factor**i
+        smoothers[f"smooth_{factor}x"] = {
+            "num_nearest_neighbours": base_neighbours * factor,
+            "sigma": round(base_sigma * factor, 5),
+        }
+    return smoothers

--- a/training/src/anemoi/training/utils/configs.py
+++ b/training/src/anemoi/training/utils/configs.py
@@ -1,0 +1,91 @@
+# (C) Copyright 2024-2026 Anemoi contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+import logging
+from omegaconf import DictConfig
+
+LOGGER = logging.getLogger(__name__)
+
+
+
+def _as_dict(value: str | dict | DictConfig) -> str | dict:
+    """Convert DictConfig payloads to plain dicts."""
+    return dict(value) if isinstance(value, DictConfig) else value
+
+
+def _normalize_dataset_config(dataset_config: str | dict | DictConfig) -> dict:
+    """Normalize dataset payload to the open_dataset dictionary contract."""
+    if isinstance(dataset_config, str):
+        return {"dataset": dataset_config}
+
+    dataset_config = _as_dict(dataset_config)
+    if "dataset" not in dataset_config:
+        msg = "dataset_config must contain the 'dataset' key."
+        raise ValueError(msg)
+
+    if dataset_config["dataset"] is None:
+        msg = "dataset_config.dataset cannot be None."
+        raise ValueError(msg)
+
+    invalid_inner_keys = {"start", "end"} & set(dataset_config)
+    if invalid_inner_keys:
+        invalid = ", ".join(sorted(invalid_inner_keys))
+        msg = f"dataset_config cannot contain [{invalid}]. Use outer keys 'start' and 'end' instead."
+        raise ValueError(msg)
+
+    # Keep only explicitly set options to avoid passing None-valued kwargs
+    # (e.g. select=None), which can trigger downstream subset selection issues.
+    return {key: value for key, value in dataset_config.items() if value is not None}
+
+
+def _normalize_reader_config(dataset_config: dict | DictConfig) -> dict:
+    """Validate and normalize reader configuration."""
+    normalized = dict(dataset_config)
+
+    if "dataset" in normalized:
+        msg = (
+            "Invalid dataloader dataset schema: use 'dataset_config' (outer key) "
+            "and 'dataset' inside it. The legacy outer 'dataset' key is no longer supported."
+        )
+        raise ValueError(msg)
+
+    base_dataset_config = normalized.pop("dataset_config", None)
+    if base_dataset_config is None:
+        msg = "Missing required 'dataset_config' in dataset reader configuration."
+        raise ValueError(msg)
+
+    allowed_keys = {"start", "end", "trajectory"}
+    unknown_keys = set(normalized) - allowed_keys
+    if unknown_keys:
+        unknown = ", ".join(sorted(unknown_keys))
+        allowed = ", ".join(sorted({"dataset_config", *allowed_keys}))
+        msg = f"Unknown dataset reader option(s) [{unknown}]. Allowed top-level keys: {allowed}."
+        raise ValueError(msg)
+
+    normalized["dataset_config"] = base_dataset_config
+    return normalized
+
+
+def get_missing_graph_config(graph_config, current_nodes: list[str], current_edges: list[tuple[str, str, str]]) -> dict:
+    missing_graph_config = {"nodes": {}, "edges": []}
+    for node in graph_config.nodes:
+        if node not in current_nodes:
+            # Add missing node to the graph config
+            LOGGER.info("Node '%s' not found in the loaded graph.", node)
+            missing_graph_config["nodes"][node] = graph_config.nodes[node]
+
+    for edges in graph_config.edges:
+        source_nodes = edges.source_nodes
+        target_nodes = edges.target_nodes
+        if (source_nodes, "to", target_nodes) not in current_edges:
+            LOGGER.info("Edge from '%s' to '%s' not found in the loaded graph.", source_nodes, target_nodes)
+            # Add missing edge to the graph config
+            missing_graph_config["edges"].append(edges)
+
+    return missing_graph_config

--- a/training/src/anemoi/training/utils/configs.py
+++ b/training/src/anemoi/training/utils/configs.py
@@ -8,8 +8,10 @@
 # nor does it submit to any jurisdiction.
 
 import logging
+from typing import Any
 
 from omegaconf import DictConfig
+from omegaconf import OmegaConf
 
 LOGGER = logging.getLogger(__name__)
 
@@ -72,7 +74,11 @@ def _normalize_reader_config(dataset_config: dict | DictConfig) -> dict:
     return normalized
 
 
-def get_missing_graph_config(graph_config, current_nodes: list[str], current_edges: list[tuple[str, str, str]]) -> dict:
+def get_missing_graph_config(
+    graph_config: DictConfig,
+    current_nodes: list[str],
+    current_edges: list[tuple[str, str, str]],
+) -> dict:
     missing_graph_config = {"nodes": {}, "edges": []}
     for node in graph_config.nodes:
         if node not in current_nodes:


### PR DESCRIPTION
## Description
<!-- What issue or task does this change relate to? -->

This PR :
- refactors the way the graph configuration is passed to the `GraphCreator` in anemoi-training.
- moves some config utilities used in several places to a common file `utils/configs.py`.
- removes the `dataset` option from the data readers. Currently, `dataset` and `dataset_config` were supported for a smoother transition.

W.I.P.:
- [ ] Raise an error when datasets specified are not part of the graph recipe.
- [ ] Moving config utilities to anemoi-training


***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)
