### PR TITLE
fix(training): fix sharding for spectral loss scalers and some suggestions

### DIFF
--- a/training/docs/modules/losses.rst
+++ b/training/docs/modules/losses.rst
@@ -223,8 +223,9 @@ Some loss functions operate in spectral space rather than directly in grid-point
 This is useful when the error characteristics are better expressed by scale (wavenumber)
 than by location, or when the loss should emphasise/regularise specific ranges of scales.
 
-In Anemoi, spectral losses follow the same API as other losses (scalers/node weights, reduction,
-etc.), but they additionally require a *spectral transform* configuration.
+In Anemoi, spectral losses follow the same API as other losses (scalers and reduction),
+but they additionally require a *spectral transform* configuration. Spatial node weights
+cannot be used after the transform; use a spectral-dimension scaler instead.
 
 Spectral transforms
 ===================
@@ -638,12 +639,18 @@ assigned to the default group.
 Spectral Loss Scalers
 =====================
 
-Spectral scalers weight the spectral dimension of spectral losses. They
-are required whenever using a
-spectral loss, because in spectral space that dimension holds spectral
-modes rather than grid points. Anemoi-training checks that every
-grid-dimension scaler attached to a spectral loss is sized to the
-spectral dimension.
+Spectral scalers optionally weight or normalise the spectral dimension of
+spectral losses. Without one, reduction sums over spectral modes. In spectral
+space the grid dimension holds spectral modes rather than grid points, so
+spatial scalers such as ``node_weights`` are not valid even when their length
+happens to equal the number of spectral modes.
+
+Anemoi-training records whether each grid scaler applies to spatial points or
+spectral modes and rejects a scaler from the wrong domain when it is attached
+to a loss. It also checks the scaler length against the global spectral
+dimension at runtime. During distributed execution, the global spectral scaler
+is sliced to the modes owned by each rank after the spectral all-to-all
+transpose.
 
 ``n_spectral_modes`` is the number of spectral modes (for spherical
 harmonic transforms this is the number of total wavenumbers
@@ -655,7 +662,8 @@ harmonic transforms this is the number of total wavenumbers
    loss before configuring these scalers. A mismatch between
    the shape of the scaler and the loss tensor will be caught at
    runtime by the spectral-loss compatibility check, but only after
-   model instantiation.
+   model instantiation. The configured size is always the global spectral
+   size, including when the loss tensor is sharded across ranks.
 
 The following spectral scaler is available:
 
@@ -693,15 +701,20 @@ Custom Scalers
 To create a custom scaler, subclass the ``BaseScaler`` and implement the
 ``get_scaling_values`` method. This method should return an array of the
 scaling values. Set ``scale_dims`` to the dimensions that the scaling
-values should be applied to.
+values should be applied to. A scaler that includes ``TensorDim.GRID`` must
+also set ``grid_domain`` to ``ScalerDomain.SPATIAL`` or
+``ScalerDomain.SPECTRAL``.
 
 .. code:: python
 
-   from anemoi.training.losses.scalers import BaseScaler
+   from anemoi.training.losses.scalers import ScalerDomain
+   from anemoi.training.losses.scalers.base_scaler import BaseScaler
    from anemoi.training.utils.enums import TensorDim
 
    class CustomScaler(BaseScaler):
       scale_dims = [TensorDim.GRID]
+      grid_domain = ScalerDomain.SPATIAL
+
       def get_scaling_values(self):
          # Custom scaling logic here
          return scaling_values

--- a/training/src/anemoi/training/losses/aggregate.py
+++ b/training/src/anemoi/training/losses/aggregate.py
@@ -76,6 +76,8 @@ class TimeAggregateLossWrapper(BaseLossWrapper):
             Distributed group for reduction, by default ``None``.
         squash_mode : str | None, optional
             Variable-dimension reduction mode. If omitted, the wrapped loss default is used.
+        **kwargs
+            Additional keyword arguments forwarded to the wrapped loss.
 
         Returns
         -------
@@ -95,11 +97,9 @@ class TimeAggregateLossWrapper(BaseLossWrapper):
 
         # Extract time weights from the shared scaler (if present)
         time_weights = None
-        for dims, scaler in self.loss.scaler.tensors.values():
-            if isinstance(dims, int):
-                dims = (dims,)
-            if TensorDim.TIME.value in dims or TensorDim.TIME in dims:
-                time_weights = scaler
+        for scaler_spec in self.loss.scaler.tensors.values():
+            if TensorDim.TIME.value in scaler_spec.dimensions or TensorDim.TIME in scaler_spec.dimensions:
+                time_weights = scaler_spec.tensor
                 break
 
         shared_kwargs = dict(

--- a/training/src/anemoi/training/losses/base.py
+++ b/training/src/anemoi/training/losses/base.py
@@ -23,6 +23,7 @@ from torch import nn
 from torch.distributed.distributed_c10d import ProcessGroup
 
 from anemoi.models.distributed.graph import reduce_tensor
+from anemoi.training.losses.scaler_tensor import ScalerDomain
 from anemoi.training.losses.scaler_tensor import ScaleTensor
 from anemoi.training.utils.enums import TensorDim
 
@@ -47,6 +48,7 @@ class BaseLoss(nn.Module, ABC):
     factory_context_keys: ClassVar[frozenset[LossFactoryContextKey | str]] = frozenset()
     scaler: ScaleTensor
     needs_graph_data: bool = False
+    grid_scaler_domain: ClassVar[ScalerDomain] = ScalerDomain.SPATIAL
 
     def __init__(
         self,
@@ -79,8 +81,54 @@ class BaseLoss(nn.Module, ABC):
         self.num_scales = 1
 
     @functools.wraps(ScaleTensor.add_scaler)
-    def add_scaler(self, dimension: int | tuple[int], scaler: torch.Tensor, *, name: str | None = None) -> None:
-        self.scaler.add_scaler(dimension=dimension, scaler=scaler, name=name)
+    def add_scaler(
+        self,
+        dimension: int | tuple[int],
+        scaler: torch.Tensor,
+        *,
+        grid_domain: ScalerDomain | None = None,
+        name: str | None = None,
+    ) -> None:
+        """Add a scaler after checking that it matches the loss's grid layout.
+
+        A scaler on the grid dimension must say whether it applies to spatial
+        points or spectral modes. This prevents scalers defined for spatial
+        points from being attached to spectral losses, and vice versa.
+
+        Parameters
+        ----------
+        dimension : int | tuple[int]
+            Tensor dimension or dimensions to which the scaler applies.
+        scaler : torch.Tensor
+            Values by which the loss tensor will be multiplied.
+        grid_domain : ScalerDomain | None, optional
+            What the entries along the grid dimension represent. This is
+            required for grid scalers and omitted for all other scalers.
+        name : str | None, optional
+            Name used to identify the scaler when updating or excluding it.
+        """
+        dimensions = (dimension,) if isinstance(dimension, int) else tuple(dimension)
+        if TensorDim.GRID in dimensions:
+            if grid_domain is None:
+                msg = f"Scaler {name!r} applies to TensorDim.GRID but does not declare a grid domain."
+                raise ValueError(msg)
+            grid_domain = ScalerDomain(grid_domain)
+            if grid_domain != self.grid_scaler_domain:
+                msg = (
+                    f"Scaler {name!r} uses the {grid_domain.value} grid domain, but "
+                    f"{self.__class__.__name__} requires {self.grid_scaler_domain.value} grid scalers."
+                )
+                raise ValueError(msg)
+        elif grid_domain is not None:
+            msg = f"Scaler {name!r} declares a grid domain but does not apply to TensorDim.GRID."
+            raise ValueError(msg)
+
+        self.scaler.add_scaler(
+            dimension=dimensions,
+            scaler=scaler,
+            grid_domain=grid_domain,
+            name=name,
+        )
 
     @functools.wraps(ScaleTensor.update_scaler)
     def update_scaler(self, name: str, scaler: torch.Tensor, *, override: bool = False) -> None:
@@ -89,6 +137,26 @@ class BaseLoss(nn.Module, ABC):
     @functools.wraps(ScaleTensor.has_scaler_for_dim)
     def has_scaler_for_dim(self, dim: TensorDim) -> bool:
         return self.scaler.has_scaler_for_dim(dim=dim)
+
+    def get_active_scalers(self, without_scalers: list[str] | list[int] | None = None) -> ScaleTensor:
+        """Choose which registered scalers to use for one loss calculation.
+
+        Parameters
+        ----------
+        without_scalers : list[str] | list[int] | None, optional
+            Scaler names or tensor dimensions to leave out for this call. If
+            omitted or empty, all registered scalers are returned.
+
+        Returns
+        -------
+        ScaleTensor
+            The registered scalers with the requested names or dimensions removed.
+        """
+        if without_scalers is None or len(without_scalers) == 0:
+            return self.scaler
+        if isinstance(without_scalers[0], str):
+            return self.scaler.without(without_scalers)
+        return self.scaler.without_by_dim(without_scalers)
 
     def scale(
         self,
@@ -134,12 +202,7 @@ class BaseLoss(nn.Module, ABC):
             )
             raise RuntimeError(error_msg)
 
-        scale_tensor = self.scaler
-        if without_scalers is not None and len(without_scalers) > 0:
-            if isinstance(without_scalers[0], str):
-                scale_tensor = self.scaler.without(without_scalers)
-            else:
-                scale_tensor = self.scaler.without_by_dim(without_scalers)
+        scale_tensor = self.get_active_scalers(without_scalers)
 
         return scale_tensor.scale_iteratively(
             x,
@@ -297,7 +360,7 @@ class BaseLoss(nn.Module, ABC):
             Distributed group to reduce over, by default None
         squash_mode : {"avg", "sum"}, optional
             Reduction mode for the variable dimension, by default ``"avg"``
-        **kwargs
+        **_kwargs
             Additional keyword arguments
 
         Returns
@@ -335,8 +398,15 @@ class BaseLossWrapper(BaseLoss):
     # -- scaler delegation --------------------------------------------------
 
     @functools.wraps(ScaleTensor.add_scaler)
-    def add_scaler(self, dimension: int | tuple[int], scaler: torch.Tensor, *, name: str | None = None) -> None:
-        self.loss.add_scaler(dimension=dimension, scaler=scaler, name=name)
+    def add_scaler(
+        self,
+        dimension: int | tuple[int],
+        scaler: torch.Tensor,
+        *,
+        grid_domain: ScalerDomain | None = None,
+        name: str | None = None,
+    ) -> None:
+        self.loss.add_scaler(dimension=dimension, scaler=scaler, grid_domain=grid_domain, name=name)
 
     @functools.wraps(ScaleTensor.update_scaler)
     def update_scaler(self, name: str, scaler: torch.Tensor, *, override: bool = False) -> None:
@@ -411,7 +481,7 @@ class FunctionalLoss(BaseLoss):
             Distributed group, by default None
         squash_mode : {"avg", "sum"}, optional
             Reduction mode for the variable dimension, by default ``"avg"``
-        **kwargs
+        **_kwargs
             Additional keyword arguments
 
         Returns

--- a/training/src/anemoi/training/losses/combined.py
+++ b/training/src/anemoi/training/losses/combined.py
@@ -20,7 +20,8 @@ from anemoi.models.data_indices.collection import IndexCollection
 from anemoi.training.losses.base import BaseLoss
 from anemoi.training.losses.base import LossFactoryContextKey
 from anemoi.training.losses.loss import get_loss_function
-from anemoi.training.losses.scaler_tensor import TENSOR_SPEC
+from anemoi.training.losses.scaler_tensor import ScalerDomain
+from anemoi.training.losses.scaler_tensor import ScalerSpec
 from anemoi.training.losses.scaler_tensor import ScaleTensor
 from anemoi.training.utils.enums import TensorDim
 
@@ -41,7 +42,7 @@ class CombinedLoss(BaseLoss):
         *extra_losses: dict[str, Any] | Callable | BaseLoss,
         loss_weights: tuple[int, ...] | None = None,
         losses: tuple[dict[str, Any] | Callable | BaseLoss] | None = None,
-        available_scalers: dict[str, TENSOR_SPEC] | None = None,
+        available_scalers: dict[str, ScalerSpec] | None = None,
         data_indices: IndexCollection | None = None,
         **kwargs,
     ):
@@ -72,7 +73,7 @@ class CombinedLoss(BaseLoss):
             Must be the same length as the number of losses.
             If None, all losses are weighted equally.
             by default None.
-        available_scalers : dict[str, TENSOR_SPEC] | None, optional
+        available_scalers : dict[str, ScalerSpec] | None, optional
             All scaler tensors available. Passed through to child losses.
         data_indices : IndexCollection | None, optional
             Training data indices needed by child losses that perform variable mapping.
@@ -192,9 +193,16 @@ class CombinedLoss(BaseLoss):
         return loss
 
     @functools.wraps(ScaleTensor.add_scaler, assigned=("__doc__", "__annotations__"))
-    def add_scaler(self, dimension: int | tuple[int], scaler: torch.Tensor, *, name: str | None = None) -> None:
+    def add_scaler(
+        self,
+        dimension: int | tuple[int],
+        scaler: torch.Tensor,
+        *,
+        grid_domain: ScalerDomain | None = None,
+        name: str | None = None,
+    ) -> None:
         for loss in self.losses:
-            loss.add_scaler(dimension=dimension, scaler=scaler, name=name)
+            loss.add_scaler(dimension=dimension, scaler=scaler, grid_domain=grid_domain, name=name)
 
     @functools.wraps(ScaleTensor.update_scaler, assigned=("__doc__", "__annotations__"))
     def update_scaler(self, name: str, scaler: torch.Tensor, *, override: bool = False) -> None:

--- a/training/src/anemoi/training/losses/loss.py
+++ b/training/src/anemoi/training/losses/loss.py
@@ -21,7 +21,7 @@ from anemoi.models.data_indices.collection import IndexCollection
 from anemoi.models.data_indices.tensor import OutputTensorIndex
 from anemoi.training.losses.base import BaseLoss
 from anemoi.training.losses.base import LossFactoryContextKey
-from anemoi.training.losses.scaler_tensor import TENSOR_SPEC
+from anemoi.training.losses.scaler_tensor import ScalerSpec
 from anemoi.training.losses.variable_mapper import LossVariableMapper
 from anemoi.training.utils.variables_metadata import ExtractVariableGroupAndLevel
 
@@ -48,7 +48,7 @@ def _graph_data_kwargs(target_cls: type, graph_data: object | None, extra_kwargs
 class LossFactoryContext:
     """Factory-supplied context that only selected loss classes use."""
 
-    available_scalers: dict[str, TENSOR_SPEC] | None = None
+    available_scalers: dict[str, ScalerSpec] | None = None
     data_indices: IndexCollection | None = None
 
     def for_loss_class(self, loss_class: type[BaseLoss]) -> tuple[dict, bool, bool]:
@@ -81,8 +81,8 @@ def _has_factory_context_key(
 
 def _filter_scalers(
     scalers_to_include: list[str],
-    scalers: dict[str, TENSOR_SPEC],
-) -> dict[str, TENSOR_SPEC]:
+    scalers: dict[str, ScalerSpec],
+) -> dict[str, ScalerSpec]:
     """Return the subset of named scalers requested by the loss config."""
     filtered_scalers = {}
     for name in scalers_to_include:
@@ -120,7 +120,7 @@ def _propagate_combined_scalers(loss_config: dict, scalers_to_include: list) -> 
 def _build_wrapped_loss(
     loss_config: dict,
     scalers_to_include: list,
-    scalers: dict[str, TENSOR_SPEC] | None,
+    scalers: dict[str, ScalerSpec] | None,
     data_indices: "IndexCollection | None",
 ) -> BaseLoss:
     """Instantiate a WRAPPED_LOSSES target (e.g. TimeAggregateLossWrapper)."""
@@ -141,7 +141,7 @@ def _build_wrapped_loss(
 # Future import breaks other type hints TODO Harrison Cook
 def get_loss_function(
     config: DictConfig,
-    scalers: dict[str, TENSOR_SPEC] | None = None,
+    scalers: dict[str, ScalerSpec] | None = None,
     data_indices: IndexCollection | None = None,
     graph_data: object | None = None,
     data_node_name: str | None = None,
@@ -155,7 +155,7 @@ def get_loss_function(
     ----------
     config : DictConfig
         Loss function configuration, should include `scalers` if scalers are to be added to the loss function.
-    scalers : TENSOR_SPEC, optional,
+    scalers : dict[str, ScalerSpec], optional,
         Scalers which can be added to the loss function. Defaults to None., by default None
         If a scaler is to be added to the loss, ensure it is in `scalers` in the loss config.
         For instance, if `scalers: ['variable']` is set in the config, and `variable` in `scalers`
@@ -271,7 +271,7 @@ def get_loss_function(
 def _apply_scalers(
     loss_function: BaseLoss,
     scalers_to_include: list,
-    scalers: dict[str, TENSOR_SPEC] | None,
+    scalers: dict[str, ScalerSpec] | None,
     data_indices: IndexCollection | None,
 ) -> None:
     """Attach scalers to a loss function and set data indices if needed."""
@@ -284,9 +284,15 @@ def _apply_scalers(
                 if idx in data_indices.model.output.prognostic and data_indices.data.output.name_to_index.get(
                     var_key,
                 ):
-                    scaling = scalers[key][1][idx]
+                    scaling = scalers[key].tensor[idx]
                     LOGGER.info("Parameter %s is being scaled by statistic_tendencies by %.2f", var_key, scaling)
-        loss_function.add_scaler(*scalers[key], name=key)
+        scaler_spec = scalers[key]
+        loss_function.add_scaler(
+            scaler_spec.dimensions,
+            scaler_spec.tensor,
+            grid_domain=scaler_spec.grid_domain,
+            name=key,
+        )
 
 
 def get_metric_ranges(

--- a/training/src/anemoi/training/losses/scaler_tensor.py
+++ b/training/src/anemoi/training/losses/scaler_tensor.py
@@ -12,6 +12,8 @@ import logging
 import uuid
 from collections.abc import Callable
 from collections.abc import Sequence
+from dataclasses import dataclass
+from enum import StrEnum
 from typing import Self
 
 import torch
@@ -59,13 +61,20 @@ def grad_scaler(
     return new_grad_in, grad_in[1]
 
 
-TENSOR_SPEC = tuple[int | tuple[int, ...], torch.Tensor]
-"""Scale Tensor specification type.
+class ScalerDomain(StrEnum):
+    """Indicate whether a grid-dimension scaler applies to spatial points or spectral modes."""
 
-A tuple of (dimension, tensor) where:
-- dimension can be a single int or a tuple of ints specifying the dimensions the tensor should be applied to.
-- tensor is a torch.Tensor that will be applied to the specified dimensions.
-"""
+    SPATIAL = "spatial"
+    SPECTRAL = "spectral"
+
+
+@dataclass(frozen=True)
+class ScalerSpec:
+    """Describe where a scaler applies, its values, and the meaning of its grid entries."""
+
+    dimensions: tuple[int, ...]
+    tensor: torch.Tensor
+    grid_domain: ScalerDomain | None = None
 
 
 class Shape:
@@ -93,7 +102,7 @@ class ScaleTensor(nn.Module):
     Examples
     --------
     >>> tensor = torch.randn(3, 4, 5)
-    >>> scalers = ScaleTensor((0, torch.randn(3)), (1, torch.randn(4)))
+    >>> scalers = ScaleTensor(ScalerSpec((0,), torch.randn(3)), ScalerSpec((1,), torch.randn(4)))
     >>> scaled_tensor = scalers.scale(tensor)
     >>> scalers.get_scaler(tensor.ndim).shape
     torch.Size([3, 4, 1])
@@ -102,47 +111,51 @@ class ScaleTensor(nn.Module):
     torch.Size([3, 4, 5])
     """
 
-    _tensors: dict[str, TENSOR_SPEC]
+    _tensors: dict[str, tuple[tuple[int, ...], ScalerDomain | None]]
 
     def __init__(
         self,
-        scalers: dict[str, TENSOR_SPEC] | TENSOR_SPEC | None = None,
-        *tensors: TENSOR_SPEC,
-        **named_tensors: dict[str, TENSOR_SPEC],
+        scalers: dict[str, ScalerSpec] | None = None,
+        *scaler_specs: ScalerSpec,
+        **named_scalers: ScalerSpec,
     ):
         """ScaleTensor constructor.
 
         Parameters
         ----------
-        scalers : dict[str, TENSOR_SPEC] | TENSOR_SPEC | None, optional
+        scalers : dict[str, ScalerSpec] | None, optional
             Scalers to initalise with, by default None
-        tensors : TENSOR_SPEC
-            Args form of (dimension, tensor) to add to the scalers
+        scaler_specs : ScalerSpec
+            Scaler specifications to add to the scalers
             Will be given a random uuid name
-        named_tensors : dict[str, TENSOR_SPEC]
-            Kwargs form of {name: (dimension, tensor)} to add to the scalers
+        named_scalers : ScalerSpec
+            Kwargs form of {name: ScalerSpec(...)} to add to the scalers
         """
         super().__init__()
 
         self._tensors = {}
 
-        named_tensors.update(scalers or {})
-        self.add(named_tensors)
+        named_scalers.update(scalers or {})
+        self.add(named_scalers)
 
-        for tensor_spec in tensors:
-            self.add_scaler(*tensor_spec)
+        for scaler_spec in scaler_specs:
+            self.add_scaler(
+                scaler_spec.dimensions,
+                scaler_spec.tensor,
+                grid_domain=scaler_spec.grid_domain,
+            )
 
     @property
-    def tensors(self) -> dict[str, TENSOR_SPEC]:
-        """Get the scalers as a dictionary of name to (dimension, tensor) pairs."""
+    def tensors(self) -> dict[str, ScalerSpec]:
+        """Get the scalers as a dictionary of names to scaler specifications."""
         tensors = {}
-        for name, (dimension, _) in self._tensors.items():
-            tensors[name] = (dimension, self._buffers[name])
+        for name, (dimension, grid_domain) in self._tensors.items():
+            tensors[name] = ScalerSpec(dimension, self._buffers[name], grid_domain)
 
         return tensors
 
     @property
-    def specified_dimensions(self) -> dict[str, tuple[int]]:
+    def specified_dimensions(self) -> dict[str, tuple[int, ...]]:
         """Get the specified dimensions for each scaler."""
         return {key: dim for key, (dim, _) in self._tensors.items()}
 
@@ -155,9 +168,9 @@ class ScaleTensor(nn.Module):
         """
 
         def get_dim_shape(dimension: int) -> int:
-            for dim_assign, tensor in self.tensors.values():
-                if isinstance(dim_assign, tuple) and dimension in dim_assign:
-                    return tensor.shape[list(dim_assign).index(dimension)]
+            for scaler_spec in self.tensors.values():
+                if dimension in scaler_spec.dimensions:
+                    return scaler_spec.tensor.shape[list(scaler_spec.dimensions).index(dimension)]
 
             unique_dims = {dim for dim_assign in self.specified_dimensions.values() for dim in dim_assign}
             error_msg = (
@@ -206,6 +219,7 @@ class ScaleTensor(nn.Module):
         dimension: int | tuple[int],
         scaler: torch.Tensor,
         *,
+        grid_domain: ScalerDomain | None = None,
         name: str | None = None,
     ) -> Self:
         """Add new scaler to be applied along `dimension`.
@@ -220,6 +234,8 @@ class ScaleTensor(nn.Module):
             Dimension/s to apply the scaler to
         scaler : torch.Tensor
             Scaler tensor to apply
+        grid_domain : ScalerDomain | None, optional
+            Whether the scaler applies to spatial points or spectral modes along the grid dimension
         name : str | None, optional
             Name of the scaler, by default None
 
@@ -255,7 +271,7 @@ class ScaleTensor(nn.Module):
             error_msg = f"Validating tensor {name!r} raised an error."
             raise ValueError(error_msg) from e
 
-        self._tensors[name] = (dimension, None)
+        self._tensors[name] = (dimension, grid_domain)
         self.register_buffer(name, scaler, persistent=False)
 
         return self
@@ -308,7 +324,13 @@ class ScaleTensor(nn.Module):
 
                 for key in record_of_scalers:
                     if key not in self:
-                        self.add_scaler(*record_of_scalers[key], name=key)
+                        scaler_spec = record_of_scalers[key]
+                        self.add_scaler(
+                            scaler_spec.dimensions,
+                            scaler_spec.tensor,
+                            grid_domain=scaler_spec.grid_domain,
+                            name=key,
+                        )
 
         return FrozenStateRecord()
 
@@ -334,7 +356,7 @@ class ScaleTensor(nn.Module):
             msg = f"scaler {name!r} not found in scalers."
             raise ValueError(msg)
 
-        dimension = self._tensors[name][0]
+        dimension, grid_domain = self._tensors[name]
 
         original_scaler = self._tensors.pop(name)
         original_scaler_buffer = self._buffers.get(name)
@@ -343,29 +365,38 @@ class ScaleTensor(nn.Module):
             self.validate_scaler(dimension, scaler)
 
         try:
-            self.add_scaler(dimension, scaler, name=name)
+            self.add_scaler(dimension, scaler, grid_domain=grid_domain, name=name)
         except ValueError:
             self._tensors[name] = original_scaler
             self.register_buffer(name, original_scaler_buffer, persistent=False)
             raise
 
-    def add(self, new_scalers: dict[str, TENSOR_SPEC] | list[TENSOR_SPEC] | None = None, **kwargs) -> None:
+    def add(self, new_scalers: dict[str, ScalerSpec] | list[ScalerSpec] | None = None, **kwargs) -> None:
         """Add multiple scalers to the existing scalers.
 
         Parameters
         ----------
-        new_scalers : dict[str, TENSOR_SPEC] | list[TENSOR_SPEC] | None, optional
+        new_scalers : dict[str, ScalerSpec] | list[ScalerSpec] | None, optional
             Scalers to add, see `add_scaler` for more info, by default None
         **kwargs:
-            Kwargs form of {name: (dimension, tensor)} to add to the scalers
+            Kwargs form of {name: ScalerSpec(...)} to add to the scalers
         """
         if isinstance(new_scalers, list):
-            for tensor_spec in new_scalers:
-                self.add_scaler(*tensor_spec)
+            for scaler_spec in new_scalers:
+                self.add_scaler(
+                    scaler_spec.dimensions,
+                    scaler_spec.tensor,
+                    grid_domain=scaler_spec.grid_domain,
+                )
         else:
             kwargs.update(new_scalers or {})
-        for name, tensor_spec in kwargs.items():
-            self.add_scaler(*tensor_spec, name=name)
+        for name, scaler_spec in kwargs.items():
+            self.add_scaler(
+                scaler_spec.dimensions,
+                scaler_spec.tensor,
+                grid_domain=scaler_spec.grid_domain,
+                name=name,
+            )
 
     def update(self, updated_scalers: dict[str, torch.Tensor] | None = None, override: bool = False, **kwargs) -> None:
         """Update multiple scalers in the existing scalers.
@@ -422,7 +453,7 @@ class ScaleTensor(nn.Module):
         """
         if isinstance(scalers, str):
             scalers = [scalers]
-        return ScaleTensor(**{name: self.tensors[name] for name in scalers})
+        return ScaleTensor({name: self.tensors[name] for name in scalers})
 
     def subset_by_dim(self, dimensions: int | Sequence[int]) -> Self:
         """Get subset of the scalers, filtering by dimension.
@@ -439,18 +470,17 @@ class ScaleTensor(nn.Module):
         ScaleTensor
             Subset of self
         """
-        subset_scalers: dict[str, TENSOR_SPEC] = {}
-
         if isinstance(dimensions, int):
             dimensions = (dimensions,)
 
-        for name, (dim, scaler) in self.tensors.items():
-            if isinstance(dim, int):
-                dim = (dim,)
-            if len(set(dimensions).intersection(dim)) > 0:
-                subset_scalers[name] = (dim, scaler)
+        dimensions = set(dimensions)
+        subset_scalers = {
+            name: scaler_spec
+            for name, scaler_spec in self.tensors.items()
+            if dimensions.intersection(scaler_spec.dimensions)
+        }
 
-        return ScaleTensor(**subset_scalers)
+        return ScaleTensor(subset_scalers)
 
     def without(self, scaler_identifier: str | Sequence[str] | int | Sequence[int]) -> Self:
         """Get subset of the scalers, filtering out by name or dimension.
@@ -486,7 +516,7 @@ class ScaleTensor(nn.Module):
         """
         if isinstance(scalers, str):
             scalers = [scalers]
-        return ScaleTensor(**{name: tensor for name, tensor in self.tensors.items() if name not in scalers})
+        return ScaleTensor({name: tensor for name, tensor in self.tensors.items() if name not in scalers})
 
     def without_by_dim(self, dimensions: int | Sequence[int]) -> Self:
         """Get subset of the scalers, filtering out by dimension.
@@ -501,18 +531,17 @@ class ScaleTensor(nn.Module):
         ScaleTensor
             Subset of self
         """
-        subset_scalers: dict[str, TENSOR_SPEC] = {}
-
         if isinstance(dimensions, int):
             dimensions = (dimensions,)
 
-        for name, (dim, scaler) in self.tensors.items():
-            if isinstance(dim, int):
-                dim = (dim,)
-            if len(set(dimensions).intersection(dim)) == 0:
-                subset_scalers[name] = (dim, scaler)
+        dimensions = set(dimensions)
+        subset_scalers = {
+            name: scaler_spec
+            for name, scaler_spec in self.tensors.items()
+            if not dimensions.intersection(scaler_spec.dimensions)
+        }
 
-        return ScaleTensor(**subset_scalers)
+        return ScaleTensor(subset_scalers)
 
     def resolve(self, ndim: int) -> Self:
         """Resolve relative indexes in scalers by associating against ndim.
@@ -531,17 +560,17 @@ class ScaleTensor(nn.Module):
         ScaleTensor
             ScaleTensor with all relative indexes resolved
         """
-        resolved_scalers: dict[str, TENSOR_SPEC] = {}
+        resolved_scalers: dict[str, ScalerSpec] = {}
 
-        for name, (dims, scaler) in self.tensors.items():
+        for name, scaler_spec in self.tensors.items():
             # Cast to plain int: dims may hold TensorDim (IntEnum) members, and
             # torch.compile/Dynamo does not support the < / >= operators on enums.
-            int_dims = [int(d) for d in dims]
+            int_dims = tuple(int(d) for d in scaler_spec.dimensions)
             if any(d < 0 for d in int_dims):
-                int_dims = [d if d >= 0 else ndim + d for d in int_dims]
-            resolved_scalers[name] = (int_dims, scaler)
+                int_dims = tuple(d if d >= 0 else ndim + d for d in int_dims)
+            resolved_scalers[name] = ScalerSpec(int_dims, scaler_spec.tensor, scaler_spec.grid_domain)
 
-        return ScaleTensor(**resolved_scalers)
+        return ScaleTensor(resolved_scalers)
 
     def scale_iteratively(
         self,
@@ -570,7 +599,9 @@ class ScaleTensor(nn.Module):
         ndim = x.ndim
         tensors = self.resolve(ndim).tensors
 
-        for dims, scaler in tensors.values():
+        for scaler_spec in tensors.values():
+            dims = scaler_spec.dimensions
+            scaler = scaler_spec.tensor
             if TensorDim.GRID in dims and grid_shard_slice is not None:
                 grid_index = dims.index(TensorDim.GRID)
                 if scaler.shape[grid_index] >= grid_shard_slice.stop:
@@ -600,13 +631,17 @@ class ScaleTensor(nn.Module):
         subset_indices: tuple[int, ...] | None = None,
         *,
         grid_shard_slice: slice | None = None,
-    ) -> None:
+    ) -> torch.Tensor:
         """Scale a given tensor by the scalers.
 
         Parameters
         ----------
-        tensor : torch.Tensor
+        x : torch.Tensor
             Input tensor to scale
+        subset_indices : tuple[int, ...] | None, optional
+            Indices used to subset the input tensor and scaler
+        grid_shard_slice : slice | None, optional
+            Slice of a global grid scaler that belongs to this rank
 
         Returns
         -------
@@ -654,7 +689,9 @@ class ScaleTensor(nn.Module):
 
         tensors = self.resolve(ndim).tensors
 
-        for dims, scaler in tensors.values():
+        for scaler_spec in tensors.values():
+            dims = scaler_spec.dimensions
+            scaler = scaler_spec.tensor
             missing_dims = [d for d in range(ndim) if d not in dims]
             reshape = [1] * len(missing_dims)
             reshape.extend(scaler.shape)

--- a/training/src/anemoi/training/losses/scalers/__init__.py
+++ b/training/src/anemoi/training/losses/scalers/__init__.py
@@ -7,6 +7,8 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
+from anemoi.training.losses.scaler_tensor import ScalerDomain
+
 from .base_scaler import TensorDim
 from .loss_weights_mask import NaNMaskScaler
 from .node_attributes import GraphNodeAttributeScaler
@@ -37,6 +39,7 @@ __all__ = [
     "PolynomialVariableLevelScaler",
     "ReluVariableLevelScaler",
     "ReweightedGraphNodeAttributeScaler",
+    "ScalerDomain",
     "SpectralDimensionScaler",
     "StdevTendencyScaler",
     "TensorDim",

--- a/training/src/anemoi/training/losses/scalers/base_scaler.py
+++ b/training/src/anemoi/training/losses/scalers/base_scaler.py
@@ -15,7 +15,8 @@ from enum import StrEnum
 import torch
 
 from anemoi.models.interface import AnemoiModelInterface
-from anemoi.training.losses.scaler_tensor import TENSOR_SPEC
+from anemoi.training.losses.scaler_tensor import ScalerDomain
+from anemoi.training.losses.scaler_tensor import ScalerSpec
 from anemoi.training.utils.enums import TensorDim
 
 LOGGER = logging.getLogger(__name__)
@@ -25,6 +26,7 @@ class BaseScaler(ABC):
     """Base class for all loss scalers."""
 
     scale_dims: tuple[TensorDim, ...]
+    grid_domain: ScalerDomain | None = None
 
     def __init__(self, norm: str | None = None) -> None:
         """Initialise BaseScaler.
@@ -44,6 +46,9 @@ class BaseScaler(ABC):
         assert self.scale_dims is not None, f"Class {self.__class__.__name__} must define 'scale_dims'"
         if isinstance(self.scale_dims, TensorDim):
             self.scale_dims = (self.scale_dims,)
+        if TensorDim.GRID in self.scale_dims and self.grid_domain is None:
+            msg = f"Class {self.__class__.__name__} must define 'grid_domain' because it scales TensorDim.GRID"
+            raise ValueError(msg)
 
     @abstractmethod
     def get_scaling_values(self, **kwargs) -> torch.Tensor:
@@ -64,7 +69,7 @@ class BaseScaler(ABC):
         error_msg = f"{self.norm} must be one of: None, unit-sum, l1, unit-mean."
         raise ValueError(error_msg)
 
-    def get_scaling(self) -> TENSOR_SPEC:
+    def get_scaling(self) -> ScalerSpec:
         """Get scaler.
 
         Returns
@@ -77,7 +82,7 @@ class BaseScaler(ABC):
         scaler_values = self.get_scaling_values()
         scaler_values = self.normalise(scaler_values)
         scale_dims = tuple(x.value for x in self.scale_dims)
-        return scale_dims, scaler_values
+        return ScalerSpec(scale_dims, scaler_values, self.grid_domain)
 
 
 class AvailableCallbacks(StrEnum):
@@ -117,14 +122,14 @@ class BaseUpdatingScaler(BaseScaler):
         """
         return torch.ones(tuple([1] * len(self.scale_dims)))
 
-    def get_scaling(self) -> TENSOR_SPEC:
+    def get_scaling(self) -> ScalerSpec:
         """Get scaling values based on the initial scaling values callback."""
         scalar_values = self.get_scaling_values()
 
         scale_dims = tuple(x.value for x in self.scale_dims)
-        return scale_dims, scalar_values
+        return ScalerSpec(scale_dims, scalar_values, self.grid_domain)
 
-    def update_scaling_values(self, callback: AvailableCallbacks, **kwargs) -> TENSOR_SPEC | None:
+    def update_scaling_values(self, callback: AvailableCallbacks, **kwargs) -> ScalerSpec | None:
         """Get scaling values based on the callback.
 
         Can return None if no scaling updates are available.
@@ -139,8 +144,8 @@ class BaseUpdatingScaler(BaseScaler):
 
         Returns
         -------
-        TENSOR_SPEC | None
-            A tuple containing the scale dimensions and the scaler values.
+        ScalerSpec | None
+            The dimensions, values, and grid-entry meaning of the scaler.
         """
         if not hasattr(self, callback):
             error_msg = f"{self.__class__.__name__} does not have a method {callback}."
@@ -152,4 +157,4 @@ class BaseUpdatingScaler(BaseScaler):
 
         scalar_values = self.normalise(scalar_values)
         scale_dims = tuple(x.value for x in self.scale_dims)
-        return scale_dims, scalar_values
+        return ScalerSpec(scale_dims, scalar_values, self.grid_domain)

--- a/training/src/anemoi/training/losses/scalers/loss_weights_mask.py
+++ b/training/src/anemoi/training/losses/scalers/loss_weights_mask.py
@@ -14,6 +14,7 @@ import torch
 
 from anemoi.models.interface import AnemoiModelInterface
 from anemoi.models.preprocessing import StepwiseProcessors
+from anemoi.training.losses.scaler_tensor import ScalerDomain
 from anemoi.training.losses.scalers.base_scaler import BaseUpdatingScaler
 from anemoi.training.utils.enums import TensorDim
 
@@ -23,6 +24,7 @@ LOGGER = logging.getLogger(__name__)
 class NaNMaskScaler(BaseUpdatingScaler):
 
     scale_dims: tuple[TensorDim] = (TensorDim.BATCH_SIZE, TensorDim.GRID, TensorDim.VARIABLE)
+    grid_domain = ScalerDomain.SPATIAL
 
     def __init__(self, norm: str | None = None, use_processors_tendencies: bool = False, **kwargs) -> None:
         """Initialise NanMaskScaler.
@@ -50,6 +52,11 @@ class NaNMaskScaler(BaseUpdatingScaler):
             The model.
         dataset_name : str, optional
             The dataset name for multi-dataset scenarios.
+
+        Returns
+        -------
+        torch.Tensor | None
+            Combined loss mask, or ``None`` when no processor provides one.
         """
         loss_weights_mask = None
         processors = []

--- a/training/src/anemoi/training/losses/scalers/node_attributes.py
+++ b/training/src/anemoi/training/losses/scalers/node_attributes.py
@@ -13,6 +13,7 @@ import logging
 import torch
 from torch_geometric.data import HeteroData
 
+from anemoi.training.losses.scaler_tensor import ScalerDomain
 from anemoi.training.losses.scalers.base_scaler import BaseScaler
 from anemoi.training.utils.enums import TensorDim
 from anemoi.training.utils.masks import BaseMask
@@ -25,6 +26,7 @@ class GraphNodeAttributeScaler(BaseScaler):
     """Class for extracting scalers from node attributes."""
 
     scale_dims: TensorDim = TensorDim.GRID
+    grid_domain = ScalerDomain.SPATIAL
 
     def __init__(
         self,

--- a/training/src/anemoi/training/losses/scalers/scalers.py
+++ b/training/src/anemoi/training/losses/scalers/scalers.py
@@ -12,7 +12,7 @@ import logging
 
 from hydra.utils import instantiate
 
-from anemoi.training.losses.scaler_tensor import TENSOR_SPEC
+from anemoi.training.losses.scaler_tensor import ScalerSpec
 from anemoi.training.losses.scalers.base_scaler import BaseScaler
 from anemoi.training.losses.scalers.base_scaler import BaseUpdatingScaler
 from anemoi.utils.config import DotDict
@@ -20,7 +20,7 @@ from anemoi.utils.config import DotDict
 LOGGER = logging.getLogger(__name__)
 
 
-def create_scalers(scalers_config: DotDict, **kwargs) -> tuple[dict[str, TENSOR_SPEC], dict[str, BaseUpdatingScaler]]:
+def create_scalers(scalers_config: DotDict, **kwargs) -> tuple[dict[str, ScalerSpec], dict[str, BaseUpdatingScaler]]:
     scalers, updating_scalars = {}, {}
     for name, config in scalers_config.items():
         scaler_builder: BaseScaler = instantiate(config, **kwargs)

--- a/training/src/anemoi/training/losses/scalers/spectral.py
+++ b/training/src/anemoi/training/losses/scalers/spectral.py
@@ -12,6 +12,7 @@ import logging
 
 import torch
 
+from anemoi.training.losses.scaler_tensor import ScalerDomain
 from anemoi.training.losses.scalers.base_scaler import BaseScaler
 from anemoi.training.utils.enums import TensorDim
 
@@ -34,6 +35,7 @@ class SpectralDimensionScaler(BaseScaler):
     """
 
     scale_dims: TensorDim = TensorDim.GRID
+    grid_domain = ScalerDomain.SPECTRAL
 
     def __init__(
         self,

--- a/training/src/anemoi/training/losses/spectral.py
+++ b/training/src/anemoi/training/losses/spectral.py
@@ -44,6 +44,7 @@ from anemoi.training.losses.base import BaseLoss
 from anemoi.training.losses.base import Squash_mode
 from anemoi.training.losses.kcrps import CRPS
 from anemoi.training.losses.kcrps import CRPSBackend
+from anemoi.training.losses.scaler_tensor import ScalerDomain
 from anemoi.training.utils.enums import TensorDim
 
 if TYPE_CHECKING:
@@ -56,33 +57,39 @@ if TYPE_CHECKING:
 LOGGER = logging.getLogger(__name__)
 
 
-def _assert_spectral_scalers_compatible(scaler_tensor: ScaleTensor, n_spectral: int) -> None:
-    """Assert that all grid-dimension scalers are spectral-compatible.
+def _validate_spectral_scalers(scaler_tensor: ScaleTensor, n_spectral: int) -> None:
+    """Validate that all grid-dimension scalers are spectral-compatible.
 
     In spectral losses the grid dimension holds spectral modes, not grid
-    points.  Any scaler registered on ``TensorDim.GRID`` must therefore
-    originate from a :class:`SpectralDimensionScaler` (i.e. be sized to the
-    flattened spectral dimension) rather than from a spatial scaler (e.g. area
-    weights sized to the number of grid points).
+    points. Any scaler registered on ``TensorDim.GRID`` must therefore declare
+    the spectral grid domain and be sized to the global spectral dimension.
 
     Parameters
     ----------
     scaler_tensor : ScaleTensor
         The ``ScaleTensor`` attached to the loss.
     n_spectral : int
-        Size of the flattened spectral dimension in the loss tensor.
+        Global size of the spectral dimension represented by the loss tensor.
     """
-    for name, (dims, tensor) in scaler_tensor.tensors.items():
-        if TensorDim.GRID not in dims:
+    for name, scaler_spec in scaler_tensor.tensors.items():
+        if TensorDim.GRID not in scaler_spec.dimensions:
             continue
-        grid_idx = list(dims).index(TensorDim.GRID)
-        scaler_grid_size = tensor.shape[grid_idx]
-        assert scaler_grid_size == n_spectral or scaler_grid_size == 1, (
-            f"Scaler '{name}' is registered on the grid dimension with size "
-            f"{scaler_grid_size}, but the spectral loss has a target with spectral "
-            f"dimension of size {n_spectral}. Grid-dimension scalers in "
-            f"spectral losses must be SpectralDimensionScalers with matching size."
-        )
+        if scaler_spec.grid_domain != ScalerDomain.SPECTRAL:
+            msg = (
+                f"Scaler {name!r} uses the {scaler_spec.grid_domain or 'unspecified'} grid domain. "
+                "Spectral losses only accept spectral grid scalers."
+            )
+            raise ValueError(msg)
+        grid_idx = list(scaler_spec.dimensions).index(TensorDim.GRID)
+        scaler_grid_size = scaler_spec.tensor.shape[grid_idx]
+        if scaler_grid_size != n_spectral and scaler_grid_size != 1:
+            msg = (
+                f"Scaler {name!r} is registered on the grid dimension with size "
+                f"{scaler_grid_size}, but the spectral loss has a global spectral "
+                f"dimension of size {n_spectral}. Spectral grid scalers must have "
+                "the global spectral size or be singleton."
+            )
+            raise ValueError(msg)
 
 
 class SpectralLoss(BaseLoss):
@@ -90,6 +97,7 @@ class SpectralLoss(BaseLoss):
 
     transform: SpectralTransform
     needs_graph_data: bool = True
+    grid_scaler_domain = ScalerDomain.SPECTRAL
 
     def __init__(
         self,
@@ -270,17 +278,48 @@ class SpectralLoss(BaseLoss):
         group: ProcessGroup | None,
         channel_shard_sizes: list[int] | None,
         spectral_grid_dim: int,
-    ) -> torch.Tensor:
-        """Move a full-mode, channel-sharded loss tensor back to mode-sharded layout."""
+    ) -> tuple[torch.Tensor, slice | None, int]:
+        """Redistribute a spectral loss so each rank owns a slice of its modes.
+
+        Before this step, each rank has every spectral mode for only its local
+        variables. This moves the variable shards back into the variable
+        dimension and splits the modes across ranks instead. It also reports
+        which part of a global spectral scaler belongs to the local rank.
+
+        Parameters
+        ----------
+        loss_tensor : torch.Tensor
+            Full-mode loss tensor with its variable dimension sharded.
+        group : ProcessGroup | None
+            Distributed group used for the all-to-all transpose.
+        channel_shard_sizes : list[int] | None
+            Number of variables owned by each rank, or ``None`` when unsharded.
+        spectral_grid_dim : int
+            Tensor dimension containing the spectral modes.
+
+        Returns
+        -------
+        tuple[torch.Tensor, slice | None, int]
+            The redistributed loss tensor, this rank's slice of the global
+            spectral dimension (or ``None`` when unsharded), and the total
+            number of spectral modes across all ranks.
+        """
         if channel_shard_sizes is None:
-            return loss_tensor
+            return loss_tensor, None, loss_tensor.size(spectral_grid_dim)
 
         if group is None:
             msg = "Spectral losses require a process group when channel_shard_sizes is provided."
             raise ValueError(msg)
 
         spectral_shard_sizes = get_shard_sizes(loss_tensor, spectral_grid_dim, group)
-        return all_to_all_transpose(
+        rank = torch.distributed.get_rank(group)
+        spectral_shard_start = sum(spectral_shard_sizes[:rank])
+        spectral_shard_slice = slice(
+            spectral_shard_start,
+            spectral_shard_start + spectral_shard_sizes[rank],
+        )
+        global_spectral_size = sum(spectral_shard_sizes)
+        loss_tensor = all_to_all_transpose(
             loss_tensor,
             spectral_grid_dim,
             spectral_shard_sizes,
@@ -288,6 +327,7 @@ class SpectralLoss(BaseLoss):
             channel_shard_sizes,
             group,
         )
+        return loss_tensor, spectral_shard_slice, global_spectral_size
 
 
 class SpectralAMSELoss(SpectralLoss):
@@ -386,13 +426,18 @@ class SpectralAMSELoss(SpectralLoss):
             # per-L AMSE: [B, T, E, L, vars]
             amse_per_l = (amp_pred - amp_target) ** 2 + 2 * torch.maximum(psd_pred, psd_target) * (1 - coherence)
 
-        amse_per_l = self._reshard_spectral_loss(amse_per_l, group, channel_shard_sizes, grid_dim)
-        _assert_spectral_scalers_compatible(self.scaler, amse_per_l.size(TensorDim.GRID))
+        amse_per_l, spectral_shard_slice, global_spectral_size = self._reshard_spectral_loss(
+            amse_per_l,
+            group,
+            channel_shard_sizes,
+            grid_dim,
+        )
+        _validate_spectral_scalers(self.get_active_scalers(without_scalers), global_spectral_size)
         result = self.scale(
             amse_per_l,
             scaler_indices,
             without_scalers=without_scalers,
-            grid_shard_slice=None if is_sharded else grid_shard_slice,
+            grid_shard_slice=spectral_shard_slice,
         )
         return self.reduce(result, squash=squash, group=group, squash_mode=squash_mode)
 
@@ -464,13 +509,18 @@ class PowerSpectrumLoss(SpectralLoss):
         target_amp = self.transform.power_spectral_density(sc_target)
         diff = (pred_amp - target_amp) ** 2
 
-        diff = self._reshard_spectral_loss(diff, group, channel_shard_sizes, grid_dim)
-        _assert_spectral_scalers_compatible(self.scaler, diff.size(TensorDim.GRID))
+        diff, spectral_shard_slice, global_spectral_size = self._reshard_spectral_loss(
+            diff,
+            group,
+            channel_shard_sizes,
+            grid_dim,
+        )
+        _validate_spectral_scalers(self.get_active_scalers(without_scalers), global_spectral_size)
         result = self.scale(
             diff,
             scaler_indices,
             without_scalers=without_scalers,
-            grid_shard_slice=None if is_sharded else grid_shard_slice,
+            grid_shard_slice=spectral_shard_slice,
         )
         return self.reduce(result, squash=squash, group=group, squash_mode=squash_mode)
 
@@ -512,14 +562,19 @@ class LogSpectralDistance(SpectralLoss):
         power_tgt = torch.abs(target_spectral) ** 2
 
         log_diff = torch.log(power_tgt + eps) - torch.log(power_pred + eps)
-        log_diff = self._reshard_spectral_loss(log_diff, group, channel_shard_sizes, grid_dim)
+        log_diff, spectral_shard_slice, global_spectral_size = self._reshard_spectral_loss(
+            log_diff,
+            group,
+            channel_shard_sizes,
+            grid_dim,
+        )
 
-        _assert_spectral_scalers_compatible(self.scaler, log_diff.size(TensorDim.GRID))
+        _validate_spectral_scalers(self.get_active_scalers(without_scalers), global_spectral_size)
         result = self.scale(
             log_diff**2,
             scaler_indices,
             without_scalers=without_scalers,
-            grid_shard_slice=None if is_sharded else grid_shard_slice,
+            grid_shard_slice=spectral_shard_slice,
         )
         return torch.sqrt(self.reduce(result, squash=squash, group=group, squash_mode=squash_mode) + eps)
 
@@ -566,13 +621,18 @@ class FourierCorrelationLoss(SpectralLoss):
         # compute correlation
         result = 1 - correlation
 
-        result = self._reshard_spectral_loss(result, group, channel_shard_sizes, grid_dim)
-        _assert_spectral_scalers_compatible(self.scaler, result.size(TensorDim.GRID))
+        result, spectral_shard_slice, global_spectral_size = self._reshard_spectral_loss(
+            result,
+            group,
+            channel_shard_sizes,
+            grid_dim,
+        )
+        _validate_spectral_scalers(self.get_active_scalers(without_scalers), global_spectral_size)
         result = self.scale(
             result,
             scaler_indices,
             without_scalers=without_scalers,
-            grid_shard_slice=None if is_sharded else grid_shard_slice,
+            grid_shard_slice=spectral_shard_slice,
         )
         return self.reduce(result, squash=squash, group=group, squash_mode=squash_mode)
 
@@ -676,14 +736,19 @@ class SpectralCRPSLoss(SpectralLoss, CRPS):
             crps = self._kernel_crps(pred_spec, tgt_spec, alpha=self.alpha)
 
         crps = einops.rearrange(crps, "b t v m -> b t 1 m v")  # consistent with tensordim
-        crps = self._reshard_spectral_loss(crps, group, channel_shard_sizes, grid_dim)
+        crps, spectral_shard_slice, global_spectral_size = self._reshard_spectral_loss(
+            crps,
+            group,
+            channel_shard_sizes,
+            grid_dim,
+        )
 
-        _assert_spectral_scalers_compatible(self.scaler, crps.size(TensorDim.GRID))
+        _validate_spectral_scalers(self.get_active_scalers(without_scalers), global_spectral_size)
         scaled = self.scale(
             crps,
             scaler_indices,
             without_scalers=without_scalers,
-            grid_shard_slice=None if is_sharded else grid_shard_slice,
+            grid_shard_slice=spectral_shard_slice,
         )
         return self.reduce(scaled, squash=squash, group=group, squash_mode=squash_mode)
 

--- a/training/src/anemoi/training/losses/variable_mapper.py
+++ b/training/src/anemoi/training/losses/variable_mapper.py
@@ -19,6 +19,7 @@ from anemoi.models.data_indices.collection import IndexCollection
 from anemoi.training.losses.base import BaseLoss
 from anemoi.training.losses.base import BaseLossWrapper
 from anemoi.training.losses.base import Squash_mode
+from anemoi.training.losses.scaler_tensor import ScalerDomain
 from anemoi.training.losses.scaler_tensor import ScaleTensor
 from anemoi.training.utils.enums import TensorDim
 from anemoi.training.utils.index_space import IndexSpace
@@ -135,16 +136,23 @@ class LossVariableMapper(BaseLossWrapper):
         return scaler.index_select(variable_axis, predicted_indices_tensor)
 
     @functools.wraps(ScaleTensor.add_scaler)
-    def add_scaler(self, dimension: int | tuple[int], scaler: torch.Tensor, *, name: str | None = None) -> None:
+    def add_scaler(
+        self,
+        dimension: int | tuple[int],
+        scaler: torch.Tensor,
+        *,
+        grid_domain: ScalerDomain | None = None,
+        name: str | None = None,
+    ) -> None:
         scaler = self._filter_variable_axis_scaler(dimension, scaler)
         # Pass scalers to the inner loss so they are actually applied during loss computation
-        self.loss.add_scaler(dimension=dimension, scaler=scaler, name=name)
+        self.loss.add_scaler(dimension=dimension, scaler=scaler, grid_domain=grid_domain, name=name)
 
     @functools.wraps(ScaleTensor.update_scaler)
     def update_scaler(self, name: str, scaler: torch.Tensor, *, override: bool = False) -> None:
         # Keep update behavior consistent with add_scaler for VARIABLE-axis scalers.
         if name in self.loss.scaler.tensors:
-            dimension = self.loss.scaler.tensors[name][0]
+            dimension = self.loss.scaler.tensors[name].dimensions
             scaler = self._filter_variable_axis_scaler(dimension, scaler)
         self.loss.update_scaler(name=name, scaler=scaler, override=override)
 

--- a/training/src/anemoi/training/train/methods/base.py
+++ b/training/src/anemoi/training/train/methods/base.py
@@ -90,6 +90,8 @@ class BaseTrainingModule(pl.LightningModule, ABC):
     ----------
     config : BaseSchema
         Configuration object defining all parameters.
+    task : BaseTask
+        Training task that defines the input and output timesteps.
     graph_data : HeteroData
         Graph-structured input data containing node and edge features, keyed by dataset name.
     statistics : dict
@@ -163,10 +165,14 @@ class BaseTrainingModule(pl.LightningModule, ABC):
         ----------
         config : DictConfig
             Job configuration
+        task : BaseTask
+            Training task definition
         graph_data : HeteroData
             Graph objects keyed by dataset name
         statistics : dict
             Statistics of the training data
+        statistics_tendencies : dict
+            Statistics of the training-data tendencies
         data_indices : dict[str, IndexCollection]
             Indices of the training data,
         metadata : dict
@@ -504,11 +510,11 @@ class BaseTrainingModule(pl.LightningModule, ABC):
             return
 
         if self._can_update_scaler(loss_obj, name):
-            loss_obj.update_scaler(scaler=scaler[1], name=name)  # Only update the values
+            loss_obj.update_scaler(scaler=scaler.tensor, name=name)  # Only update the values
 
         for metric in metrics_dict.values():  # If scalar in metrics, update it
             if self._can_update_scaler(metric, name):
-                metric.update_scaler(scaler=scaler[1], name=name)  # Only update the values
+                metric.update_scaler(scaler=scaler.tensor, name=name)  # Only update the values
 
     @staticmethod
     def _can_update_scaler(loss_or_metric: torch.nn.Module, scaler_name: str) -> bool:
@@ -582,6 +588,8 @@ class BaseTrainingModule(pl.LightningModule, ABC):
             Predicted values
         y : torch.Tensor
             Target values
+        dataset_name : str
+            Dataset whose shard layout should be used
         validation_mode : bool
             Whether in validation mode
 
@@ -632,6 +640,10 @@ class BaseTrainingModule(pl.LightningModule, ABC):
             Grid shard slice for distributed training
         dataset_name : str
             Dataset name for multi-dataset scenarios
+        pred_layout : IndexSpace | str | None
+            Index layout of the prediction tensor
+        target_layout : IndexSpace | str | None
+            Index layout of the target tensor
         **_kwargs
             Additional arguments
 
@@ -681,8 +693,16 @@ class BaseTrainingModule(pl.LightningModule, ABC):
             Target values
         grid_shard_slice : slice | None
             Grid shard slice for distributed training
+        dataset_name : str
+            Dataset name for multi-dataset scenarios
+        pred_layout : IndexSpace | str | None
+            Index layout of the prediction tensor
+        target_layout : IndexSpace | str | None
+            Index layout of the target tensor
         rollout_step : int | None
             Current rollout step index, used to produce per-step metric key suffixes.
+        **_kwargs
+            Additional arguments
 
         Returns
         -------
@@ -715,10 +735,10 @@ class BaseTrainingModule(pl.LightningModule, ABC):
             Predicted values
         y : torch.Tensor
             Target values
-        step : int, optional
-            Current step
         validation_mode : bool, optional
             Whether to compute validation metrics
+        dataset_name : str | None, optional
+            Dataset for which to compute the loss and metrics
         **kwargs
             Additional arguments to pass to loss computation
 
@@ -771,8 +791,6 @@ class BaseTrainingModule(pl.LightningModule, ABC):
             Predicted values
         y : dict[str, torch.Tensor]
             Target values
-        step : int, optional
-            Current step
         validation_mode : bool, optional
             Whether to compute validation metrics
         **kwargs
@@ -971,8 +989,20 @@ class BaseTrainingModule(pl.LightningModule, ABC):
             Predicted ensemble
         y: torch.Tensor
             Ground truth (target).
+        grid_shard_slice : slice | None, optional
+            Slice of the grid owned by this rank.
+        dataset_name : str | None, optional
+            Dataset for which to calculate metrics.
         step: int, optional
             Step number
+        pred_layout : IndexSpace | str | None, optional
+            Index layout of the prediction tensor.
+        target_layout : IndexSpace | str | None, optional
+            Index layout of the target tensor.
+        without_scalers : list[str] | list[int] | None, optional
+            Scalers to exclude from this calculation.
+        **_kwargs
+            Additional arguments.
 
         Returns
         -------

--- a/training/tests/unit/diagnostics/test_callbacks.py
+++ b/training/tests/unit/diagnostics/test_callbacks.py
@@ -21,6 +21,8 @@ from anemoi.training.diagnostics.callbacks import CallbacksContext
 from anemoi.training.diagnostics.callbacks import _get_progress_bar_callback
 from anemoi.training.diagnostics.callbacks import get_callbacks
 from anemoi.training.diagnostics.callbacks.evaluation import RolloutEval
+from anemoi.training.losses.scaler_tensor import ScalerDomain
+from anemoi.training.losses.scaler_tensor import ScalerSpec
 from anemoi.training.train.step_output import TrainingStepOutput
 
 NUM_FIXED_CALLBACKS = 3  # ParentUUIDCallback, CheckVariableOrder, RegisterMigrations
@@ -211,7 +213,13 @@ def test_plot_loss_gathers_nan_mask_weights_from_nested_losses(monkeypatch):
                 "scalers": ["*"],
             },
         ),
-        scalers={"nan_mask_weights": ((0, 3, 4), torch.ones(1, 3, 2))},
+        scalers={
+            "nan_mask_weights": ScalerSpec(
+                (0, 3, 4),
+                torch.ones(1, 3, 2),
+                ScalerDomain.SPATIAL,
+            ),
+        },
         data_indices=data_indices,
     )
 

--- a/training/tests/unit/losses/test_aggregate_loss.py
+++ b/training/tests/unit/losses/test_aggregate_loss.py
@@ -15,6 +15,7 @@ from anemoi.training.losses.base import BaseLoss
 from anemoi.training.losses.kcrps import CRPS
 from anemoi.training.losses.mae import MAELoss
 from anemoi.training.losses.multiscale import MultiscaleLossWrapper
+from anemoi.training.losses.scaler_tensor import ScalerDomain
 from anemoi.training.utils.enums import TensorDim
 
 # ---------------------------------------------------------------------------
@@ -25,14 +26,14 @@ from anemoi.training.utils.enums import TensorDim
 def _make_loss() -> MAELoss:
     """Return an MAE loss with a unit grid scaler (4 grid points)."""
     loss = MAELoss()
-    loss.add_scaler(TensorDim.GRID, torch.ones(4), name="unit_grid")
+    loss.add_scaler(TensorDim.GRID, torch.ones(4), grid_domain=ScalerDomain.SPATIAL, name="unit_grid")
     return loss
 
 
 def _make_crps_loss() -> CRPS:
     """Return a CRPS loss with a unit grid scaler (4 grid points)."""
     loss = CRPS(no_autocast=False)
-    loss.add_scaler(TensorDim.GRID, torch.ones(4), name="unit_grid")
+    loss.add_scaler(TensorDim.GRID, torch.ones(4), grid_domain=ScalerDomain.SPATIAL, name="unit_grid")
     return loss
 
 
@@ -386,7 +387,7 @@ def test_nested_add_scaler_reaches_leaf() -> None:
     leaf = MAELoss()
     ms = _make_multiscale_wrapper(leaf)
     wrapper = TimeAggregateLossWrapper(["mean"], ms)
-    wrapper.add_scaler(TensorDim.GRID, torch.ones(4), name="grid_w")
+    wrapper.add_scaler(TensorDim.GRID, torch.ones(4), grid_domain=ScalerDomain.SPATIAL, name="grid_w")
     assert leaf.scaler.has_scaler_for_dim(TensorDim.GRID)
 
 
@@ -413,8 +414,18 @@ def test_combined_loss_scaler_reaches_wrapped_inner() -> None:
 
     # Verify that add_scaler on the wrapper propagates to the inner loss
     grid_scaler = torch.ones(4)
-    wrapper.add_scaler(TensorDim.GRID, grid_scaler, name="node_weights")
-    inner1.add_scaler(TensorDim.GRID, grid_scaler, name="node_weights")
+    wrapper.add_scaler(
+        TensorDim.GRID,
+        grid_scaler,
+        grid_domain=ScalerDomain.SPATIAL,
+        name="node_weights",
+    )
+    inner1.add_scaler(
+        TensorDim.GRID,
+        grid_scaler,
+        grid_domain=ScalerDomain.SPATIAL,
+        name="node_weights",
+    )
 
     # Both leaf losses should have the scaler
     assert inner1.scaler.has_scaler_for_dim(TensorDim.GRID)

--- a/training/tests/unit/losses/test_combined_loss.py
+++ b/training/tests/unit/losses/test_combined_loss.py
@@ -25,6 +25,8 @@ from anemoi.training.losses import SpectralCRPSLoss
 from anemoi.training.losses import WeightedMSELoss
 from anemoi.training.losses import get_loss_function
 from anemoi.training.losses.multiscale import MultiscaleLossWrapper
+from anemoi.training.losses.scaler_tensor import ScalerDomain
+from anemoi.training.losses.scaler_tensor import ScalerSpec
 from anemoi.training.losses.variable_mapper import LossVariableMapper
 from anemoi.training.utils.index_space import IndexSpace
 
@@ -50,7 +52,7 @@ def test_combined_loss() -> None:
                 "loss_weights": [1.0, 0.5],
             },
         ),
-        scalers={"test": (-1, torch.ones(2))},
+        scalers={"test": ScalerSpec((-1,), torch.ones(2))},
     )
     assert isinstance(loss.losses[0], MSELoss)
     assert "test" in loss.losses[0].scaler
@@ -73,7 +75,7 @@ def test_combined_loss_invalid_loss_weights() -> None:
                     "loss_weights": [1.0, 0.5, 1],
                 },
             ),
-            scalers={"test": (-1, torch.ones(2))},
+            scalers={"test": ScalerSpec((-1,), torch.ones(2))},
         )
 
 
@@ -107,7 +109,10 @@ def test_combined_loss_seperate_scalers() -> None:
                 "loss_weights": [1.0, 0.5],
             },
         ),
-        scalers={"test": (-1, torch.ones(2)), "test2": (-1, torch.ones(2))},
+        scalers={
+            "test": ScalerSpec((-1,), torch.ones(2)),
+            "test2": ScalerSpec((-1,), torch.ones(2)),
+        },
     )
     assert isinstance(loss, CombinedLoss)
 
@@ -208,9 +213,9 @@ def test_combined_loss_with_filtered_target_only_subloss_preserves_scaler_remapp
             },
         ),
         scalers={
-            "grid_uniform": (3, torch.ones(4)),
+            "grid_uniform": ScalerSpec((3,), torch.ones(4), ScalerDomain.SPATIAL),
             # dynamic has one value per DATA_FULL variable: tp=2, f0=99(ignored), t2m=3, msl=5, imerg=7
-            "dynamic": (4, torch.tensor([2.0, 99.0, 3.0, 5.0, 7.0])),
+            "dynamic": ScalerSpec((4,), torch.tensor([2.0, 99.0, 3.0, 5.0, 7.0])),
         },
         data_indices=data_indices,
     )
@@ -221,12 +226,12 @@ def test_combined_loss_with_filtered_target_only_subloss_preserves_scaler_remapp
 
     # First subloss predicts [tp, t2m, msl] → dynamic scaler filtered to [2.0, 3.0, 5.0]
     torch.testing.assert_close(
-        loss.losses[0].loss.scaler.tensors["dynamic"][1],
+        loss.losses[0].loss.scaler.tensors["dynamic"].tensor,
         torch.tensor([2.0, 3.0, 5.0]),
     )
     # Second subloss predicts [tp] → dynamic scaler filtered to [2.0]
     torch.testing.assert_close(
-        loss.losses[1].loss.scaler.tensors["dynamic"][1],
+        loss.losses[1].loss.scaler.tensors["dynamic"].tensor,
         torch.tensor([2.0]),
     )
 

--- a/training/tests/unit/losses/test_filtered_loss.py
+++ b/training/tests/unit/losses/test_filtered_loss.py
@@ -18,6 +18,8 @@ from anemoi.training.losses import MSELoss
 from anemoi.training.losses import get_loss_function
 from anemoi.training.losses.base import BaseLoss
 from anemoi.training.losses.multiscale import MultiscaleLossWrapper
+from anemoi.training.losses.scaler_tensor import ScalerDomain
+from anemoi.training.losses.scaler_tensor import ScalerSpec
 from anemoi.training.losses.variable_mapper import LossVariableMapper
 from anemoi.training.utils.index_space import IndexSpace
 from anemoi.training.utils.variables_metadata import ExtractVariableGroupAndLevel
@@ -39,8 +41,8 @@ def test_instantiation_with_filtering() -> None:
             },
         ),
         scalers={
-            "grid_uniform": (3, torch.ones(4)),
-            "dynamic": (4, torch.tensor([2.0, 7.0, 11.0])),
+            "grid_uniform": ScalerSpec((3,), torch.ones(4), ScalerDomain.SPATIAL),
+            "dynamic": ScalerSpec((4,), torch.tensor([2.0, 7.0, 11.0])),
         },
         data_indices=data_indices,
     )
@@ -49,7 +51,7 @@ def test_instantiation_with_filtering() -> None:
     assert IndexSpace.MODEL_OUTPUT in loss.predicted_indices_by_layout
     assert loss.predicted_indices_by_layout[IndexSpace.MODEL_OUTPUT] == [0]
     assert loss.target_indices_by_layout[IndexSpace.DATA_FULL] == [2]
-    torch.testing.assert_close(loss.loss.scaler.tensors["dynamic"][1], torch.tensor([2.0]))
+    torch.testing.assert_close(loss.loss.scaler.tensors["dynamic"].tensor, torch.tensor([2.0]))
 
     pred = torch.ones((1, 1, 1, 4, 1))
     target = torch.zeros((1, 1, 1, 4, len(name_to_index)))
@@ -65,7 +67,7 @@ def test_instantiation_with_filtering() -> None:
     torch.testing.assert_close(loss_total, torch.tensor(32.0))
 
     loss.update_scaler("dynamic", torch.tensor([13.0, 17.0, 19.0]), override=True)
-    torch.testing.assert_close(loss.loss.scaler.tensors["dynamic"][1], torch.tensor([13.0]))
+    torch.testing.assert_close(loss.loss.scaler.tensors["dynamic"].tensor, torch.tensor([13.0]))
 
 
 def test_instantiation_with_filtering_requires_layout_kwargs() -> None:
@@ -251,16 +253,26 @@ class TestVariableAxisScalerFiltering:
         """Multi-dim (BATCH, GRID, VARIABLE) scaler is sliced on the VARIABLE axis."""
         w = _mapper(data_indices_forcing_gaps, ["var_0"], ["imerg"])
         n_model_vars = len(data_indices_forcing_gaps.model.output.full)
-        w.add_scaler(dimension=(0, 3, 4), scaler=torch.ones(2, 8, n_model_vars), name="mixed")
+        w.add_scaler(
+            dimension=(0, 3, 4),
+            scaler=torch.ones(2, 8, n_model_vars),
+            grid_domain=ScalerDomain.SPATIAL,
+            name="mixed",
+        )
 
-        assert w.loss.scaler.tensors["mixed"][1].shape == (2, 8, 1)
+        assert w.loss.scaler.tensors["mixed"].tensor.shape == (2, 8, 1)
 
     def test_broadcast_variable_axis_untouched(self, data_indices_forcing_gaps: IndexCollection) -> None:
         """Broadcast VARIABLE axis (size 1) must not be index-selected."""
         w = _mapper(data_indices_forcing_gaps, ["var_0"], ["imerg"])
-        w.add_scaler(dimension=(0, 3, 4), scaler=torch.ones(2, 8, 1), name="bc")
+        w.add_scaler(
+            dimension=(0, 3, 4),
+            scaler=torch.ones(2, 8, 1),
+            grid_domain=ScalerDomain.SPATIAL,
+            name="bc",
+        )
 
-        assert w.loss.scaler.tensors["bc"][1].shape == (2, 8, 1)
+        assert w.loss.scaler.tensors["bc"].tensor.shape == (2, 8, 1)
 
     def test_data_full_scaler_with_forcing_gap(self) -> None:
         """DATA_FULL-sized scaler correctly resolves through forcing gaps."""
@@ -272,16 +284,16 @@ class TestVariableAxisScalerFiltering:
         w.add_scaler(dimension=4, scaler=torch.tensor([10.0, 20.0, 30.0]), name="full")
 
         # var_1 is at data-full index 2 → value 30.0
-        torch.testing.assert_close(w.loss.scaler.tensors["full"][1], torch.tensor([30.0]))
+        torch.testing.assert_close(w.loss.scaler.tensors["full"].tensor, torch.tensor([30.0]))
 
     def test_update_scaler_refilters(self, data_indices_forcing_gaps: IndexCollection) -> None:
         """update_scaler with override re-applies VARIABLE-axis filtering."""
         w = _mapper(data_indices_forcing_gaps, ["var_2"])
         w.add_scaler(dimension=4, scaler=torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0]), name="vw")
-        torch.testing.assert_close(w.loss.scaler.tensors["vw"][1], torch.tensor([3.0]))
+        torch.testing.assert_close(w.loss.scaler.tensors["vw"].tensor, torch.tensor([3.0]))
 
         w.update_scaler("vw", torch.tensor([10.0, 20.0, 30.0, 40.0, 50.0]), override=True)
-        torch.testing.assert_close(w.loss.scaler.tensors["vw"][1], torch.tensor([30.0]))
+        torch.testing.assert_close(w.loss.scaler.tensors["vw"].tensor, torch.tensor([30.0]))
 
 
 # --- variable ordering and defaults ------------------------------------------
@@ -303,12 +315,12 @@ def test_scaler_preserves_reversed_variable_order() -> None:
                 "scalers": ["pl"],
             },
         ),
-        scalers={"pl": (4, torch.tensor([0.1 * (i + 1) for i in range(11)]))},
+        scalers={"pl": ScalerSpec((4,), torch.tensor([0.1 * (i + 1) for i in range(11)]))},
         data_indices=di,
     )
 
     expected = torch.tensor([0.1 * (i + 1) for i in range(9, -1, -1)])
-    torch.testing.assert_close(loss.loss.scaler.tensors["pl"][1], expected)
+    torch.testing.assert_close(loss.loss.scaler.tensors["pl"].tensor, expected)
 
 
 def test_default_target_inherits_predicted_order(data_indices_forcing_gaps: IndexCollection) -> None:
@@ -367,7 +379,12 @@ class TestScalerIndicesRemapping:
     def test_global_to_local_remap(self, data_indices_forcing_gaps: IndexCollection) -> None:
         """Global scaler_indices are translated to filtered-tensor-local positions."""
         w = _mapper(data_indices_forcing_gaps, ["var_0", "var_3"])
-        w.add_scaler(dimension=3, scaler=torch.ones(8), name="grid")
+        w.add_scaler(
+            dimension=3,
+            scaler=torch.ones(8),
+            grid_domain=ScalerDomain.SPATIAL,
+            name="grid",
+        )
         w.add_scaler(dimension=4, scaler=torch.tensor([2.0, 3.0]), name="var_w")
 
         pred = torch.zeros(1, 1, 1, 8, 6)
@@ -449,7 +466,12 @@ class TestScalerIndicesRemapping:
     def test_empty_remap_returns_zero(self, data_indices_forcing_gaps: IndexCollection) -> None:
         """scaler_indices selecting no filtered variables → zero tensor."""
         w = _mapper(data_indices_forcing_gaps, ["var_0"])
-        w.add_scaler(dimension=3, scaler=torch.ones(8), name="grid")
+        w.add_scaler(
+            dimension=3,
+            scaler=torch.ones(8),
+            grid_domain=ScalerDomain.SPATIAL,
+            name="grid",
+        )
         w.add_scaler(dimension=4, scaler=torch.tensor([2.0]), name="var_w")
 
         pred = torch.zeros(1, 1, 1, 8, 6)
@@ -473,7 +495,12 @@ class TestScalerIndicesRemapping:
     ) -> None:
         """Partially dropped scaler indices should be visible at DEBUG level."""
         w = _mapper(data_indices_forcing_gaps, ["var_0", "var_3"])
-        w.add_scaler(dimension=3, scaler=torch.ones(8), name="grid")
+        w.add_scaler(
+            dimension=3,
+            scaler=torch.ones(8),
+            grid_domain=ScalerDomain.SPATIAL,
+            name="grid",
+        )
         w.add_scaler(dimension=4, scaler=torch.tensor([2.0, 3.0]), name="var_w")
 
         pred = torch.zeros(1, 1, 1, 8, 6)
@@ -499,7 +526,12 @@ class TestScalerIndicesRemapping:
     ) -> None:
         """Fully dropped scaler indices should warn because forward returns zeros."""
         w = _mapper(data_indices_forcing_gaps, ["var_0"])
-        w.add_scaler(dimension=3, scaler=torch.ones(8), name="grid")
+        w.add_scaler(
+            dimension=3,
+            scaler=torch.ones(8),
+            grid_domain=ScalerDomain.SPATIAL,
+            name="grid",
+        )
         w.add_scaler(dimension=4, scaler=torch.tensor([2.0]), name="var_w")
 
         pred = torch.zeros(1, 1, 1, 8, 6)

--- a/training/tests/unit/losses/test_loss_function.py
+++ b/training/tests/unit/losses/test_loss_function.py
@@ -33,6 +33,8 @@ from anemoi.training.losses import WeightedMSELoss
 from anemoi.training.losses import get_loss_function
 from anemoi.training.losses.base import BaseLoss
 from anemoi.training.losses.base import FunctionalLoss
+from anemoi.training.losses.scaler_tensor import ScalerDomain
+from anemoi.training.losses.scaler_tensor import ScalerSpec
 from anemoi.training.train.methods.base import BaseTrainingModule
 from anemoi.training.utils.enums import TensorDim
 
@@ -202,7 +204,12 @@ def test_scale_subset_indices_requires_tuple(
 ) -> None:
     loss = functionalloss()
     if add_grid_scaler:
-        loss.add_scaler(TensorDim.GRID, torch.tensor([1.0, 2.0, 3.0, 4.0]), name="grid_test")
+        loss.add_scaler(
+            TensorDim.GRID,
+            torch.tensor([1.0, 2.0, 3.0, 4.0]),
+            grid_domain=ScalerDomain.SPATIAL,
+            name="grid_test",
+        )
 
     x = torch.arange(1 * 1 * 1 * 4 * 5, dtype=torch.float32).reshape(1, 1, 1, 4, 5)
     with pytest.raises(TypeError, match="must be a tuple"):
@@ -212,21 +219,26 @@ def test_scale_subset_indices_requires_tuple(
 @pytest.fixture
 def simple_functionalloss(functionalloss: type[FunctionalLoss]) -> FunctionalLoss:
     loss = functionalloss()
-    loss.add_scaler(TensorDim.GRID, torch.ones((4,)), name="unit_scaler")
+    loss.add_scaler(
+        TensorDim.GRID,
+        torch.ones((4,)),
+        grid_domain=ScalerDomain.SPATIAL,
+        name="unit_scaler",
+    )
     return loss
 
 
 @pytest.fixture
 def functionalloss_with_scaler(simple_functionalloss: FunctionalLoss) -> FunctionalLoss:
     loss = simple_functionalloss
-    loss.add_scaler(TensorDim.GRID, torch.rand((4,)), name="test")
+    loss.add_scaler(TensorDim.GRID, torch.rand((4,)), grid_domain=ScalerDomain.SPATIAL, name="test")
     return loss
 
 
 @pytest.fixture
 def functionalloss_with_scaler_fine(functionalloss: FunctionalLoss) -> FunctionalLoss:
     loss = functionalloss()
-    loss.add_scaler(TensorDim.GRID, torch.rand((8,)), name="test")
+    loss.add_scaler(TensorDim.GRID, torch.rand((8,)), grid_domain=ScalerDomain.SPATIAL, name="test")
     return loss
 
 
@@ -380,7 +392,7 @@ def test_dynamic_init_scaler(loss_cls: type[BaseLoss]) -> None:
     }
     loss = get_loss_function(
         DictConfig(loss_dic),
-        scalers={"test": ((0, 1), torch.ones((1, 2)))},
+        scalers={"test": ScalerSpec((0, 1), torch.ones((1, 2)))},
     )
     assert isinstance(loss, BaseLoss)
 
@@ -401,7 +413,7 @@ def test_dynamic_init_add_all(loss_cls: type[BaseLoss]) -> None:
     }
     loss = get_loss_function(
         DictConfig(loss_dic),
-        scalers={"test": ((0, 1), torch.ones((1, 2)))},
+        scalers={"test": ScalerSpec((0, 1), torch.ones((1, 2)))},
     )
     assert isinstance(loss, BaseLoss)
 
@@ -422,7 +434,7 @@ def test_dynamic_init_scaler_not_add(loss_cls: type[BaseLoss]) -> None:
     }
     loss = get_loss_function(
         DictConfig(loss_dic),
-        scalers={"test": (-1, torch.ones(2))},
+        scalers={"test": ScalerSpec((-1,), torch.ones(2))},
     )
     assert isinstance(loss, BaseLoss)
     assert "test" not in loss.scaler
@@ -441,7 +453,7 @@ def test_dynamic_init_scaler_exclude(loss_cls: type[BaseLoss]) -> None:
     }
     loss = get_loss_function(
         DictConfig(loss_dic),
-        scalers={"test": (-1, torch.ones(2))},
+        scalers={"test": ScalerSpec((-1,), torch.ones(2))},
     )
     assert isinstance(loss, BaseLoss)
     assert "test" not in loss.scaler
@@ -530,6 +542,12 @@ def test_spectral_losses_use_all_to_all_for_sharded_layout(
     local_grid = grid_shard_sizes[0]
 
     loss = loss_cls(**transform_kwargs)
+    loss.add_scaler(
+        TensorDim.GRID,
+        torch.ones(sum(spectral_shard_sizes)),
+        grid_domain=ScalerDomain.SPECTRAL,
+        name="spectral",
+    )
     pred = torch.randn(1, 1, ensemble_size, local_grid, 2)
     target = torch.randn(1, 1, 1, local_grid, 2)
 
@@ -557,6 +575,7 @@ def test_spectral_losses_use_all_to_all_for_sharded_layout(
         side_effect=fake_all_to_all,
     )
     mocker.patch("anemoi.training.losses.base.reduce_tensor", side_effect=lambda x, _group: x)
+    mocker.patch("anemoi.training.losses.spectral.torch.distributed.get_rank", return_value=0)
     scale = mocker.spy(loss, "scale")
 
     out = loss(
@@ -596,7 +615,98 @@ def test_spectral_losses_use_all_to_all_for_sharded_layout(
         channel_shard_sizes,
         group,
     )
-    assert scale.call_args.kwargs["grid_shard_slice"] is None
+    assert scale.call_args.kwargs["grid_shard_slice"] == slice(0, spectral_shard_sizes[0])
+
+
+def test_spectral_loss_rejects_spatial_grid_scaler_even_when_lengths_match() -> None:
+    loss = LogSpectralDistance(transform="fft2d", x_dim=4, y_dim=4)
+
+    with pytest.raises(ValueError, match="uses the spatial grid domain"):
+        loss.add_scaler(
+            TensorDim.GRID,
+            torch.ones(16),
+            grid_domain=ScalerDomain.SPATIAL,
+            name="node_weights",
+        )
+
+
+def test_spatial_loss_rejects_spectral_grid_scaler() -> None:
+    loss = MSELoss()
+
+    with pytest.raises(ValueError, match="requires spatial grid scalers"):
+        loss.add_scaler(
+            TensorDim.GRID,
+            torch.ones(16),
+            grid_domain=ScalerDomain.SPECTRAL,
+            name="spectral",
+        )
+
+
+def test_spectral_loss_applies_matching_spectral_grid_scaler() -> None:
+    loss = LogSpectralDistance(transform="fft2d", x_dim=4, y_dim=4)
+    loss.add_scaler(
+        TensorDim.GRID,
+        torch.linspace(0.5, 1.5, 16),
+        grid_domain=ScalerDomain.SPECTRAL,
+        name="spectral",
+    )
+    pred = torch.rand(1, 1, 1, 16, 1)
+    target = torch.rand_like(pred)
+
+    out = loss(pred, target)
+
+    assert torch.isfinite(out)
+
+
+def test_spectral_loss_validates_only_active_scalers() -> None:
+    loss = LogSpectralDistance(transform="fft2d", x_dim=4, y_dim=4)
+    loss.add_scaler(
+        TensorDim.GRID,
+        torch.ones(15),
+        grid_domain=ScalerDomain.SPECTRAL,
+        name="wrong_size",
+    )
+    pred = torch.ones(1, 1, 1, 16, 1)
+    target = torch.ones_like(pred)
+
+    with pytest.raises(ValueError, match="global spectral dimension of size 16"):
+        loss(pred, target)
+
+    out = loss(pred, target, without_scalers=["wrong_size"])
+    assert torch.isfinite(out)
+
+
+def test_reshard_spectral_loss_returns_global_slice_for_uneven_shards(mocker: MockerFixture) -> None:
+    loss = LogSpectralDistance(transform="fft2d", x_dim=4, y_dim=4)
+    group = object()
+    spectral_shard_sizes = [9, 7]
+    full_loss = torch.zeros(1, 1, 1, 16, 1)
+    local_loss = torch.zeros(1, 1, 1, 7, 1)
+    mocker.patch("anemoi.training.losses.spectral.get_shard_sizes", return_value=spectral_shard_sizes)
+    mocker.patch("anemoi.training.losses.spectral.torch.distributed.get_rank", return_value=1)
+    transpose = mocker.patch(
+        "anemoi.training.losses.spectral.all_to_all_transpose",
+        return_value=local_loss,
+    )
+
+    result, spectral_slice, global_spectral_size = loss._reshard_spectral_loss(
+        full_loss,
+        group,
+        channel_shard_sizes=[1, 1],
+        spectral_grid_dim=TensorDim.GRID,
+    )
+
+    assert result is local_loss
+    assert spectral_slice == slice(9, 16)
+    assert global_spectral_size == 16
+    transpose.assert_called_once_with(
+        full_loss,
+        TensorDim.GRID,
+        spectral_shard_sizes,
+        TensorDim.VARIABLE,
+        [1, 1],
+        group,
+    )
 
 
 @pytest.mark.parametrize("loss_cls", spectral_losses)

--- a/training/tests/unit/losses/test_loss_scaling.py
+++ b/training/tests/unit/losses/test_loss_scaling.py
@@ -412,7 +412,7 @@ def test_tendency_scaler_uses_configured_timestep(
 
     variable_idx = data_indices.model.output.name_to_index["y_50"]
 
-    assert scalers["additional_scaler"][1][variable_idx] == expected_scaling
+    assert scalers["additional_scaler"].tensor[variable_idx] == expected_scaling
 
 
 @pytest.mark.parametrize("fake_data", [linear_scaler], indirect=["fake_data"])
@@ -470,17 +470,19 @@ def test_updating_scalars(mock_updating_scalar: type[BaseUpdatingScaler]) -> Non
     assert isinstance(scalar.get_scaling_values(), torch.Tensor)
 
     assert scalar.get_scaling() is not None
-    assert scalar.get_scaling()[1] == torch.Tensor([1.0]), "Scalar values should be from the initial scaling values."
+    assert scalar.get_scaling().tensor == torch.Tensor(
+        [1.0],
+    ), "Scalar values should be from the initial scaling values."
 
     assert scalar.on_training_start(None) == torch.Tensor([2.0])
     updated_scaling = scalar.update_scaling_values(callback="on_training_start", model=None)
-    assert updated_scaling is not None and updated_scaling[1] == torch.Tensor(
+    assert updated_scaling is not None and updated_scaling.tensor == torch.Tensor(
         [2.0],
     ), "Scalar values should be updated after on_training_start."
 
     assert scalar.on_batch_start(None) == torch.Tensor([3.0])
     updated_scaling = scalar.update_scaling_values(callback="on_batch_start", model=None)
-    assert updated_scaling is not None and updated_scaling[1] == torch.Tensor(
+    assert updated_scaling is not None and updated_scaling.tensor == torch.Tensor(
         [3.0],
     ), "Scalar values should be updated after on_batch_start."
 
@@ -507,12 +509,14 @@ def test_variable_masking(
     vars_to_mask = ["z", "other", "q"]
     indices_to_mask = [data_indices.model.output.name_to_index[v] for v in vars_to_mask]
     scaler = scalers["variable_masking"]
-    assert scaler[0][0] == TensorDim.VARIABLE.value, "Expected scaler to be applied along variable dimension"
+    assert scaler.dimensions[0] == TensorDim.VARIABLE.value, "Expected scaler to be applied along variable dimension"
     # masked variables should have scaler of 0, unmasked 1
-    assert int(scaler[1].sum().item()) == scaler[1].shape[0] - len(
+    assert int(scaler.tensor.sum().item()) == scaler.tensor.shape[0] - len(
         vars_to_mask,
     ), "Sum of scaler values should be equal to number of unmasked variables"
-    assert not scalers["variable_masking"][1][indices_to_mask].any(), "Expected scalers for masked variables to be zero"
+    assert (
+        not scalers["variable_masking"].tensor[indices_to_mask].any()
+    ), "Expected scalers for masked variables to be zero"
 
     config.training.scalers.builders["variable_masking"].update(invert=True)
     scalers, _ = create_scalers(
@@ -526,10 +530,10 @@ def test_variable_masking(
     )
     inverted_scaler = scalers["variable_masking"]
     # dimension where scaler is applied is variable
-    assert inverted_scaler[0][0] == TensorDim.VARIABLE.value
+    assert inverted_scaler.dimensions[0] == TensorDim.VARIABLE.value
     # masked variables with inverted = True should have scaler of 1, unmasked 0
-    assert int(inverted_scaler[1].sum().item()) == len(vars_to_mask)
-    assert inverted_scaler[1][indices_to_mask].all(), "Expected scalers for unmasked variables to be one"
+    assert int(inverted_scaler.tensor.sum().item()) == len(vars_to_mask)
+    assert inverted_scaler.tensor[indices_to_mask].all(), "Expected scalers for unmasked variables to be one"
 
 
 def test_variable_loss_scaling_val_complex_variable_groups(

--- a/training/tests/unit/losses/test_multiscale_loss.py
+++ b/training/tests/unit/losses/test_multiscale_loss.py
@@ -20,6 +20,7 @@ from anemoi.training.losses import MSELoss
 from anemoi.training.losses.base import BaseLoss
 from anemoi.training.losses.loss import get_loss_function
 from anemoi.training.losses.multiscale import MultiscaleLossWrapper
+from anemoi.training.losses.scaler_tensor import ScalerDomain
 from anemoi.training.utils.enums import TensorDim
 from anemoi.training.utils.index_space import IndexSpace
 
@@ -215,7 +216,12 @@ def test_multiscale_loss_forwards_scaler_indices() -> None:
     target = torch.zeros((1, 1, 1, 2, 2))
 
     per_scale_loss = MSELoss()
-    per_scale_loss.add_scaler(TensorDim.GRID, torch.ones(2), name="grid_weights")
+    per_scale_loss.add_scaler(
+        TensorDim.GRID,
+        torch.ones(2),
+        grid_domain=ScalerDomain.SPATIAL,
+        name="grid_weights",
+    )
     multiscale_loss = MultiscaleLossWrapper(
         per_scale_loss=per_scale_loss,
         weights=[1.0],

--- a/training/tests/unit/losses/test_scaler.py
+++ b/training/tests/unit/losses/test_scaler.py
@@ -10,31 +10,40 @@
 import pytest
 import torch
 
+from anemoi.training.losses.scaler_tensor import ScalerSpec
 from anemoi.training.losses.scaler_tensor import ScaleTensor
 
 
+def _spec(dimensions: int | tuple[int, ...], values) -> ScalerSpec:  # noqa: ANN001
+    values = values if isinstance(values, torch.Tensor) else torch.as_tensor(values)
+    if values.ndim == 0:
+        values = values.reshape(1)
+    dimensions = (dimensions,) if isinstance(dimensions, int) else dimensions
+    return ScalerSpec(dimensions, values)
+
+
 def test_scale_contains() -> None:
-    scale = ScaleTensor(test=(0, 2))
+    scale = ScaleTensor(test=_spec(0, 2))
     assert "test" in scale
 
 
 def test_scale_contains_indexing() -> None:
-    scale = ScaleTensor(test=(0, 2))
+    scale = ScaleTensor(test=_spec(0, 2))
     assert 0 in scale
 
 
 def test_scale_tuple_contains_indexing() -> None:
-    scale = ScaleTensor(test=((0, 1), 2))
+    scale = ScaleTensor(test=_spec((0, 1), 2))
     assert (0, 1) in scale
 
 
 def test_scale_tuple_not_contains_indexing() -> None:
-    scale = ScaleTensor(test=(0, 2))
+    scale = ScaleTensor(test=_spec(0, 2))
     assert (0, 1) not in scale
 
 
 def test_scale_contains_subset_indexing() -> None:
-    scale = ScaleTensor(test=(0, 2), wow=(0, 2))
+    scale = ScaleTensor(test=_spec(0, 2), wow=_spec(0, 2))
     assert "test" in scale
     scale = scale.subset("wow")
     assert "wow" in scale
@@ -42,7 +51,7 @@ def test_scale_contains_subset_indexing() -> None:
 
 
 def test_scale_contains_subset_by_dim_indexing() -> None:
-    scale = ScaleTensor(test=(0, 2), wow=(1, 2))
+    scale = ScaleTensor(test=_spec(0, 2), wow=_spec(1, 2))
     assert "test" in scale
     scale = scale.subset_by_dim(1)
     assert "wow" in scale
@@ -50,26 +59,26 @@ def test_scale_contains_subset_by_dim_indexing() -> None:
 
 
 def test_scale_resolve() -> None:
-    scale = ScaleTensor(test=(-1, 2))
+    scale = ScaleTensor(test=_spec(-1, 2))
     scale = scale.resolve(4)
     assert 3 in scale
     assert -1 not in scale
 
 
 def test_add_existing_scaler() -> None:
-    scale = ScaleTensor(test=(0, torch.tensor([2.0])))
+    scale = ScaleTensor(test=_spec(0, torch.tensor([2.0])))
     with pytest.raises(ValueError, match=r".*already exists.*"):
         scale.add_scaler(0, torch.tensor(3.0), name="test")
 
 
 def test_update_scaler() -> None:
-    scale = ScaleTensor(test=(0, torch.ones(2)))
+    scale = ScaleTensor(test=_spec(0, torch.ones(2)))
     scale.update_scaler("test", torch.tensor([3.0]))
-    torch.testing.assert_close(scale.tensors["test"][1], torch.tensor([3.0]))
+    torch.testing.assert_close(scale.tensors["test"].tensor, torch.tensor([3.0]))
 
 
 def test_update_missing_scaler() -> None:
-    scale = ScaleTensor(test=(0, torch.ones(2)))
+    scale = ScaleTensor(test=_spec(0, torch.ones(2)))
     with pytest.raises(ValueError, match=r".*not found in scalers.*"):
         scale.update_scaler("test_missing", torch.tensor([3.0]))
     assert "test" in scale
@@ -77,7 +86,7 @@ def test_update_missing_scaler() -> None:
 
 
 def test_update_scaler_wrong_dim_allow_override() -> None:
-    scale = ScaleTensor(test=(0, torch.ones((2, 3))))
+    scale = ScaleTensor(test=_spec(0, torch.ones((2, 3))))
     assert scale.update_scaler("test", torch.ones((2, 2)), override=True) is None
 
 
@@ -181,8 +190,8 @@ def test_scale_tensor_subset_indices_requires_tuple(method_name: str) -> None:
 @pytest.mark.parametrize("method_name", ["scale", "scale_iteratively"])
 def test_scale_tensor_subset_indices_select_last_dimension(method_name: str) -> None:
     scale = ScaleTensor(
-        batch=(0, torch.tensor([10.0, 20.0])),
-        variable=(-1, torch.tensor([1.0, 2.0, 3.0, 4.0])),
+        batch=_spec(0, torch.tensor([10.0, 20.0])),
+        variable=_spec(-1, torch.tensor([1.0, 2.0, 3.0, 4.0])),
     )
     x = torch.arange(2 * 3 * 4, dtype=torch.float32).reshape(2, 3, 4)
     subset_indices = (..., torch.tensor([0, 2]))
@@ -197,8 +206,8 @@ def test_scale_tensor_subset_indices_select_last_dimension(method_name: str) -> 
 @pytest.mark.parametrize("method_name", ["scale", "scale_iteratively"])
 def test_scale_tensor_subset_indices_select_first_dimension(method_name: str) -> None:
     scale = ScaleTensor(
-        batch=(0, torch.tensor([10.0, 20.0])),
-        variable=(-1, torch.tensor([1.0, 2.0, 3.0, 4.0])),
+        batch=_spec(0, torch.tensor([10.0, 20.0])),
+        variable=_spec(-1, torch.tensor([1.0, 2.0, 3.0, 4.0])),
     )
     x = torch.arange(2 * 3 * 4, dtype=torch.float32).reshape(2, 3, 4)
     subset_indices = ([1, 0],)
@@ -213,7 +222,7 @@ def test_scale_tensor_subset_indices_select_first_dimension(method_name: str) ->
 
 @pytest.mark.parametrize("subset_id", ["test", 0])
 def test_scaler_subset(subset_id) -> None:  # noqa: ANN001
-    scale = ScaleTensor(test=(0, torch.tensor([2.0])), wow=(1, torch.tensor([3.0])))
+    scale = ScaleTensor(test=_spec(0, torch.tensor([2.0])), wow=_spec(1, torch.tensor([3.0])))
     subset = scale.subset(subset_id)
     assert "test" in subset
     assert "wow" not in subset
@@ -223,7 +232,7 @@ def test_scaler_subset(subset_id) -> None:  # noqa: ANN001
 
 @pytest.mark.parametrize("without_id", ["test", 0])
 def test_scaler_subset_without(without_id: int) -> None:
-    scale = ScaleTensor(test=(0, torch.tensor([2.0])), wow=(1, torch.tensor([3.0])))
+    scale = ScaleTensor(test=_spec(0, torch.tensor([2.0])), wow=_spec(1, torch.tensor([3.0])))
     subset = scale.without(without_id)
     assert "test" not in subset
     assert "wow" in subset
@@ -232,7 +241,7 @@ def test_scaler_subset_without(without_id: int) -> None:
 
 @pytest.mark.parametrize("subset_id", [0, 1])
 def test_scaler_subset_by_dim(subset_id: int) -> None:
-    scale = ScaleTensor(test=(-2, torch.tensor([2.0])), wow=(-1, torch.tensor([3.0])))
+    scale = ScaleTensor(test=_spec(-2, torch.tensor([2.0])), wow=_spec(-1, torch.tensor([3.0])))
     scale = scale.resolve(2)
     subset1 = scale.subset(subset_id)
     assert subset_id in subset1
@@ -240,7 +249,7 @@ def test_scaler_subset_by_dim(subset_id: int) -> None:
 
 @pytest.mark.parametrize("without_id", ["test"])
 def test_scaler_subset_without_overlap(without_id) -> None:  # noqa: ANN001
-    scale = ScaleTensor(test=(0, torch.tensor([2.0])), wow=(0, torch.tensor([3.0])))
+    scale = ScaleTensor(test=_spec(0, torch.tensor([2.0])), wow=_spec(0, torch.tensor([3.0])))
     subset = scale.without(without_id)
     assert "test" not in subset
     assert "wow" in subset
@@ -248,7 +257,7 @@ def test_scaler_subset_without_overlap(without_id) -> None:  # noqa: ANN001
 
 
 def test_scaler_remove_str() -> None:
-    scale = ScaleTensor(test=(0, torch.tensor([2.0])), wow=(1, torch.tensor([3.0])))
+    scale = ScaleTensor(test=_spec(0, torch.tensor([2.0])), wow=_spec(1, torch.tensor([3.0])))
     subset = scale.remove_scaler("wow")
     assert "test" in subset
     assert "wow" not in subset
@@ -256,7 +265,7 @@ def test_scaler_remove_str() -> None:
 
 
 def test_scaler_remove_int() -> None:
-    scale = ScaleTensor(test=(0, torch.tensor([2.0])), wow=(1, torch.tensor([3.0])))
+    scale = ScaleTensor(test=_spec(0, torch.tensor([2.0])), wow=_spec(1, torch.tensor([3.0])))
     subset = scale.remove_scaler(1)
     assert "test" in subset
     assert "wow" not in subset
@@ -265,7 +274,7 @@ def test_scaler_remove_int() -> None:
 
 
 def test_scaler_freeze_str() -> None:
-    scale = ScaleTensor(test=(0, torch.tensor([2.0])), wow=(1, torch.tensor([3.0])))
+    scale = ScaleTensor(test=_spec(0, torch.tensor([2.0])), wow=_spec(1, torch.tensor([3.0])))
     with scale.freeze_state():
         subset = scale.remove_scaler("wow")
         assert "test" in subset
@@ -278,7 +287,7 @@ def test_scaler_freeze_str() -> None:
 
 
 def test_scaler_freeze_int() -> None:
-    scale = ScaleTensor(test=(0, torch.tensor([2.0])), wow=(1, torch.tensor([3.0])))
+    scale = ScaleTensor(test=_spec(0, torch.tensor([2.0])), wow=_spec(1, torch.tensor([3.0])))
     with scale.freeze_state():
         subset = scale.remove_scaler(1)
         assert "test" in subset


### PR DESCRIPTION
make sharding work with spectral loss scalers
some suggestions: introduce ScalerDomain.SPATIAL and SPECTRAL to distinguish scalers not only by size which could accidentally match.


<!-- readthedocs-preview anemoi-training start -->
----
📚 Documentation preview 📚: https://anemoi-training--1258.org.readthedocs.build/en/1258/

<!-- readthedocs-preview anemoi-training end -->

<!-- readthedocs-preview anemoi-graphs start -->
----
📚 Documentation preview 📚: https://anemoi-graphs--1258.org.readthedocs.build/en/1258/

<!-- readthedocs-preview anemoi-graphs end -->

<!-- readthedocs-preview anemoi-models start -->
----
📚 Documentation preview 📚: https://anemoi-models--1258.org.readthedocs.build/en/1258/

<!-- readthedocs-preview anemoi-models end -->