### PR TITLE
fix(training): changes to benchmark integration tests 

### DIFF
--- a/.github/workflows/integration-tests-hpc.yml
+++ b/.github/workflows/integration-tests-hpc.yml
@@ -93,6 +93,9 @@ jobs:
             # propagate to the sbatch job); secrets are valid inside this template.
             export MLFLOW_TEST_URL=${{ secrets.MLFLOW_TEST_URL }}
             export DATASET_ROOT_PATH=${{ secrets.DATASET_ROOT_PATH }}
+            # Set up a persistent cache for TorchInductor and Triton, to be reused across jobs.
+            export TORCHINDUCTOR_CACHE_DIR=$SCRATCH/torch-compile-cache
+            export TRITON_CACHE_DIR=$SCRATCH/torch-compile-cache
             ${{ matrix.pytest_cmd }}
             deactivate
             rm -rf $REPO_NAME

--- a/.github/workflows/integration-tests-hpc.yml
+++ b/.github/workflows/integration-tests-hpc.yml
@@ -93,9 +93,6 @@ jobs:
             # propagate to the sbatch job); secrets are valid inside this template.
             export MLFLOW_TEST_URL=${{ secrets.MLFLOW_TEST_URL }}
             export DATASET_ROOT_PATH=${{ secrets.DATASET_ROOT_PATH }}
-            # Set up a persistent cache for TorchInductor and Triton, to be reused across jobs.
-            export TORCHINDUCTOR_CACHE_DIR=$SCRATCH/torch-compile-cache
-            export TRITON_CACHE_DIR=$SCRATCH/torch-compile-cache
             ${{ matrix.pytest_cmd }}
             deactivate
             rm -rf $REPO_NAME

--- a/.github/workflows/integration-tests-hpc.yml
+++ b/.github/workflows/integration-tests-hpc.yml
@@ -44,7 +44,7 @@ jobs:
               #SBATCH --gpus-per-node=2
               #SBATCH --time=1:00:00
               #SBATCH --qos=ng
-              #SBATCH --mem=0
+              #SBATCH --mem=64G
           - test_name: test_training_cycle
             pip_extras: all,tests
             pytest_cmd: python3 -m pytest -v training/tests/integration/test_training_cycle.py --slow --mlflow --mlflow-server=$MLFLOW_TEST_URL

--- a/.github/workflows/integration-tests-hpc.yml
+++ b/.github/workflows/integration-tests-hpc.yml
@@ -44,7 +44,7 @@ jobs:
               #SBATCH --gpus-per-node=2
               #SBATCH --time=1:00:00
               #SBATCH --qos=ng
-              #SBATCH --mem=64G
+              #SBATCH --mem=128G
           - test_name: test_training_cycle
             pip_extras: all,tests
             pytest_cmd: python3 -m pytest -v training/tests/integration/test_training_cycle.py --slow --mlflow --mlflow-server=$MLFLOW_TEST_URL

--- a/.github/workflows/integration-tests-hpc.yml
+++ b/.github/workflows/integration-tests-hpc.yml
@@ -34,7 +34,7 @@ jobs:
         include:
           - test_name: test_benchmark
             pip_extras: all,tests,profile
-            pytest_cmd: srun python -m pytest -v training/tests/integration/test_benchmark.py --slow --multigpu
+            pytest_cmd: srun python -m pytest --basetemp="$TMPDIR/pytest" -v training/tests/integration/test_benchmark.py --slow --multigpu
             timeout_minutes: 360
             sbatch_options: |
               #SBATCH --job-name=anemoi_core_benchmark_pytest
@@ -44,7 +44,7 @@ jobs:
               #SBATCH --gpus-per-node=2
               #SBATCH --time=1:00:00
               #SBATCH --qos=ng
-              #SBATCH --mem=128G
+              #SBATCH --mem=64G
           - test_name: test_training_cycle
             pip_extras: all,tests
             pytest_cmd: python3 -m pytest -v training/tests/integration/test_training_cycle.py --slow --mlflow --mlflow-server=$MLFLOW_TEST_URL

--- a/training/src/anemoi/training/diagnostics/benchmark_server.py
+++ b/training/src/anemoi/training/diagnostics/benchmark_server.py
@@ -71,9 +71,9 @@ class BenchmarkValue:
         return f"{self.name}: {self.value:.2f}{self.unit} (date: {self.date}, commit: {self.commit})"
 
     def to_csv(self, include_header: bool = False) -> str:
