### PR TITLE
fix(training): increase checkpoint download timeout time

### DIFF
--- a/training/tests/unit/checkpoint/test_utils.py
+++ b/training/tests/unit/checkpoint/test_utils.py
@@ -39,6 +39,8 @@ from anemoi.training.checkpoint.utils import format_size
 from anemoi.training.checkpoint.utils import get_checkpoint_metadata
 from anemoi.training.checkpoint.utils import validate_checkpoint
 
+TIMEOUT = 60
+
 
 class TestDownloadWithRetry:
     """Test async download functionality with retry logic."""
@@ -50,7 +52,7 @@ class TestDownloadWithRetry:
         dest_path = temp_checkpoint_dir / "downloaded_file.bin"
 
         try:
-            result_path = await download_with_retry(network_urls["valid"], dest_path, max_retries=3, timeout=30)
+            result_path = await download_with_retry(network_urls["valid"], dest_path, max_retries=3, timeout=TIMEOUT)
 
             assert result_path == dest_path
             assert dest_path.exists()
@@ -83,7 +85,7 @@ class TestDownloadWithRetry:
         dest_path = temp_checkpoint_dir / "not_found_file.bin"
 
         with pytest.raises(CheckpointSourceError) as exc_info:
-            await download_with_retry(network_urls["not_found"], dest_path, max_retries=2, timeout=30)
+            await download_with_retry(network_urls["not_found"], dest_path, max_retries=2, timeout=60)
 
         # The message is "http" and source_path contains the URL
         assert "http" in exc_info.value.message or "http" in exc_info.value.source_path
@@ -99,7 +101,7 @@ class TestDownloadWithRetry:
         dest_path = temp_checkpoint_dir / "server_error_file.bin"
 
         with pytest.raises(CheckpointSourceError):
-            await download_with_retry(network_urls["server_error"], dest_path, max_retries=2, timeout=30)
+            await download_with_retry(network_urls["server_error"], dest_path, max_retries=2, timeout=TIMEOUT)
 
     @pytest.mark.unit
     async def test_download_with_retry_creates_parent_dir(self, temp_checkpoint_dir: Path) -> None:
@@ -159,7 +161,7 @@ class TestDownloadWithRetry:
             mock_client_session.return_value = mock_session
 
             with pytest.raises(CheckpointSourceError):
-                await download_with_retry("https://example.com/fail.bin", dest_path, max_retries=3, timeout=30)
+                await download_with_retry("https://example.com/fail.bin", dest_path, max_retries=3, timeout=TIMEOUT)
 
         # Should have waited for exponential backoff: 1s + 2s = 3s minimum
         elapsed_time = time.time() - start_time
@@ -920,7 +922,7 @@ class TestUtilsIntegration:
 
         try:
             # Download file
-            await download_with_retry(network_urls["valid"], dest_path, max_retries=2, timeout=30)
+            await download_with_retry(network_urls["valid"], dest_path, max_retries=2, timeout=TIMEOUT)
 
             assert dest_path.exists()
 


### PR DESCRIPTION
## Description
recently the checkpoint download tests in `training/tests/unit/checkpoint/test_utils.py` have been timing out. this presents as spurious unit test failures on unrelated PRs. The failure often goes away when you rerun the tests. This PR doubles the timeout window from 30s to 60s

~~possible alternate solution: check the location of `temp_checkpoint_dir` and ensure its writing somewhere sensible. it could be the issue is FS write latency.~~ Seems `tmp_path` defaults to $TMPDIR which seems sensible.
 
By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)
