### PR TITLE
fix(training): remove broken n_plots_per_sample option from ensemble plots

### DIFF
--- a/training/src/anemoi/training/config/diagnostics/evaluation_ens.yaml
+++ b/training/src/anemoi/training/config/diagnostics/evaluation_ens.yaml
@@ -25,7 +25,6 @@ plot:
       plot_fn:
         _target_: anemoi.training.diagnostics.evaluation.plotting.batch_output.ensemble_plot_fn
         _partial_: true
-        n_plots_per_sample: 2
         accumulation_levels_plot: [0, 0.05, 0.1, 0.25, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 7, 100] # in mm
 
     # Deterministic callbacks are also overloaded.

--- a/training/src/anemoi/training/diagnostics/evaluation/plotting/batch_output.py
+++ b/training/src/anemoi/training/diagnostics/evaluation/plotting/batch_output.py
@@ -42,8 +42,6 @@ Built-in plot functions and their optional kwargs
 
     - ``accumulation_levels_plot`` (list, default ``DEFAULT_ACCUMULATION_LEVELS``):
       colour levels in mm for precipitation fields.
-    - ``n_plots_per_sample`` (int, default ``4``): number of fixed panels per
-      variable row (target, pred mean, mean error, ens sd).
 
 Rendering settings (datashader, projection, colormaps, precip_and_related_fields)
 are read from the ``settings`` object passed by the callback — configure them
@@ -158,7 +156,6 @@ def ensemble_plot_fn(
     auxiliary: np.ndarray | None = None,  # noqa: ARG001
     settings: Any | None = None,
     accumulation_levels_plot: list | None = None,
-    n_plots_per_sample: int = 4,
     **_kwargs: Any,
 ) -> Figure:
     """Adapter for ``plot_predicted_ensemble`` (PlotEnsSample)."""