-        header = "testName,unit,date,commit,value"
+        header = "testName,unit,date,commit,value,TestUpdated"
 
-        result = f"{self.name},{self.unit},{self.date},{self.commit},{self.value}"
+        result = f"{self.name},{self.unit},{self.date},{self.commit},{self.value},False"
         if include_header:
             result = header + "\n" + result
         return result

--- a/training/src/anemoi/training/diagnostics/benchmark_server.py
+++ b/training/src/anemoi/training/diagnostics/benchmark_server.py
@@ -358,13 +358,16 @@ class BenchmarkServer(ABC):
 
         return
 
-    def store_artifacts(self, artifacts: list[Path], commit: str) -> None:
+    def store_artifacts(self, artifacts: list[Path], commit: str, subdir: str = "artifacts") -> None:
         """Takes a list of files and stores them on the server, under a commit folder.
 
         if the files exist already, by default nothing will be stored
         tar-ing reduced the size of an artifact dir from 450MB (420MB was the trace) to 22MB
+        subdir selects which folder under the store the artifacts are saved to
+        (e.g. "artifacts" for successful runs, "failed-test-artifacts" for failed runs).
+        The artifact limit is applied per subdir.
         """
-        artifact_dir = Path(f"{self.store}/artifacts")
+        artifact_dir = Path(f"{self.store}/{subdir}")
         commit_tar = Path(f"./{commit}.tar.gz")  # store commits locally before copuing them to the server
 
         LOGGER.debug("Saving artifacts for commit %s under %s", commit, commit_tar)
