### PR TITLE
fix(training)!: aggregate multiscale loss outputs

### DIFF
--- a/training/CHANGELOG.md
+++ b/training/CHANGELOG.md
@@ -13,6 +13,7 @@ Keep it human-readable, your future self will thank you!
 
 ### ⚠ BREAKING CHANGES
 
+* **training:** return aggregated multiscale losses and remove per-scale validation metrics
 * **training:** speedup multiscale loss ([#1212](https://github.com/ecmwf/anemoi-core/issues/1212))
 * **training:** make user-specified search path take precedence and simplify Hydra search paths hierarchy ([#1181](https://github.com/ecmwf/anemoi-core/issues/1181))
 * Forecast dataset dataloader ([#1133](https://github.com/ecmwf/anemoi-core/issues/1133))

--- a/training/CHANGELOG.md
+++ b/training/CHANGELOG.md
@@ -13,7 +13,6 @@ Keep it human-readable, your future self will thank you!
 
 ### ⚠ BREAKING CHANGES
 
-* **training:** return aggregated multiscale losses and remove per-scale validation metrics
 * **training:** speedup multiscale loss ([#1212](https://github.com/ecmwf/anemoi-core/issues/1212))
 * **training:** make user-specified search path take precedence and simplify Hydra search paths hierarchy ([#1181](https://github.com/ecmwf/anemoi-core/issues/1181))
 * Forecast dataset dataloader ([#1133](https://github.com/ecmwf/anemoi-core/issues/1133))

--- a/training/src/anemoi/training/diagnostics/callbacks/evaluation.py
+++ b/training/src/anemoi/training/diagnostics/callbacks/evaluation.py
@@ -81,9 +81,6 @@ class RolloutEval(Callback):
             self._log(pl_module, step_output.loss, step_output.metrics, batch_tensor.shape[0])
 
     def _log(self, pl_module: pl.LightningModule, loss: torch.Tensor, metrics: dict, bs: int) -> None:
-
-        loss_scales = loss
-        loss = loss_scales.sum()
         loss_name = getattr(pl_module.loss, "name", pl_module.loss.__class__.__name__.lower())
         pl_module.log(
             f"val_r{self.max_rollout}_{loss_name}",
@@ -95,34 +92,18 @@ class RolloutEval(Callback):
             batch_size=bs,
             sync_dist=True,
         )
-        if loss_scales.numel() > 1:
-            for scale in range(loss_scales.numel()):
-                pl_module.log(
-                    f"val_r{self.max_rollout}_{loss_name}_{scale}",
-                    loss_scales[scale],
-                    on_epoch=True,
-                    on_step=True,
-                    prog_bar=False,
-                    logger=pl_module.logger_enabled,
-                    batch_size=bs,
-                    sync_dist=True,
-                )
 
         for mname, mvalue in metrics.items():
-            for scale in range(mvalue.numel()):
-
-                log_val = mvalue[scale] if mvalue.numel() > 1 else mvalue
-
-                pl_module.log(
-                    f"val_r{self.max_rollout}_" + mname + "_scale_" + str(scale),
-                    log_val,
-                    on_epoch=True,
-                    on_step=False,
-                    prog_bar=False,
-                    logger=pl_module.logger_enabled,
-                    batch_size=bs,
-                    sync_dist=True,
-                )
+            pl_module.log(
+                f"val_r{self.max_rollout}_" + mname,
+                mvalue,
+                on_epoch=True,
+                on_step=False,
+                prog_bar=False,
+                logger=pl_module.logger_enabled,
+                batch_size=bs,
+                sync_dist=True,
+            )
 
     def on_validation_batch_end(
         self,

--- a/training/src/anemoi/training/losses/base.py
+++ b/training/src/anemoi/training/losses/base.py
@@ -240,7 +240,12 @@ class BaseLoss(nn.Module, ABC):
                 TensorDim.TIME,
                 TensorDim.ENSEMBLE_DIM,
             ),
-        ).squeeze()
+        )
+        # Remove the grid dimension while retaining one value per variable
+        # when squash=False.
+        out = out.squeeze(0)
+        if squash:
+            out = out.squeeze(-1)
 
         return out if group is None else reduce_tensor(out, group)
 

--- a/training/src/anemoi/training/losses/multiscale.py
+++ b/training/src/anemoi/training/losses/multiscale.py
@@ -419,4 +419,6 @@ class MultiscaleLossWrapper(BaseLossWrapper):
                 ),
             )
 
-        return torch.stack(weighted_losses)
+        # The scale dimension is internal to this wrapper. Return the same
+        # scalar or per-variable shape as the wrapped loss.
+        return torch.stack(weighted_losses).sum(dim=0)

--- a/training/src/anemoi/training/train/methods/base.py
+++ b/training/src/anemoi/training/train/methods/base.py
@@ -797,8 +797,7 @@ class BaseTrainingModule(pl.LightningModule, ABC):
             )
 
             if dataset_loss is not None:
-                dataset_loss_sum = dataset_loss.sum()  # collapse potential multi-scale loss
-                total_loss = dataset_loss_sum if total_loss is None else total_loss + dataset_loss_sum
+                total_loss = dataset_loss if total_loss is None else total_loss + dataset_loss
 
                 if validation_mode:
                     loss_obj = self.loss[dataset_name]
@@ -1046,7 +1045,7 @@ class BaseTrainingModule(pl.LightningModule, ABC):
         batch_size = next(iter(batch.values())).shape[0]
 
         step_output = self._step(batch)
-        train_loss = step_output.loss.sum()
+        train_loss = step_output.loss
 
         self.log(
             "train_" + self._get_loss_name() + "_loss",
@@ -1086,9 +1085,8 @@ class BaseTrainingModule(pl.LightningModule, ABC):
 
         with torch.no_grad():
             step_output = self._step(batch, validation_mode=True)
-        val_loss_scales = step_output.loss
+        val_loss = step_output.loss
         metrics = step_output.metrics
-        val_loss = val_loss_scales.sum()
 
         self.log(
             "val_" + self._get_loss_name() + "_loss",
@@ -1101,38 +1099,17 @@ class BaseTrainingModule(pl.LightningModule, ABC):
             sync_dist=True,
         )
 
-        if val_loss_scales.numel() > 1:
-            loss_name = self._get_loss_name()
-            if len(self.loss) == 1:
-                loss_obj = next(iter(self.loss.values()))
-                loss_name = getattr(loss_obj, "name", loss_obj.__class__.__name__.lower())
-            for scale in range(val_loss_scales.numel()):
-                self.log(
-                    "val_" + loss_name + "_loss" + "_scale_" + str(scale),
-                    val_loss_scales[scale],
-                    on_epoch=True,
-                    on_step=True,
-                    prog_bar=False,
-                    logger=self.logger_enabled,
-                    batch_size=batch_size,
-                    sync_dist=True,
-                )
-
         for mname, mvalue in metrics.items():
-            for scale in range(mvalue.numel()):
-
-                log_val = mvalue[scale] if mvalue.numel() > 1 else mvalue
-
-                self.log(
-                    "val_" + mname + "_scale_" + str(scale),
-                    log_val,
-                    on_epoch=True,
-                    on_step=False,
-                    prog_bar=False,
-                    logger=self.logger_enabled,
-                    batch_size=batch_size,
-                    sync_dist=True,
-                )
+            self.log(
+                "val_" + mname,
+                mvalue,
+                on_epoch=True,
+                on_step=False,
+                prog_bar=False,
+                logger=self.logger_enabled,
+                batch_size=batch_size,
+                sync_dist=True,
+            )
 
         return step_output
 

--- a/training/tests/unit/diagnostics/test_callbacks.py
+++ b/training/tests/unit/diagnostics/test_callbacks.py
@@ -191,6 +191,25 @@ def test_rollout_eval_handles_dict_batch(n_ensemble):
         assert args[3] == 2  # batch size
 
 
+def test_rollout_eval_logs_loss_and_metrics():
+    callback = RolloutEval(rollout=[2], every_n_batches=1)
+    pl_module = MagicMock()
+    pl_module.loss.name = "mse"
+    pl_module.logger_enabled = True
+
+    callback._log(
+        pl_module,
+        loss=torch.tensor(3.0),
+        metrics={"data_mse_loss": torch.tensor(2.0)},
+        bs=2,
+    )
+
+    assert [call.args[0] for call in pl_module.log.call_args_list] == [
+        "val_r2_mse",
+        "val_r2_data_mse_loss",
+    ]
+
+
 def test_plot_loss_gathers_nan_mask_weights_from_nested_losses():
     from omegaconf import DictConfig
 

--- a/training/tests/unit/losses/test_combined_loss.py
+++ b/training/tests/unit/losses/test_combined_loss.py
@@ -294,8 +294,32 @@ def test_combined_loss_mixed_children_filter_shard_layout_kwargs(monkeypatch: py
 
     result = loss(pred, target, weights=weights, group=group, grid_shard_sizes=grid_shard_sizes, grid_dim=-2)
 
-    assert result.shape == (1,)
+    assert result.shape == ()
     prepare_for_smoothing.assert_called_once_with(pred, target, group, grid_shard_sizes)
+
+
+def test_combined_loss_with_multiscale_child() -> None:
+    pred = torch.ones((1, 1, 1, 4, 2), requires_grad=True)
+    target = torch.zeros_like(pred)
+    loss = CombinedLoss(
+        MAELoss(),
+        MultiscaleLossWrapper(
+            per_scale_loss=MSELoss(),
+            weights=[1.0, 1.0, 1.0],
+            multiscale_config={"loss_matrices": [None, None, None]},
+        ),
+    )
+
+    scalar_loss = loss(pred, target)
+    per_variable_loss = loss(pred, target, squash=False)
+
+    assert scalar_loss.shape == ()
+    assert per_variable_loss.shape == (2,)
+    torch.testing.assert_close(scalar_loss, torch.tensor(8.0))
+    torch.testing.assert_close(per_variable_loss, torch.tensor([8.0, 8.0]))
+
+    scalar_loss.backward()
+    assert pred.grad is not None
 
 
 def test_iter_leaf_losses_combined() -> None:

--- a/training/tests/unit/losses/test_loss_function.py
+++ b/training/tests/unit/losses/test_loss_function.py
@@ -72,6 +72,15 @@ def _assert_variable_and_scalar_shapes(
     assert out_total.numel() == 1, "squash=True should return a single aggregated loss"
 
 
+def test_unsquashed_loss_preserves_single_variable_dimension() -> None:
+    pred = torch.ones((1, 1, 1, 4, 1))
+    target = torch.zeros_like(pred)
+
+    loss = MSELoss()(pred, target, squash=False)
+
+    assert loss.shape == (1,)
+
+
 @pytest.mark.parametrize(
     "loss_cls",
     losses,

--- a/training/tests/unit/losses/test_multiscale_loss.py
+++ b/training/tests/unit/losses/test_multiscale_loss.py
@@ -54,6 +54,18 @@ class TrackingLoss(BaseLoss):
         return torch.tensor(1.0)
 
 
+class FixedLoss(BaseLoss):
+    def forward(
+        self,
+        pred: torch.Tensor,
+        target: torch.Tensor,
+        squash: bool = True,
+        **kwargs: object,
+    ) -> torch.Tensor:
+        del target, kwargs
+        return pred.new_tensor(2.0) if squash else pred.new_tensor([2.0, 3.0])
+
+
 class FakeGroup:
     def __init__(self, size: int) -> None:
         self._size = size
@@ -74,7 +86,7 @@ def loss_inputs_multiscale() -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     # With only one "grid point" differing by 1 in all
     # variables, the loss should be 1.0
 
-    loss_result = torch.tensor([1.0])
+    loss_result = torch.tensor(1.0)
     return pred, target, loss_result
 
 
@@ -103,6 +115,22 @@ def test_multiscale_weights_length_mismatch_raises() -> None:
             weights=[1.0],  # 1 weight but multiscale_config gives 2 scales
             multiscale_config={"loss_matrices": [None, None]},
         )
+
+
+def test_multiscale_sums_weighted_scale_losses() -> None:
+    multiscale_loss = MultiscaleLossWrapper(
+        per_scale_loss=FixedLoss(),
+        weights=[0.5, 2.0],
+        multiscale_config={"loss_matrices": [None, None]},
+    )
+    pred = torch.zeros((1, 1, 1, 2, 2))
+    target = torch.zeros_like(pred)
+
+    scalar_loss = multiscale_loss(pred, target)
+    per_variable_loss = multiscale_loss(pred, target, squash=False)
+
+    torch.testing.assert_close(scalar_loss, torch.tensor(5.0))
+    torch.testing.assert_close(per_variable_loss, torch.tensor([5.0, 7.5]))
 
 
 @pytest.mark.parametrize("per_scale_loss", [CRPS(), MSELoss()])
@@ -143,15 +171,11 @@ def test_multi_scale(
     loss = multiscale_loss(pred, target, squash=True)
 
     assert isinstance(loss, torch.Tensor)
-    assert loss.shape == (2,), "Loss should have shape (num_scales,) when squash=True"
+    assert loss.shape == (), "squash=True should return one aggregated loss"
     loss = multiscale_loss(pred, target, squash=False)
 
     assert isinstance(loss, torch.Tensor)
-    # better to have a nvar > 1 because otherwise pred.shape[-1] == 1 and loss.shape == (2) which makes the test fail
-    assert loss.shape == (
-        2,
-        pred.shape[-1],
-    ), "Loss should have shape (num_scales, num_variables) when squash=False"
+    assert loss.shape == (pred.shape[-1],), "squash=False should return one loss per variable"
 
 
 def test_multiscale_loss_equivalent_to_per_scale_loss() -> None:
@@ -205,6 +229,20 @@ def test_multiscale_forwards_layout_kwargs_to_filtered_per_scale_loss() -> None:
     )
 
     assert isinstance(loss, torch.Tensor)
+    assert loss.shape == ()
+
+
+def test_multiscale_loss_preserves_single_variable_dimension() -> None:
+    pred = torch.ones((1, 1, 1, 4, 1))
+    target = torch.zeros_like(pred)
+    multiscale_loss = MultiscaleLossWrapper(
+        per_scale_loss=MSELoss(),
+        weights=[0.25, 0.75],
+        multiscale_config={"loss_matrices": [None, None]},
+    )
+
+    loss = multiscale_loss(pred, target, squash=False)
+
     assert loss.shape == (1,)
 
 

--- a/training/tests/unit/train/test_methods.py
+++ b/training/tests/unit/train/test_methods.py
@@ -436,8 +436,29 @@ def test_base_compute_loss_forwards_shard_layout_to_combined_multiscale_loss(
         dataset_name="data",
     )
 
-    assert result.shape == (1,)
+    assert result.shape == ()
     prepare_for_smoothing.assert_called_once_with(pred, target, group, grid_shard_sizes)
+
+
+def test_validation_step_logs_loss_and_metrics() -> None:
+    module = MagicMock(spec=BaseTrainingModule)
+    module.logger_enabled = True
+    module._get_loss_name.return_value = "mse"
+    module._step.return_value = SimpleNamespace(
+        loss=torch.tensor(3.0),
+        metrics={"data_mse_loss": torch.tensor(2.0)},
+    )
+
+    BaseTrainingModule.validation_step(
+        module,
+        {"data": torch.zeros((2, 1, 1, 1, 1))},
+        batch_idx=0,
+    )
+
+    assert [call.args[0] for call in module.log.call_args_list] == [
+        "val_mse_loss",
+        "val_data_mse_loss",
+    ]
 
 
 # ── EDMDiffusionTransportObjective: compute_loss ─────────────────────────────────


### PR DESCRIPTION
MultiscaleLossWrapper now returns a scalar when squashed and a per-variable vector when unsquashed. This prevents a bug when combined with other losses via the CombinedLoss. Per-scale validation metrics are no longer logged. Please note that this will change the labeling of some ml flow metrics - it will impact the labels only. 