@@ -168,7 +165,6 @@ def ensemble_plot_fn(
     levels = accumulation_levels_plot if accumulation_levels_plot is not None else DEFAULT_ACCUMULATION_LEVELS
     return plot_predicted_ensemble(
         parameters=parameters,
-        n_plots_per_sample=n_plots_per_sample,
         latlons=latlons,
         clevels=levels,
         y_true=np.asarray(y_true).squeeze(),

--- a/training/src/anemoi/training/diagnostics/evaluation/plotting/ensemble.py
+++ b/training/src/anemoi/training/diagnostics/evaluation/plotting/ensemble.py
@@ -73,6 +73,8 @@ def plot_ensemble_sample(
         Colormap for the plot
     error_cmap : Colormap, optional
         Colormap for the error plot
+    data_crs : object, optional
+        Cartopy CRS describing the coordinate system of lon/lat, by default None
 
     Returns
     -------
@@ -159,7 +161,6 @@ def plot_ensemble_sample(
 
 def plot_predicted_ensemble(
     parameters: dict[int, str],
-    n_plots_per_sample: int,
     latlons: np.ndarray,
     clevels: float,
     y_true: np.ndarray,
@@ -175,9 +176,6 @@ def plot_predicted_ensemble(
     ----------
     parameters : Dict[int, str]
         Dictionary of target variables
-    n_plots_per_sample : int
-        Number of fixed panels per variable row (target, pred mean, mean error, ens sd = 4).
-        Ensemble member panels are added on top of this count.
     latlons : np.ndarray
         Latitudes and longitudes
     clevels : float
@@ -202,7 +200,9 @@ def plot_predicted_ensemble(
     """
     nens = y_pred.shape[0] if len(y_pred.shape) == 3 else 1
 
-    n_plots_x, n_plots_y = len(parameters), nens + n_plots_per_sample
+    # 4 fixed panels per variable row (target, pred mean, ens mean err, ens sd),
+    # matching the axes plot_ensemble_sample writes to, plus one panel per member
+    n_plots_x, n_plots_y = len(parameters), nens + 4
     LOGGER.debug("n_plots_x = %d, n_plots_y = %d", n_plots_x, n_plots_y)
 
     plot_kind = "equirectangular" if datashader else projection_kind

--- a/training/tests/integration/config/test_ensemble_crps.yaml
+++ b/training/tests/integration/config/test_ensemble_crps.yaml
@@ -45,7 +45,6 @@ diagnostics:
         plot_fn:
           _target_: anemoi.training.diagnostics.evaluation.plotting.batch_output.ensemble_plot_fn
           _partial_: true
-          n_plots_per_sample: 4
           accumulation_levels_plot: [0, 0.05, 0.1, 0.25, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 7, 100]
 
       # Deterministic callbacks are also overloaded.

--- a/training/tests/integration/config/test_transport.yaml
+++ b/training/tests/integration/config/test_transport.yaml
@@ -27,7 +27,6 @@ diagnostics:
         plot_fn:
           _target_: anemoi.training.diagnostics.evaluation.plotting.batch_output.ensemble_plot_fn
           _partial_: true
-          n_plots_per_sample: 4
           accumulation_levels_plot: [0, 0.05, 0.1, 0.25, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 7, 100]
 
       - _target_: anemoi.training.diagnostics.callbacks.plot.LossCurvePlot

--- a/training/tests/unit/diagnostics/test_plotting_callbacks.py
+++ b/training/tests/unit/diagnostics/test_plotting_callbacks.py
@@ -90,7 +90,6 @@ PlotEnsSample = _wrap_plot_callback(
     tag_infix="ens_sample",
     plot_fn_kwargs={
         "accumulation_levels_plot": None,
-        "n_plots_per_sample": 4,
         "plot_members": None,
     },
 )
@@ -1230,6 +1229,44 @@ def test_plots_plot_predicted_multilevel_flat_sample_accepts_auxiliary_panel():
     assert any(title == "tp corrupted targets" for title in plot_titles)
     assert "tp increment [pred - input]" not in plot_titles
     assert "tp persist err" not in plot_titles
+    fig.clear()
+    plt.close(fig)
+
+
+@pytest.mark.parametrize("nens", [1, 4])
+def test_plots_plot_predicted_ensemble_allocates_four_fixed_panels_plus_members(nens):
+    """plot_predicted_ensemble gives each variable 4 fixed panels plus one per member."""
+    import matplotlib.pyplot as plt
+
+    from anemoi.training.diagnostics.evaluation.plotting.ensemble import plot_predicted_ensemble
+
+    parameters = {0: ("t2m", False), 1: ("tp", True)}
+    nlatlon, nvar = 12, 2
+    latlons = np.stack(
+        [np.linspace(50, 55, nlatlon), np.linspace(0, 5, nlatlon)],
+        axis=1,
+    )
+    rng = np.random.default_rng(0)
+    y_true = rng.standard_normal((nlatlon, nvar)).astype(np.float64)
+    y_pred = rng.standard_normal((nens, nlatlon, nvar)).astype(np.float64)
+
+    fig = plot_predicted_ensemble(
+        parameters,
+        latlons,
+        [0.5],
+        y_true,
+        y_pred,
+        datashader=False,
+    )
+
+    # colorbar axes carry no title, so titled axes == plotted panels
+    titles = [ax.get_title() for ax in fig.axes if ax.get_title()]
+    assert len(titles) == nvar * (nens + 4)
+    for vname in ("t2m", "tp"):
+        for suffix in ("target", "pred mean", "ens mean err", "ens sd"):
+            assert f"{vname} {suffix}" in titles
+        for i_ens in range(nens):
+            assert f"{vname}_{i_ens + 1} - mean" in titles
     fig.clear()
     plt.close(fig)
 


### PR DESCRIPTION
plot_ensemble_sample hardcodes 4 summary panels (target, pred mean, ens mean err, ens sd), so any configured value below 4 caused an IndexError in the rank-0 plotting callback, surfacing as NCCL broken-pipe errors on the other ranks. Allocate nens + 4 axes directly and drop the option from ensemble_plot_fn and the configs; old configs still setting it are ignored harmlessly via **kwargs.

## Description
<!-- What issue or task does this change relate to? -->

## What problem does this change solve?
<!-- Describe if it's a bugfix, new feature, doc update, or breaking change -->

## What issue or task does this change relate to?
<!-- link to Issue Number -->

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)
