### PR TITLE
feat(models): Allow torch compile to go through triton GT

### DIFF
--- a/models/src/anemoi/models/layers/block.py
+++ b/models/src/anemoi/models/layers/block.py
@@ -51,7 +51,7 @@ from anemoi.models.triton.utils import is_triton_available
 from anemoi.utils.config import DotDict
 
 if is_triton_available():
-    from anemoi.models.triton.gt import GraphTransformerFunction
+    from anemoi.models.triton.gt import graph_transformer_attention_conv
 
 LOGGER = logging.getLogger(__name__)
 
@@ -613,7 +613,7 @@ class GraphTransformerBaseBlock(BaseBlock, ABC):
 
         if self.graph_attention_backend == "triton":
             LOGGER.info(f"{self.__class__.__name__} using triton graph attention backend.")
-            self.conv = GraphTransformerFunction.apply
+            self.conv = graph_transformer_attention_conv
         else:
             self.conv = GraphTransformerConv(out_channels=self.out_channels_conv)
 

--- a/models/src/anemoi/models/triton/gt.py
+++ b/models/src/anemoi/models/triton/gt.py
@@ -376,15 +376,10 @@ def _gt_bwd_src_pass(
     )
 
 
-# TODO(Jan): single bwd pass for non-bipartite graphs
-
-# ---------------------------------------------------------------------------
-# To make the Triton attention compatible with ``torch.compile`` we expose it as
-# an opaque custom operator with a registered fake/meta implementation (so dynamo
-# can propagate shapes without running the kernel) and a registered autograd rule
-# (so the backward is not traced). All tuple arguments are flattened to plain
-# tensors, as required by the ``torch.library`` custom-op schema.
-# ---------------------------------------------------------------------------
+###################################
+# Wrapper functions for Triton GT #
+###################################
+# These functions allocate the required tenosrs and launch the triton kernels.
 
 
 def _gt_forward_impl(
@@ -408,6 +403,7 @@ def _gt_forward_impl(
     return out_saved, m
 
 
+# TODO(Jan): single bwd pass for non-bipartite graphs
 def _gt_backward_impl(
     d_out: Tensor,
     q: Tensor,
@@ -455,50 +451,15 @@ def _gt_backward_impl(
     return dQ, dK, dV, dE
 
 
-@torch.library.custom_op("anemoi::graph_transformer_attention_backward", mutates_args=(), device_types="cuda")
-def graph_transformer_attention_backward(
-    d_out: Tensor,
-    q: Tensor,
-    k: Tensor,
-    v: Tensor,
-    e: Tensor,
-    out_saved: Tensor,
-    m: Tensor,
-    row: Tensor,
-    colptr: Tensor,
-    rowptr: Tensor,
-    edge_ids: Tensor,
-    edge_dst: Tensor,
-) -> tuple[Tensor, Tensor, Tensor, Tensor]:
-    """Opaque custom op wrapping the Triton GraphTransformer backward kernels.
-
-    Registered as its own custom op so that AOTAutograd does not trace into the
-    raw Triton kernel launches when compiling the backward graph.
-    """
-    return _gt_backward_impl(d_out, q, k, v, e, out_saved, m, row, colptr, rowptr, edge_ids, edge_dst)
-
-
-@graph_transformer_attention_backward.register_fake
-def _graph_transformer_attention_backward_fake(
-    d_out: Tensor,
-    q: Tensor,
-    k: Tensor,
-    v: Tensor,
-    e: Tensor,
-    out_saved: Tensor,
-    m: Tensor,
-    row: Tensor,
-    colptr: Tensor,
-    rowptr: Tensor,
-    edge_ids: Tensor,
-    edge_dst: Tensor,
-) -> tuple[Tensor, Tensor, Tensor, Tensor]:
-    return (
-        torch.empty_like(q),
-        torch.empty_like(k),
-        torch.empty_like(v),
-        torch.empty_like(e),
-    )
+#########################################
+# PyTorch Custom Operator for Triton GT #
+#########################################
+# These functions wrap the Triton kernels in PyTorch custom ops,
+# so that they can be used in a PyTorch autograd graph and compiled with torch.compile.
+# They include '_fake' versions which just do the relevant memory allocations
+# and return empty tensors, for use in torch.compile tracing.
+# The '_setup_context' function saves the necessary tensors for the backward pass.
+# for more details on pytorch custom ops see https://docs.pytorch.org/tutorials/advanced/python_custom_ops_functional.html
 
 
 @torch.library.custom_op("anemoi::graph_transformer_attention", mutates_args=(), device_types="cuda")
@@ -554,10 +515,50 @@ def _graph_transformer_attention_fake(
     return out, out_saved, m
 
 
-def _graph_transformer_attention_setup_context(ctx, inputs, output):
-    q, k, v, e, row, colptr, rowptr, edge_ids, edge_dst = inputs
-    _out, out_saved, m = output
-    ctx.save_for_backward(q, k, v, e, out_saved, m, row, colptr, rowptr, edge_ids, edge_dst)
+@torch.library.custom_op("anemoi::graph_transformer_attention_backward", mutates_args=(), device_types="cuda")
+def graph_transformer_attention_backward(
+    d_out: Tensor,
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    e: Tensor,
+    out_saved: Tensor,
+    m: Tensor,
+    row: Tensor,
+    colptr: Tensor,
+    rowptr: Tensor,
+    edge_ids: Tensor,
+    edge_dst: Tensor,
+) -> tuple[Tensor, Tensor, Tensor, Tensor]:
+    """Opaque custom op wrapping the Triton GraphTransformer backward kernels.
+
+    Registered as its own custom op so that AOTAutograd does not trace into the
+    raw Triton kernel launches when compiling the backward graph.
+    """
+    return _gt_backward_impl(d_out, q, k, v, e, out_saved, m, row, colptr, rowptr, edge_ids, edge_dst)
+
+
+@graph_transformer_attention_backward.register_fake
+def _graph_transformer_attention_backward_fake(
+    d_out: Tensor,
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    e: Tensor,
+    out_saved: Tensor,
+    m: Tensor,
+    row: Tensor,
+    colptr: Tensor,
+    rowptr: Tensor,
+    edge_ids: Tensor,
+    edge_dst: Tensor,
+) -> tuple[Tensor, Tensor, Tensor, Tensor]:
+    return (
+        torch.empty_like(q),
+        torch.empty_like(k),
+        torch.empty_like(v),
+        torch.empty_like(e),
+    )
 
 
 def _graph_transformer_attention_backward(ctx, d_out, _d_out_saved, _d_m):
@@ -573,10 +574,21 @@ def _graph_transformer_attention_backward(ctx, d_out, _d_out_saved, _d_m):
     return dQ, dK, dV, dE, None, None, None, None, None
 
 
+def _graph_transformer_attention_setup_context(ctx, inputs, output):
+    q, k, v, e, row, colptr, rowptr, edge_ids, edge_dst = inputs
+    _out, out_saved, m = output
+    ctx.save_for_backward(q, k, v, e, out_saved, m, row, colptr, rowptr, edge_ids, edge_dst)
+
+
 graph_transformer_attention.register_autograd(
     _graph_transformer_attention_backward,
     setup_context=_graph_transformer_attention_setup_context,
 )
+
+
+#######################
+# Triton GT interface #
+#######################
 
 
 def graph_transformer_attention_conv(
@@ -587,11 +599,7 @@ def graph_transformer_attention_conv(
     csc: tuple[Tensor, Tensor],
     reverse: tuple[Tensor, Tensor, Tensor],
 ) -> Tensor:
-    """torch.compile-friendly GraphTransformer attention.
-
-    Drop-in replacement for ``GraphTransformerFunction.apply`` that unpacks the
-    CSC/reverse tuples into plain tensors and dispatches to the opaque custom op.
-    """
+    """torch.compile-friendly GraphTransformer attention."""
     row, colptr = csc
     rowptr, edge_ids, edge_dst = reverse
     out, _out_saved, _m = graph_transformer_attention(query, key, value, edges, row, colptr, rowptr, edge_ids, edge_dst)

--- a/models/src/anemoi/models/triton/gt.py
+++ b/models/src/anemoi/models/triton/gt.py
@@ -8,6 +8,7 @@
 # nor does it submit to any jurisdiction.
 
 import torch
+from torch import Tensor
 
 # check if triton is installed
 # If pytorch is installed on CPU then torch is not available
@@ -377,78 +378,221 @@ def _gt_bwd_src_pass(
 
 # TODO(Jan): single bwd pass for non-bipartite graphs
 
+# ---------------------------------------------------------------------------
+# To make the Triton attention compatible with ``torch.compile`` we expose it as
+# an opaque custom operator with a registered fake/meta implementation (so dynamo
+# can propagate shapes without running the kernel) and a registered autograd rule
+# (so the backward is not traced). All tuple arguments are flattened to plain
+# tensors, as required by the ``torch.library`` custom-op schema.
+# ---------------------------------------------------------------------------
 
-class GraphTransformerFunction(torch.autograd.Function):
-    """Custom autograd for GraphTransformer using Triton kernels."""
 
-    def __init__(self):
-        if not torch.cuda.is_available():
-            raise ValueError(
-                "Error. The 'triton' backend was selected for the GraphTransformer but 'torch.cuda.is_available()' returned 'False'. The 'triton' backend is currently only supported on GPUs. To run on other device types, please select a different backend for the GraphTransformer in the models config. If you intend to run on GPUs, please ensure your torch install supports running on GPUs."
-            )
+def _gt_forward_impl(
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    e: Tensor,
+    row: Tensor,
+    colptr: Tensor,
+) -> tuple[Tensor, Tensor]:
+    """Run the Triton forward kernel, returning (out_f32, m_f32)."""
+    q, k, v, e = (x.contiguous() for x in (q, k, v, e))
+    row, colptr = (x.contiguous() for x in (row, colptr))
 
-    @staticmethod
-    def forward(ctx, q, k, v, e, csc, reverse):
-        """Args:
-        q: [N_dst, H, C]
-        k: [N_src, H, C]
-        v: [N_src, H, C]
-        e: [num_edges, H, C]
-        csc: (row, colptr)
-        reverse: (rowptr, edge_ids, edge_dst)
-        """
-        row, colptr = csc
-        rowptr, edge_ids, edge_dst = reverse
+    N_dst, H, C = q.shape
+    out_saved = torch.empty((N_dst, H, C), device=q.device, dtype=torch.float32)
+    m = torch.empty((N_dst, H), device=q.device, dtype=torch.float32)
 
-        # Ensure contiguous memory layout for Triton
-        q, k, v, e = [x.contiguous() for x in (q, k, v, e)]
-        row, colptr, rowptr, edge_ids, edge_dst = [x.contiguous() for x in (row, colptr, rowptr, edge_ids, edge_dst)]
+    _gt_fwd[(N_dst,)](q, k, v, e, m, row, colptr, out_saved, N_dst, H, C, tl.float32)
 
-        N_dst, H, C = q.shape
-        out_saved = torch.empty((N_dst, H, C), device=q.device, dtype=torch.float32)
-        m = torch.empty((N_dst, H), device=q.device, dtype=torch.float32)
+    return out_saved, m
 
-        # fix: write output in float32 for backward stability, then cast back to input dtype at the end of forward
-        _gt_fwd[(N_dst,)](q, k, v, e, m, row, colptr, out_saved, N_dst, H, C, tl.float32)
 
-        # Save tensors for backward
-        ctx.save_for_backward(q, k, v, e, out_saved, m, row, colptr, rowptr, edge_ids, edge_dst)
-        return out_saved.to(q.dtype)
+def _gt_backward_impl(
+    d_out: Tensor,
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    e: Tensor,
+    out_saved: Tensor,
+    m: Tensor,
+    row: Tensor,
+    colptr: Tensor,
+    rowptr: Tensor,
+    edge_ids: Tensor,
+    edge_dst: Tensor,
+) -> tuple[Tensor, Tensor, Tensor, Tensor]:
+    """Run the Triton backward kernels, returning (dQ, dK, dV, dE)."""
+    d_out = d_out.contiguous()
 
-    @staticmethod
-    def backward(ctx, d_out):
-        d_out = d_out.contiguous()
-        q, k, v, e, out_saved, m, row, colptr, rowptr, edge_ids, edge_dst = ctx.saved_tensors
+    N_dst, H, C = q.shape
+    N_src = k.shape[0]
 
-        N_dst, H, C = q.shape
-        N_src = k.shape[0]
+    def torch_dtype_to_triton(dtype):
+        if dtype == torch.float16:
+            return tl.float16
+        elif dtype == torch.bfloat16:
+            return tl.bfloat16
+        elif dtype == torch.float32:
+            return tl.float32
+        else:
+            raise ValueError(f"Unsupported dtype: {dtype}")
 
-        # Infer gradient dtype from incoming gradient tensor
-        def torch_dtype_to_triton(dtype):
-            if dtype == torch.float16:
-                return tl.float16
-            elif dtype == torch.bfloat16:
-                return tl.bfloat16
-            elif dtype == torch.float32:
-                return tl.float32
-            else:
-                raise ValueError(f"Unsupported dtype: {dtype}")
+    grad_dtype = torch_dtype_to_triton(d_out.dtype)
 
-        grad_dtype = torch_dtype_to_triton(d_out.dtype)
+    dQ = torch.empty_like(q)
+    dK = torch.empty_like(k)
+    dV = torch.empty_like(v)
+    dE = torch.empty_like(e)
+    D = torch.empty((N_dst, H), device=q.device, dtype=torch.float32)
 
-        # Allocate grads and intermediates
-        dQ = torch.empty_like(q)
-        dK = torch.empty_like(k)
-        dV = torch.empty_like(v)
-        dE = torch.empty_like(e)
-        D = torch.empty((N_dst, H), device=q.device, dtype=torch.float32)
+    # Pass A: destination nodes (computes D and dQ)
+    _gt_bwd_dst_pass[(N_dst,)](q, k, v, e, out_saved, m, row, colptr, d_out, dQ, D, N_dst, H, C, grad_dtype)
 
-        # Pass A: destination nodes (computes D and dQ)
-        _gt_bwd_dst_pass[(N_dst,)](q, k, v, e, out_saved, m, row, colptr, d_out, dQ, D, N_dst, H, C, grad_dtype)
+    # Pass B: source nodes (accumulate dK, dV, dE)
+    _gt_bwd_src_pass[(N_src,)](q, k, v, e, rowptr, edge_ids, edge_dst, D, m, d_out, dK, dV, dE, N_src, H, C, grad_dtype)
 
-        # Pass B: source nodes (accumulate dK, dV, dE)
-        _gt_bwd_src_pass[(N_src,)](
-            q, k, v, e, rowptr, edge_ids, edge_dst, D, m, d_out, dK, dV, dE, N_src, H, C, grad_dtype
-        )
+    return dQ, dK, dV, dE
 
-        return dQ, dK, dV, dE, None, None
+
+@torch.library.custom_op("anemoi::graph_transformer_attention_backward", mutates_args=(), device_types="cuda")
+def graph_transformer_attention_backward(
+    d_out: Tensor,
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    e: Tensor,
+    out_saved: Tensor,
+    m: Tensor,
+    row: Tensor,
+    colptr: Tensor,
+    rowptr: Tensor,
+    edge_ids: Tensor,
+    edge_dst: Tensor,
+) -> tuple[Tensor, Tensor, Tensor, Tensor]:
+    """Opaque custom op wrapping the Triton GraphTransformer backward kernels.
+
+    Registered as its own custom op so that AOTAutograd does not trace into the
+    raw Triton kernel launches when compiling the backward graph.
+    """
+    return _gt_backward_impl(d_out, q, k, v, e, out_saved, m, row, colptr, rowptr, edge_ids, edge_dst)
+
+
+@graph_transformer_attention_backward.register_fake
+def _graph_transformer_attention_backward_fake(
+    d_out: Tensor,
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    e: Tensor,
+    out_saved: Tensor,
+    m: Tensor,
+    row: Tensor,
+    colptr: Tensor,
+    rowptr: Tensor,
+    edge_ids: Tensor,
+    edge_dst: Tensor,
+) -> tuple[Tensor, Tensor, Tensor, Tensor]:
+    return (
+        torch.empty_like(q),
+        torch.empty_like(k),
+        torch.empty_like(v),
+        torch.empty_like(e),
+    )
+
+
+@torch.library.custom_op("anemoi::graph_transformer_attention", mutates_args=(), device_types="cuda")
+def graph_transformer_attention(
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    e: Tensor,
+    row: Tensor,
+    colptr: Tensor,
+    rowptr: Tensor,
+    edge_ids: Tensor,
+    edge_dst: Tensor,
+) -> tuple[Tensor, Tensor, Tensor]:
+    """Opaque custom op wrapping the Triton GraphTransformer attention.
+
+    Returns
+    -------
+    out : Tensor
+        Attention output cast back to ``q.dtype`` (the user-facing result).
+    out_saved : Tensor
+        Float32 attention output, kept for the backward pass.
+    m : Tensor
+        Float32 log-sum-exp normalizer, kept for the backward pass.
+    """
+    out_saved, m = _gt_forward_impl(q, k, v, e, row, colptr)
+
+    out = out_saved.to(q.dtype)
+    # Custom-op outputs must not alias one another; ``.to`` returns ``self`` when
+    # ``q`` is already float32, so clone to keep ``out`` and ``out_saved`` distinct.
+    if out is out_saved:
+        out = out.clone()
+
+    return out, out_saved, m
+
+
+@graph_transformer_attention.register_fake
+def _graph_transformer_attention_fake(
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    e: Tensor,
+    row: Tensor,
+    colptr: Tensor,
+    rowptr: Tensor,
+    edge_ids: Tensor,
+    edge_dst: Tensor,
+) -> tuple[Tensor, Tensor, Tensor]:
+    N_dst, H, C = q.shape
+    out = torch.empty((N_dst, H, C), device=q.device, dtype=q.dtype)
+    out_saved = torch.empty((N_dst, H, C), device=q.device, dtype=torch.float32)
+    m = torch.empty((N_dst, H), device=q.device, dtype=torch.float32)
+    return out, out_saved, m
+
+
+def _graph_transformer_attention_setup_context(ctx, inputs, output):
+    q, k, v, e, row, colptr, rowptr, edge_ids, edge_dst = inputs
+    _out, out_saved, m = output
+    ctx.save_for_backward(q, k, v, e, out_saved, m, row, colptr, rowptr, edge_ids, edge_dst)
+
+
+def _graph_transformer_attention_backward(ctx, d_out, _d_out_saved, _d_m):
+    # Only the gradient w.r.t. the user-facing ``out`` is used; ``out_saved`` and
+    # ``m`` are internal saved tensors that are not consumed downstream.
+    q, k, v, e, out_saved, m, row, colptr, rowptr, edge_ids, edge_dst = ctx.saved_tensors
+
+    dQ, dK, dV, dE = graph_transformer_attention_backward(
+        d_out, q, k, v, e, out_saved, m, row, colptr, rowptr, edge_ids, edge_dst
+    )
+
+    # Gradients for (q, k, v, e, row, colptr, rowptr, edge_ids, edge_dst).
+    return dQ, dK, dV, dE, None, None, None, None, None
+
+
+graph_transformer_attention.register_autograd(
+    _graph_transformer_attention_backward,
+    setup_context=_graph_transformer_attention_setup_context,
+)
+
+
+def graph_transformer_attention_conv(
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    edges: Tensor,
+    csc: tuple[Tensor, Tensor],
+    reverse: tuple[Tensor, Tensor, Tensor],
+) -> Tensor:
+    """torch.compile-friendly GraphTransformer attention.
+
+    Drop-in replacement for ``GraphTransformerFunction.apply`` that unpacks the
+    CSC/reverse tuples into plain tensors and dispatches to the opaque custom op.
+    """
+    row, colptr = csc
+    rowptr, edge_ids, edge_dst = reverse
+    out, _out_saved, _m = graph_transformer_attention(query, key, value, edges, row, colptr, rowptr, edge_ids, edge_dst)
+    return out

--- a/models/src/anemoi/models/triton/gt.py
+++ b/models/src/anemoi/models/triton/gt.py
@@ -376,81 +376,6 @@ def _gt_bwd_src_pass(
     )
 
 
-###################################
-# Wrapper functions for Triton GT #
-###################################
-# These functions allocate the required tenosrs and launch the triton kernels.
-
-
-def _gt_forward_impl(
-    q: Tensor,
-    k: Tensor,
-    v: Tensor,
-    e: Tensor,
-    row: Tensor,
-    colptr: Tensor,
-) -> tuple[Tensor, Tensor]:
-    """Run the Triton forward kernel, returning (out_f32, m_f32)."""
-    q, k, v, e = (x.contiguous() for x in (q, k, v, e))
-    row, colptr = (x.contiguous() for x in (row, colptr))
-
-    N_dst, H, C = q.shape
-    out_saved = torch.empty((N_dst, H, C), device=q.device, dtype=torch.float32)
-    m = torch.empty((N_dst, H), device=q.device, dtype=torch.float32)
-
-    _gt_fwd[(N_dst,)](q, k, v, e, m, row, colptr, out_saved, N_dst, H, C, tl.float32)
-
-    return out_saved, m
-
-
-# TODO(Jan): single bwd pass for non-bipartite graphs
-def _gt_backward_impl(
-    d_out: Tensor,
-    q: Tensor,
-    k: Tensor,
-    v: Tensor,
-    e: Tensor,
-    out_saved: Tensor,
-    m: Tensor,
-    row: Tensor,
-    colptr: Tensor,
-    rowptr: Tensor,
-    edge_ids: Tensor,
-    edge_dst: Tensor,
-) -> tuple[Tensor, Tensor, Tensor, Tensor]:
-    """Run the Triton backward kernels, returning (dQ, dK, dV, dE)."""
-    d_out = d_out.contiguous()
-
-    N_dst, H, C = q.shape
-    N_src = k.shape[0]
-
-    def torch_dtype_to_triton(dtype):
-        if dtype == torch.float16:
-            return tl.float16
-        elif dtype == torch.bfloat16:
-            return tl.bfloat16
-        elif dtype == torch.float32:
-            return tl.float32
-        else:
-            raise ValueError(f"Unsupported dtype: {dtype}")
-
-    grad_dtype = torch_dtype_to_triton(d_out.dtype)
-
-    dQ = torch.empty_like(q)
-    dK = torch.empty_like(k)
-    dV = torch.empty_like(v)
-    dE = torch.empty_like(e)
-    D = torch.empty((N_dst, H), device=q.device, dtype=torch.float32)
-
-    # Pass A: destination nodes (computes D and dQ)
-    _gt_bwd_dst_pass[(N_dst,)](q, k, v, e, out_saved, m, row, colptr, d_out, dQ, D, N_dst, H, C, grad_dtype)
-
-    # Pass B: source nodes (accumulate dK, dV, dE)
-    _gt_bwd_src_pass[(N_src,)](q, k, v, e, rowptr, edge_ids, edge_dst, D, m, d_out, dK, dV, dE, N_src, H, C, grad_dtype)
-
-    return dQ, dK, dV, dE
-
-
 #########################################
 # PyTorch Custom Operator for Triton GT #
 #########################################
@@ -485,7 +410,14 @@ def graph_transformer_attention(
     m : Tensor
         Float32 log-sum-exp normalizer, kept for the backward pass.
     """
-    out_saved, m = _gt_forward_impl(q, k, v, e, row, colptr)
+    q, k, v, e = (x.contiguous() for x in (q, k, v, e))
+    row, colptr = (x.contiguous() for x in (row, colptr))
+
+    N_dst, H, C = q.shape
+    out_saved = torch.empty((N_dst, H, C), device=q.device, dtype=torch.float32)
+    m = torch.empty((N_dst, H), device=q.device, dtype=torch.float32)
+
+    _gt_fwd[(N_dst,)](q, k, v, e, m, row, colptr, out_saved, N_dst, H, C, tl.float32)
 
     out = out_saved.to(q.dtype)
     # Custom-op outputs must not alias one another; ``.to`` returns ``self`` when
@@ -515,6 +447,7 @@ def _graph_transformer_attention_fake(
     return out, out_saved, m
 
 
+# TODO(Jan): single bwd pass for non-bipartite graphs
 @torch.library.custom_op("anemoi::graph_transformer_attention_backward", mutates_args=(), device_types="cuda")
 def graph_transformer_attention_backward(
     d_out: Tensor,
@@ -535,7 +468,36 @@ def graph_transformer_attention_backward(
     Registered as its own custom op so that AOTAutograd does not trace into the
     raw Triton kernel launches when compiling the backward graph.
     """
-    return _gt_backward_impl(d_out, q, k, v, e, out_saved, m, row, colptr, rowptr, edge_ids, edge_dst)
+    d_out = d_out.contiguous()
+
+    N_dst, H, C = q.shape
+    N_src = k.shape[0]
+
+    def torch_dtype_to_triton(dtype):
+        if dtype == torch.float16:
+            return tl.float16
+        elif dtype == torch.bfloat16:
+            return tl.bfloat16
+        elif dtype == torch.float32:
+            return tl.float32
+        else:
+            raise ValueError(f"Unsupported dtype: {dtype}")
+
+    grad_dtype = torch_dtype_to_triton(d_out.dtype)
+
+    dQ = torch.empty_like(q)
+    dK = torch.empty_like(k)
+    dV = torch.empty_like(v)
+    dE = torch.empty_like(e)
+    D = torch.empty((N_dst, H), device=q.device, dtype=torch.float32)
+
+    # Pass A: destination nodes (computes D and dQ)
+    _gt_bwd_dst_pass[(N_dst,)](q, k, v, e, out_saved, m, row, colptr, d_out, dQ, D, N_dst, H, C, grad_dtype)
+
+    # Pass B: source nodes (accumulate dK, dV, dE)
+    _gt_bwd_src_pass[(N_src,)](q, k, v, e, rowptr, edge_ids, edge_dst, D, m, d_out, dK, dV, dE, N_src, H, C, grad_dtype)
+
+    return dQ, dK, dV, dE
 
 
 @graph_transformer_attention_backward.register_fake

--- a/models/src/anemoi/models/triton/gt.py
+++ b/models/src/anemoi/models/triton/gt.py
@@ -539,6 +539,14 @@ def _graph_transformer_attention_backward(ctx, d_out, _d_out_saved, _d_m):
 def _graph_transformer_attention_setup_context(ctx, inputs, output):
     q, k, v, e, row, colptr, rowptr, edge_ids, edge_dst = inputs
     _out, out_saved, m = output
+
+    # The forward op makes contiguous copies internally, but those are not the tensors
+    # passed here (setup_context receives the original op inputs). Save contiguous
+    # versions so the Triton backward kernels, which assume a contiguous layout, receive
+    # contiguous inputs.
+    q, k, v, e = (x.contiguous() for x in (q, k, v, e))
+    row, colptr, rowptr, edge_ids, edge_dst = (x.contiguous() for x in (row, colptr, rowptr, edge_ids, edge_dst))
+
     ctx.save_for_backward(q, k, v, e, out_saved, m, row, colptr, rowptr, edge_ids, edge_dst)
 
 

--- a/models/tests/integration/triton/test_triton_gt.py
+++ b/models/tests/integration/triton/test_triton_gt.py
@@ -17,7 +17,8 @@ from anemoi.models.triton.utils import edge_index_to_csc
 from anemoi.models.triton.utils import is_triton_available
 
 if is_triton_available():
-    from anemoi.models.triton.gt import GraphTransformerFunction
+    from anemoi.models.triton.gt import graph_transformer_attention
+    from anemoi.models.triton.gt import graph_transformer_attention_conv
 
 
 @pytest.fixture(autouse=True)
@@ -65,7 +66,7 @@ def test_graph_transformer_forward(n_src: int, n_dst: int, h: int, d: int):
     edge_attr = torch.randn((m, h, d), requires_grad=True)
 
     edge_attr_csc = edge_attr[perm]
-    out_triton = GraphTransformerFunction.apply(query, key, value, edge_attr_csc, csc, reverse)
+    out_triton = graph_transformer_attention_conv(query, key, value, edge_attr_csc, csc, reverse)
 
     # Verify output shape
     assert out_triton.shape == (n_dst, h, d), f"Expected shape {(n_dst, h, d)}, got {out_triton.shape}"
@@ -95,7 +96,7 @@ def test_graph_transformer_backward(n_src: int, n_dst: int, h: int, d: int):
     edge_attr = torch.randn((m, h, d), requires_grad=True)
 
     edge_attr_csc = edge_attr[perm]
-    out_triton = GraphTransformerFunction.apply(query, key, value, edge_attr_csc, csc, reverse)
+    out_triton = graph_transformer_attention_conv(query, key, value, edge_attr_csc, csc, reverse)
     loss = out_triton.pow(2).sum()
     loss.backward()
 
@@ -131,7 +132,7 @@ def test_graph_transformer_vs_reference_forward(n_src: int, n_dst: int, h: int, 
     edge_attr = torch.randn((m, h, d), requires_grad=True)
 
     edge_attr_csc = edge_attr[perm]
-    out_triton = GraphTransformerFunction.apply(query, key, value, edge_attr_csc, csc, reverse)
+    out_triton = graph_transformer_attention_conv(query, key, value, edge_attr_csc, csc, reverse)
 
     # Reference pyg implementation
     gt_ref = GraphTransformerConv(out_channels=d)
@@ -166,7 +167,7 @@ def test_graph_transformer_vs_reference_backward(n_src: int, n_dst: int, h: int,
     edge_attr = torch.randn((m, h, d), requires_grad=True)
 
     edge_attr_csc = edge_attr[perm]
-    out_triton = GraphTransformerFunction.apply(query, key, value, edge_attr_csc, csc, reverse)
+    out_triton = graph_transformer_attention_conv(query, key, value, edge_attr_csc, csc, reverse)
     loss_triton = out_triton.pow(2).sum()
     loss_triton.backward()
     grads_triton = (query.grad.clone(), key.grad.clone(), value.grad.clone(), edge_attr.grad.clone())
@@ -190,3 +191,38 @@ def test_graph_transformer_vs_reference_backward(n_src: int, n_dst: int, h: int,
     torch.testing.assert_close(grads_triton[1], grads_ref[1], atol=tolerance, rtol=0)  # keys
     torch.testing.assert_close(grads_triton[2], grads_ref[2], atol=tolerance, rtol=0)  # values
     torch.testing.assert_close(grads_triton[3], grads_ref[3], atol=tolerance, rtol=0)  # edges
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize(
+    "n_src,n_dst,h,d",
+    [
+        (4, 10, 2, 4),
+        (4, 10, 6, 4),
+        (4, 10, 2, 6),
+        (4, 10, 6, 6),
+    ],
+)
+def test_graph_transformer_attention_opcheck(n_src: int, n_dst: int, h: int, d: int):
+    """Check the ``graph_transformer_attention`` custom op is registered correctly.
+
+    ``torch.library.opcheck`` validates the schema, fake/meta implementation and
+    autograd registration of the operator.
+    """
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+
+    edge_index, m = build_bipartite_graph(n_src, n_dst)
+    (row, colptr), perm, (rowptr, edge_ids, edge_dst) = edge_index_to_csc(
+        edge_index, num_nodes=(n_src, n_dst), reverse=True
+    )
+
+    query = torch.randn((n_dst, h, d), requires_grad=True)
+    key = torch.randn((n_src, h, d), requires_grad=True)
+    value = torch.randn((n_src, h, d), requires_grad=True)
+    edge_attr_csc = torch.randn((m, h, d), requires_grad=True)
+
+    torch.library.opcheck(
+        graph_transformer_attention,
+        (query, key, value, edge_attr_csc, row, colptr, rowptr, edge_ids, edge_dst),
+    )

--- a/models/tests/integration/triton/test_triton_gt.py
+++ b/models/tests/integration/triton/test_triton_gt.py
@@ -53,7 +53,7 @@ def build_bipartite_graph(n_src: int, n_dst: int) -> Tuple[torch.Tensor, int]:
     ],
 )
 def test_graph_transformer_forward(n_src: int, n_dst: int, h: int, d: int):
-    """Test forward pass of GraphTransformerFunction."""
+    """Test forward pass of Triton GT."""
     if not torch.cuda.is_available():
         pytest.skip("CUDA not available")
 
@@ -83,7 +83,7 @@ def test_graph_transformer_forward(n_src: int, n_dst: int, h: int, d: int):
     ],
 )
 def test_graph_transformer_backward(n_src: int, n_dst: int, h: int, d: int):
-    """Test backward pass of GraphTransformerFunction."""
+    """Test backward pass of Triton GT."""
     if not torch.cuda.is_available():
         pytest.skip("CUDA not available")
 
@@ -118,7 +118,7 @@ def test_graph_transformer_backward(n_src: int, n_dst: int, h: int, d: int):
     ],
 )
 def test_graph_transformer_vs_reference_forward(n_src: int, n_dst: int, h: int, d: int):
-    """Test that triton GraphTransformerFunction matches reference implementation."""
+    """Test that triton Triton GT matches reference implementation."""
     if not torch.cuda.is_available():
         pytest.skip("CUDA not available")
 
@@ -153,7 +153,7 @@ def test_graph_transformer_vs_reference_forward(n_src: int, n_dst: int, h: int, 
     ],
 )
 def test_graph_transformer_vs_reference_backward(n_src: int, n_dst: int, h: int, d: int):
-    """Test that triton GraphTransformerFunction matches reference implementation."""
+    """Test that triton Triton GT matches reference implementation."""
     if not torch.cuda.is_available():
         pytest.skip("CUDA not available")
 

--- a/models/tests/integration/triton/test_triton_gt.py
+++ b/models/tests/integration/triton/test_triton_gt.py
@@ -23,9 +23,12 @@ if is_triton_available():
 
 @pytest.fixture(autouse=True)
 def setup_torch():
-    """Set up torch defaults for all tests."""
-    device = "cuda" if torch.cuda.is_available() else "cpu"
-    torch.set_default_device(device)
+    """Skip when CUDA/Triton are unavailable and set up torch defaults for all tests."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+    if not is_triton_available():
+        pytest.skip("Triton not available")
+    torch.set_default_device("cuda")
     torch.set_default_dtype(torch.float32)
     yield
 
@@ -54,9 +57,6 @@ def build_bipartite_graph(n_src: int, n_dst: int) -> Tuple[torch.Tensor, int]:
 )
 def test_graph_transformer_forward(n_src: int, n_dst: int, h: int, d: int):
     """Test forward pass of Triton GT."""
-    if not torch.cuda.is_available():
-        pytest.skip("CUDA not available")
-
     edge_index, m = build_bipartite_graph(n_src, n_dst)
     csc, perm, reverse = edge_index_to_csc(edge_index, num_nodes=(n_src, n_dst), reverse=True)
 
@@ -84,9 +84,6 @@ def test_graph_transformer_forward(n_src: int, n_dst: int, h: int, d: int):
 )
 def test_graph_transformer_backward(n_src: int, n_dst: int, h: int, d: int):
     """Test backward pass of Triton GT."""
-    if not torch.cuda.is_available():
-        pytest.skip("CUDA not available")
-
     edge_index, m = build_bipartite_graph(n_src, n_dst)
     csc, perm, reverse = edge_index_to_csc(edge_index, num_nodes=(n_src, n_dst), reverse=True)
 
@@ -119,9 +116,6 @@ def test_graph_transformer_backward(n_src: int, n_dst: int, h: int, d: int):
 )
 def test_graph_transformer_vs_reference_forward(n_src: int, n_dst: int, h: int, d: int):
     """Test that triton Triton GT matches reference implementation."""
-    if not torch.cuda.is_available():
-        pytest.skip("CUDA not available")
-
     edge_index, m = build_bipartite_graph(n_src, n_dst)
     csc, perm, reverse = edge_index_to_csc(edge_index, num_nodes=(n_src, n_dst), reverse=True)
 
@@ -154,9 +148,6 @@ def test_graph_transformer_vs_reference_forward(n_src: int, n_dst: int, h: int, 
 )
 def test_graph_transformer_vs_reference_backward(n_src: int, n_dst: int, h: int, d: int):
     """Test that triton Triton GT matches reference implementation."""
-    if not torch.cuda.is_available():
-        pytest.skip("CUDA not available")
-
     edge_index, m = build_bipartite_graph(n_src, n_dst)
     csc, perm, reverse = edge_index_to_csc(edge_index, num_nodes=(n_src, n_dst), reverse=True)
 
@@ -209,9 +200,6 @@ def test_graph_transformer_attention_opcheck(n_src: int, n_dst: int, h: int, d: 
     ``torch.library.opcheck`` validates the schema, fake/meta implementation and
     autograd registration of the operator.
     """
-    if not torch.cuda.is_available():
-        pytest.skip("CUDA not available")
-
     edge_index, m = build_bipartite_graph(n_src, n_dst)
     (row, colptr), perm, (rowptr, edge_ids, edge_dst) = edge_index_to_csc(
         edge_index, num_nodes=(n_src, n_dst), reverse=True


### PR DESCRIPTION
## Description
Before if you tried to compile a region of code containing the triton GT you would get an error. This happened because the compiler was not able to trace through the triton GT. 
To enable this, you have to register [a custom pytorch operator](https://docs.pytorch.org/tutorials/advanced/python_custom_ops_functional.html). This does two things

1. defines '_fake' versions of forward and backward to be used during tracing. these just do the required memory allocations
```
@graph_transformer_attention.register_fake
def _graph_transformer_attention_fake(
    q: Tensor,
    k: Tensor,
    v: Tensor,
    e: Tensor,
    row: Tensor,
    colptr: Tensor,
    rowptr: Tensor,
    edge_ids: Tensor,
    edge_dst: Tensor,
) -> tuple[Tensor, Tensor, Tensor]:
    N_dst, H, C = q.shape
    out = torch.empty((N_dst, H, C), device=q.device, dtype=q.dtype)
    out_saved = torch.empty((N_dst, H, C), device=q.device, dtype=torch.float32)
    m = torch.empty((N_dst, H), device=q.device, dtype=torch.float32)
    return out, out_saved, m
```
2. Defines a '_setup_context' function which defines which tensors must be saved for the backward pass
```
def _graph_transformer_attention_setup_context(ctx, inputs, output):
    q, k, v, e, row, colptr, rowptr, edge_ids, edge_dst = inputs
    _out, out_saved, m = output
    ctx.save_for_backward(q, k, v, e, out_saved, m, row, colptr, rowptr, edge_ids, edge_dst)
```
Once after these changes, the triton GT can now be traced by torch compile.

I removed the triton GT module, and replaced it with an autograd function. The syntax changed from
```
 - self.conv = GraphTransformerFunction.apply
 + self.conv = graph_transformer_attention_conv
```
I updated the integration tests to use this new syntax, and added a test [recommended by pytorch](https://docs.pytorch.org/tutorials/advanced/python_custom_ops_functional.html#testing-python-custom-operators) to ensure the operator was registered correctly.