### PR TITLE
fix(training): expandable segments warning

### DIFF
--- a/training/src/anemoi/training/diagnostics/benchmark_server.py
+++ b/training/src/anemoi/training/diagnostics/benchmark_server.py
@@ -33,7 +33,6 @@ from pytorch_lightning.utilities.rank_zero import rank_zero_only
 from torch.cuda import memory_stats
 
 os.environ["ANEMOI_BASE_SEED"] = "42"  # need to set base seed if running on github runners
-os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"  # reduce memory fragmentation
 
 LOGGER = logging.getLogger(__name__)
 

--- a/training/src/anemoi/training/diagnostics/benchmark_server.py
+++ b/training/src/anemoi/training/diagnostics/benchmark_server.py
@@ -32,8 +32,6 @@ from omegaconf import DictConfig
 from pytorch_lightning.utilities.rank_zero import rank_zero_only
 from torch.cuda import memory_stats
 
-os.environ["ANEMOI_BASE_SEED"] = "42"  # need to set base seed if running on github runners
-
 LOGGER = logging.getLogger(__name__)
 
 BENCHMARK_SERVER_ARTIFACT_LIMIT = 10

--- a/training/src/anemoi/training/train/train.py
+++ b/training/src/anemoi/training/train/train.py
@@ -34,7 +34,6 @@ from anemoi.graphs.create import load_graph_from_file
 from anemoi.graphs.create import validate_loaded_graph
 from anemoi.graphs.projection_helpers import DEFAULT_DATASET_NAME
 from anemoi.graphs.projection_helpers import uses_fused_dataset_graph
-from anemoi.models.utils.compile import mark_for_compilation
 from anemoi.models.utils.config import get_multiple_datasets_config
 from anemoi.training.data.datamodule import AnemoiDatasetsDataModule
 from anemoi.training.diagnostics.callbacks import CallbacksContext
@@ -48,6 +47,7 @@ from anemoi.training.schemas.dataloader import DatasetConfigSchema
 from anemoi.training.tasks.base import BaseTask
 from anemoi.training.utils.checkpoint import freeze_submodule_by_name
 from anemoi.training.utils.checkpoint import transfer_learning_loading
+from anemoi.training.utils.compile import prepare_compilation
 from anemoi.training.utils.hydra import instantiate_with_runtime_kwargs
 from anemoi.training.utils.jsonify import map_config_to_primitives
 from anemoi.training.utils.seeding import get_base_seed
@@ -674,26 +674,6 @@ class AnemoiTrainer(ABC):
             )
             LOGGER.info("Dry run: %s", self.dry_run)
 
-    def prepare_compilation(self) -> None:
-
-        if hasattr(self.config.model, "compile"):
-            self.model = mark_for_compilation(self.model, self.config.model.compile)
-        recompile_limit = getattr(self.config.model, "recompile_limit", None)
-        if hasattr(self.config.training, "recompile_limit"):
-            LOGGER.warning(
-                "The recompile_limit in config.training is deprecated. "
-                "Please use config.model.recompile_limit instead.",
-            )
-            recompile_limit = getattr(self.config.training, "recompile_limit", None)
-        if recompile_limit is not None:
-            torch._dynamo.config.cache_size_limit = int(recompile_limit)
-            torch._dynamo.config.accumulated_cache_size_limit = max(8 * int(recompile_limit), 256)
-            LOGGER.info(
-                "Recompile limit set to %d per kernel, %d accumulated",
-                torch._dynamo.config.cache_size_limit,
-                torch._dynamo.config.accumulated_cache_size_limit,
-            )
-
     @cached_property
     def strategy(self) -> Any:
         return instantiate(
@@ -754,7 +734,7 @@ class AnemoiTrainer(ABC):
             check_val_every_n_epoch=getattr(self.config.diagnostics, "check_val_every_n_epoch", 1),
         )
 
-        self.prepare_compilation()
+        prepare_compilation(self.model, self.config.model, self.config.training)
 
         LOGGER.debug("Starting training..")
 

--- a/training/src/anemoi/training/train/train.py
+++ b/training/src/anemoi/training/train/train.py
@@ -743,7 +743,7 @@ class AnemoiTrainer(ABC):
             check_val_every_n_epoch=getattr(self.config.diagnostics, "check_val_every_n_epoch", 1),
         )
 
-        prepare_compilation(self.model, self.config.model, self.config.training)
+        self.model = prepare_compilation(self.model, self.config.model, self.config.training)
 
         LOGGER.debug("Starting training..")
 

--- a/training/src/anemoi/training/utils/compile.py
+++ b/training/src/anemoi/training/utils/compile.py
@@ -6,7 +6,15 @@
 # In applying this licence, ECMWF does not waive the privileges and immunities
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
+import logging
+import os
+
 import torch