@@ -761,6 +764,14 @@ def benchmark(
         artifacts_tar = Path(f"./{test_case}_artifacts.tar.gz")
         _tar_files(artifacts, artifacts_tar)
         LOGGER.info("Profiling artifacts from failed run stored under: %s", artifacts_tar)
+
+        # also store the failed run's artifacts on the server (keeping the last N failed runs)
+        LOGGER.info("Storing failed-run artifacts on server under 'failed-test-artifacts'")
+        benchmark_server.store_artifacts(
+            artifacts,
+            local_benchmark_results[0].commit,
+            subdir="failed-test-artifacts",
+        )
         raise ValueError(msg)
     # the tests have passed, possibly update the data on the server
     update_data = update_data or _is_repo_on_branch("main")  # update if our branch is main

--- a/training/src/anemoi/training/diagnostics/benchmark_server.py
+++ b/training/src/anemoi/training/diagnostics/benchmark_server.py
@@ -71,7 +71,7 @@ class BenchmarkValue:
         return f"{self.name}: {self.value:.2f}{self.unit} (date: {self.date}, commit: {self.commit})"
 
     def to_csv(self, include_header: bool = False) -> str:
-        header = "testName,unit,date,commit,value,TestUpdated"
+        header = "testName,unit,date,commit,value,testUpdated"
 
         result = f"{self.name},{self.unit},{self.date},{self.commit},{self.value},False"
         if include_header:

--- a/training/tests/integration/config/benchmark/edm_diffusion_tendency.yaml
+++ b/training/tests/integration/config/benchmark/edm_diffusion_tendency.yaml
@@ -3,7 +3,7 @@ system:
   hardware:
     num_gpus_per_model: 2
   input:
-    dataset:  /home/mlx/ai-ml/datasets/aifs-ea-an-oper-0001-mars-n320-1979-2023-6h-v8.zarr
+    dataset: "${oc.env:DATASET_ROOT_PATH}/aifs-ea-an-oper-0001-mars-n320-1979-2023-6h-v8.zarr"
     graph: ./edm_diffusion_tendency-bm-graph.pt
     #store locally so graph will be reused by non-zero processes
 

--- a/training/tests/integration/config/benchmark/ensemble_crps.yaml
+++ b/training/tests/integration/config/benchmark/ensemble_crps.yaml
@@ -4,7 +4,7 @@ system:
     num_gpus_per_model: 1
     num_gpus_per_ensemble: 2
   input:
-    dataset:  /home/mlx/ai-ml/datasets/aifs-ea-an-oper-0001-mars-n320-1979-2023-6h-v8.zarr
+    dataset: "${oc.env:DATASET_ROOT_PATH}/aifs-ea-an-oper-0001-mars-n320-1979-2023-6h-v8.zarr"
     graph: ./ens-bm-graph.pt
     truncation: null
     truncation_inv: null

--- a/training/tests/integration/config/benchmark/graphtransformer.yaml
+++ b/training/tests/integration/config/benchmark/graphtransformer.yaml
@@ -3,7 +3,7 @@ system:
   hardware:
     num_gpus_per_model: 2
   input:
-    dataset:  /home/mlx/ai-ml/datasets/aifs-ea-an-oper-0001-mars-n320-1979-2023-6h-v8.zarr
+    dataset: "${oc.env:DATASET_ROOT_PATH}/aifs-ea-an-oper-0001-mars-n320-1979-2023-6h-v8.zarr"
     graph: ./graphtransformer-bm-graph.pt
     #store locally so graph will be reused by non-zero processes
 

--- a/training/tests/integration/config/benchmark/lam.yaml
+++ b/training/tests/integration/config/benchmark/lam.yaml
@@ -3,8 +3,8 @@ system:
   hardware:
     num_gpus_per_model: 2
   input:
-    dataset: /home/mlx/ai-ml/datasets/cerra-rr-an-oper-0001-mars-5p5km-1984-2022-6h-v3-hmsi.zarr
-    forcing_dataset: /home/mlx/ai-ml/datasets/aifs-ea-an-oper-0001-mars-o96-1979-2023-6h-v8.zarr
+    dataset: "${oc.env:DATASET_ROOT_PATH}/cerra-rr-an-oper-0001-mars-5p5km-1984-2022-6h-v3-hmsi.zarr"
+    forcing_dataset: "${oc.env:DATASET_ROOT_PATH}/aifs-ea-an-oper-0001-mars-o96-1979-2023-6h-v8.zarr"
     graph: ./lam-bm-graph.pt
 
 dataloader:

--- a/training/tests/integration/config/benchmark/stretched.yaml
+++ b/training/tests/integration/config/benchmark/stretched.yaml
@@ -2,8 +2,8 @@
 
 system:
   input:
-    dataset: /home/mlx/ai-ml/datasets/cerra-rr-an-oper-0001-mars-5p5km-1984-2022-6h-v3-hmsi.zarr
-    forcing_dataset: /home/mlx/ai-ml/datasets/aifs-ea-an-oper-0001-mars-o96-1979-2023-6h-v8.zarr
+    dataset: "${oc.env:DATASET_ROOT_PATH}/cerra-rr-an-oper-0001-mars-5p5km-1984-2022-6h-v3-hmsi.zarr"
+    forcing_dataset: "${oc.env:DATASET_ROOT_PATH}/aifs-ea-an-oper-0001-mars-o96-1979-2023-6h-v8.zarr"
     graph: ./stretched-bm-graph.pt
   hardware:
     num_gpus_per_model: 2

--- a/training/tests/integration/test_benchmark.py
+++ b/training/tests/integration/test_benchmark.py
@@ -60,6 +60,32 @@ def restore_base_seed(original_seed: str | None) -> None:
 
 @pytest.mark.multigpu
 @pytest.mark.slow
+def test_benchmark_training_cycle(
+    benchmark_config: tuple[DictConfig, str],  # cfg, benchmarkTestCase, task
+) -> None:
+    """Runs a benchmark and then compares them against the values stored on a server."""
+    cfg, test_case = benchmark_config
+    LOGGER.info("Benchmarking the configuration: %s", test_case)
+
+    # Reset memory logging and free all possible memory between runs
+    # this ensures we report the peak memory used during each run,
+    # and not the peak memory used by the run with the highest memory usage
+    reset_peak_memory_stats()
+    empty_cache()
+    gc.collect()
+    # Run model with profiler
+    AnemoiProfiler(cfg).profile()
+
+    # determine store from benchmark config
+    config_path = Path("~/.config/anemoi/anemoi-benchmark.yaml").expanduser()
+    user, hostname, path = parse_benchmark_config(config_path)
+    store: str = f"ssh://{user}@{hostname}:{path}"
+
+    benchmark(cfg, test_case, store)
+
+
+@pytest.mark.multigpu
+@pytest.mark.slow
 def test_benchmark_dataloader(
     benchmark_config: tuple[DictConfig, str],  # cfg, benchmarkTestCase,
 ) -> None:
@@ -67,6 +93,10 @@ def test_benchmark_dataloader(
     from anemoi.training.data.datamodule import AnemoiDatasetsDataModule
 
     cfg, test_case = benchmark_config
+
+    # Just run for graphtransformer configuration, in order to minimize test runtime.
+    if test_case != "graphtransformer":
+        pytest.skip("Dataloader benchmark only runs for the graphtransformer configuration")
 
     original_seed, random_seed = set_temp_base_seed()
     LOGGER.info("Benchmarking dataloader for configuration: %s (seed=%s)", test_case, random_seed)
@@ -130,29 +160,3 @@ def test_benchmark_dataloader(
         track_dataloader_benchmark_results(test_case, batches_per_second)
     finally:
         restore_base_seed(original_seed)
-
-
-@pytest.mark.multigpu
-@pytest.mark.slow
-def test_benchmark_training_cycle(
-    benchmark_config: tuple[DictConfig, str],  # cfg, benchmarkTestCase, task
-) -> None:
-    """Runs a benchmark and then compares them against the values stored on a server."""
-    cfg, test_case = benchmark_config
-    LOGGER.info("Benchmarking the configuration: %s", test_case)
-
-    # Reset memory logging and free all possible memory between runs
-    # this ensures we report the peak memory used during each run,
-    # and not the peak memory used by the run with the highest memory usage
-    reset_peak_memory_stats()
-    empty_cache()
-    gc.collect()
-    # Run model with profiler
-    AnemoiProfiler(cfg).profile()
-
-    # determine store from benchmark config
-    config_path = Path("~/.config/anemoi/anemoi-benchmark.yaml").expanduser()
-    user, hostname, path = parse_benchmark_config(config_path)
-    store: str = f"ssh://{user}@{hostname}:{path}"
-
-    benchmark(cfg, test_case, store)

--- a/training/tests/integration/test_benchmark.py
+++ b/training/tests/integration/test_benchmark.py
@@ -106,6 +106,10 @@ def test_benchmark_training_dataloader(
     original_seed, random_seed = set_temp_base_seed()
     LOGGER.info("Benchmarking dataloader for configuration: %s (seed=%s)", test_case, random_seed)
 
+    task = None
+    datamodule = None
+    train_dataloader = None
+    data_iter = None
     try:
         # Initialize task
         task = instantiate(cfg.task)
@@ -126,7 +130,8 @@ def test_benchmark_training_dataloader(
         start_time = time.perf_counter()
         batch_count = 0
 
-        for batch_idx, batch in enumerate(train_dataloader):
+        data_iter = iter(train_dataloader)
+        for batch_idx, batch in enumerate(data_iter):
             if batch_idx >= num_batches_to_test:
                 break
             batch_count += 1
@@ -164,4 +169,12 @@ def test_benchmark_training_dataloader(
         LOGGER.info("  Process tree RSS delta:  %.2f MiB", rss_after - rss_before)
         track_dataloader_benchmark_results(test_case, batches_per_second)
     finally:
+        # Shut down the DataLoader worker processes and free their shared-memory
+        # segments.
+        del data_iter
+        del train_dataloader
+        del datamodule
+        del task
+        gc.collect()
+        empty_cache()
         restore_base_seed(original_seed)


### PR DESCRIPTION
## Description
small tweaks to improve benchmark tests:
1. extend the use of DATASET_ROOT_PATH to benchmark tests
2. add 'testUpdated' column to benchmark database  - in the future this will be used to show on the performance-over-time plot when the benchmark test has been updated
3. lower slurm CPU memory requirement in benchmark tests => less queuing, others can use the other half of the node
4. Run just the graph transformer dataloader test and run it after the main tests
5. store the profiling artifacts from the last 10 *failed* runs on the benchmark server => help debugging performance regressions

very happy to get feedback on these changes.


I suggest skipping most of the dataloader tests to speedup the benchmark tests overall as they can now often run for over an hour. I am open to reverting this If people think there is significant value from running all/more of the dataloader benchmarks.

the benchmark tests are [passing](https://github.com/ecmwf/anemoi-core/actions/runs/30264377819/job/89988082850)

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)
