### PR TITLE
feat(training): ignore warmup iterations when calculating throughput

### DIFF
--- a/training/src/anemoi/training/diagnostics/profilers.py
+++ b/training/src/anemoi/training/diagnostics/profilers.py
@@ -535,8 +535,8 @@ class BenchmarkProfiler(Profiler):
         batch_size_val = self.config.dataloader.batch_size.validation
 
         training_rates_array = np.array(progressbar.training_rates)
-        speed_metrics["training_avg_throughput"] = training_rates_array.mean()
-        speed_metrics["training_avg_throughput_per_sample"] = training_rates_array.mean() / batch_size_tr
+        speed_metrics["training_avg_throughput"] = training_rates_array[-1]
+        speed_metrics["training_avg_throughput_per_sample"] = training_rates_array[-1] / batch_size_tr
 
         validation_rates_array = np.array(progressbar.validation_rates)
         speed_metrics["validation_avg_throughput"] = validation_rates_array.mean()
@@ -670,7 +670,11 @@ class ProfilerProgressBar(TQDMProgressBar):
         self._refresh_rate = refresh_rate
 
     def _extract_rate(self, pbar: _tqdm) -> float:
-        """Extracts the iteration rate from the progress bar.
+        """Extracts the instantaneous iteration rate of the most recent batch.
+
+        The previous (n, elapsed) is stored on the progress bar so the rate is
+        computed over the last interval only, rather than as a running average
+        over the whole epoch (which is skewed by the slow init iterations).
 
         Parameters
         ----------
@@ -682,7 +686,19 @@ class ProfilerProgressBar(TQDMProgressBar):
         float
             The iteration rate.
         """
-        return (pbar.format_dict["n"] - pbar.format_dict["initial"]) / pbar.format_dict["elapsed"]
+        n = pbar.format_dict["n"]
+        elapsed = pbar.format_dict["elapsed"]
+        prev_n = getattr(pbar, "_prev_n", 0)
+        prev_elapsed = getattr(pbar, "_prev_elapsed", 0.0)
+        pbar._prev_n = n
+        pbar._prev_elapsed = elapsed
+
+        delta_n = n - prev_n
+        delta_elapsed = elapsed - prev_elapsed
+        if delta_elapsed > 0:
+            return delta_n / delta_elapsed
+        # fall back to the cumulative rate if we have no valid interval
+        return (n - pbar.format_dict["initial"]) / elapsed
 
     def on_train_batch_end(
         self,

--- a/training/src/anemoi/training/diagnostics/profilers.py
+++ b/training/src/anemoi/training/diagnostics/profilers.py
@@ -534,9 +534,12 @@ class BenchmarkProfiler(Profiler):
         batch_size_tr = self.config.dataloader.batch_size.training
         batch_size_val = self.config.dataloader.batch_size.validation
 
+        # average over the last n iterations to smooth out per-iteration fluctuations
+        num_iterations = 10
         training_rates_array = np.array(progressbar.training_rates)
-        speed_metrics["training_avg_throughput"] = training_rates_array[-1]
-        speed_metrics["training_avg_throughput_per_sample"] = training_rates_array[-1] / batch_size_tr
+        training_throughput = training_rates_array[-num_iterations:].mean()
+        speed_metrics["training_avg_throughput"] = training_throughput
+        speed_metrics["training_avg_throughput_per_sample"] = training_throughput / batch_size_tr
 
         validation_rates_array = np.array(progressbar.validation_rates)
         speed_metrics["validation_avg_throughput"] = validation_rates_array.mean()

--- a/training/src/anemoi/training/diagnostics/profilers.py
+++ b/training/src/anemoi/training/diagnostics/profilers.py
@@ -534,10 +534,14 @@ class BenchmarkProfiler(Profiler):
         batch_size_tr = self.config.dataloader.batch_size.training
         batch_size_val = self.config.dataloader.batch_size.validation
 
-        # average over the last n iterations to smooth out per-iteration fluctuations
-        num_iterations = 10
+        # skip the first 100 iterations to avoid warmup effects on the throughput calculation
+        # if training on less then 100 iterations, skip 50% of the iterations to avoid warmup effects
+        # on the throughput calculation
+        warmup_iterations = 100
+        if self.config.dataloader.limit_batches.get("training", 0) < warmup_iterations:
+            warmup_iterations = int(self.config.dataloader.limit_batches.get("training", 0) * 0.5)
         training_rates_array = np.array(progressbar.training_rates)
-        training_throughput = training_rates_array[-num_iterations:].mean()
+        training_throughput = training_rates_array[warmup_iterations:].mean()
         speed_metrics["training_avg_throughput"] = training_throughput
         speed_metrics["training_avg_throughput_per_sample"] = training_throughput / batch_size_tr
 


### PR DESCRIPTION
## Description
currently throughput is a rolling avg of all batch times. however the initial batches (first 100) are typically slow (torch compile, cuda memory allocations) and variable. when running a ~200 iterations these initial batches drag down the reported throughput, this can cause throughput results to vary across runs.

this pr ignores the first 100 iterations when calculation throughput. if you're running less then 100 iterations it ignores the first half.