+from omegaconf import DictConfig
+
+from anemoi.models.utils.compile import mark_for_compilation
+
+LOGGER = logging.getLogger(__name__)
 
 
 def subset_tensor(
@@ -57,3 +65,52 @@ def subset_tensor(
 
     # perform the subsetting using torch.index_select
     return torch.index_select(x, dim=subset_dim, index=subset_index), subset_index, subset_dim
+
+
+def check_env_and_warn() -> None:
+    """Reads env for settings which interfere with compilation and gives a warning.
+
+    checks 'PYTORCH_CUDA_ALLOC_CONF' for 'expandable_segments:true', this can cause
+    null pointer exceptions when compiling with certain versions of pytorch.
+    """
+    conf = os.environ.get("PYTORCH_CUDA_ALLOC_CONF", "")
+
+    # convert 'keyword1:value,keyword2:value,...' into a dict
+    options = dict(item.split(":", 1) for item in conf.split(",") if ":" in item)
+
+    # check if expandable segments is true
+    using_expandable_segments = options.get("expandable_segments", "False").lower() == "true"
+    if using_expandable_segments:
+        LOGGER.warning(
+            "You are using the 'expandable_segments' option for PyTorchs CUDA caching memory "
+            "allocator, alongside torch.compile()."
+            "This can cause null pointer exceptions at runtime 'RuntimeError: Expected "
+            "curr_block->next == nullptr to be true, but got false.'"
+            "To avoid this error, unset expandable segments e.g. 'unset PYTORCH_CUDA_ALLOC_CONF' "
+            "or try upgrading your PyTorch.",
+        )
+
+
+def prepare_compilation(
+    model: torch.nn.Module,
+    model_config: DictConfig,
+    training_config: DictConfig,
+) -> torch.nn.Module:
+    """Reads model_config and marks the matching submodules in model for compilation."""
+    if hasattr(model_config, "compile"):
+        model = mark_for_compilation(model, model_config.compile)
+    recompile_limit = getattr(model_config, "recompile_limit", None)
+    if hasattr(training_config, "recompile_limit"):
+        LOGGER.warning(
+            "The recompile_limit in config.training is deprecated. Please use config.model.recompile_limit instead.",
+        )
+        recompile_limit = getattr(training_config, "recompile_limit", None)
+    if recompile_limit is not None:
+        torch._dynamo.config.cache_size_limit = int(recompile_limit)
+        torch._dynamo.config.accumulated_cache_size_limit = max(8 * int(recompile_limit), 256)
+        LOGGER.info(
+            "Recompile limit set to %d per kernel, %d accumulated",
+            torch._dynamo.config.cache_size_limit,
+            torch._dynamo.config.accumulated_cache_size_limit,
+        )
+    return model

--- a/training/src/anemoi/training/utils/compile.py
+++ b/training/src/anemoi/training/utils/compile.py
@@ -99,6 +99,7 @@ def prepare_compilation(
     """Reads model_config and marks the matching submodules in model for compilation."""
     if hasattr(model_config, "compile"):
         model = mark_for_compilation(model, model_config.compile)
+        check_env_and_warn()  # warn if env settings interfere with compilation
     recompile_limit = getattr(model_config, "recompile_limit", None)
     if hasattr(training_config, "recompile_limit"):
         LOGGER.warning(

--- a/training/src/anemoi/training/utils/compile.py
+++ b/training/src/anemoi/training/utils/compile.py
@@ -76,7 +76,12 @@ def check_env_and_warn() -> None:
     conf = os.environ.get("PYTORCH_CUDA_ALLOC_CONF", "")
 
     # convert 'keyword1:value,keyword2:value,...' into a dict
-    options = dict(item.split(":", 1) for item in conf.split(",") if ":" in item)
+    options: dict[str, str] = {}
+    for item in conf.split(","):
+        if ":" not in item:
+            continue
+        key, value = (s.strip() for s in item.split(":", 1))
+        options[key] = value
 
     # check if expandable segments is true
     using_expandable_segments = options.get("expandable_segments", "False").lower() == "true"

--- a/training/src/anemoi/training/utils/compile.py
+++ b/training/src/anemoi/training/utils/compile.py
@@ -82,11 +82,11 @@ def check_env_and_warn() -> None:
     using_expandable_segments = options.get("expandable_segments", "False").lower() == "true"
     if using_expandable_segments:
         LOGGER.warning(
-            "You are using the 'expandable_segments' option for PyTorchs CUDA caching memory "
-            "allocator, alongside torch.compile()."
-            "This can cause null pointer exceptions at runtime 'RuntimeError: Expected "
-            "curr_block->next == nullptr to be true, but got false.'"
-            "To avoid this error, unset expandable segments e.g. 'unset PYTORCH_CUDA_ALLOC_CONF' "
+            "You are using the 'expandable_segments' option for PyTorch's CUDA caching memory "
+            "allocator, alongside torch.compile(). "
+            "This can cause null pointer exceptions at runtime: 'RuntimeError: Expected "
+            "curr_block->next == nullptr to be true, but got false.' "
+            "To avoid this error, unset expandable segments (e.g. 'unset PYTORCH_CUDA_ALLOC_CONF') "
             "or try upgrading your PyTorch.",
         )
 

--- a/training/tests/integration/test_benchmark.py
+++ b/training/tests/integration/test_benchmark.py
@@ -27,7 +27,6 @@ from anemoi.training.diagnostics.benchmark_server import track_dataloader_benchm
 from anemoi.training.train.profiler import AnemoiProfiler
 
 os.environ["ANEMOI_BASE_SEED"] = "42"  # need to set base seed if running on github runners
-os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"  # reduce memory fragmentation
 
 LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Description
compiling the ensemble crps while using expandable segments gives a null pointer error for torch 2.10 and older. this PR does two things:
1) disable expandable segments by default in benchmark tests (we dont need it since we made the tests smaller)
2) when using compilation, check if expandable segments is enabled and warning users that this error might occur and how to fix it

with this PR the ensemble crps runs and [the benchmark tests are passing](https://github.com/ecmwf/anemoi-core/actions/runs/29996078754/job/89193053150#step:3:5393)
```
11:56:10 INFO PASS. Local value for avThroughputIterPerS has improved compared to the reference value (1.23iter/s local vs 0.39iter/s reference)
11:56:10 INFO PASS. Local value for peakMemoryMB has improved compared to the reference value (14975.36MB local vs 16335.80MB reference)
```

*Note* this error appears to be fixed in torch 2.12, so as soon as anemoi can go past 2.10 then it will be possible to use expandable segments + torch compile
