### PR TITLE
fix(training): set default progress bar for profiler

### DIFF
--- a/training/src/anemoi/training/train/profiler.py
+++ b/training/src/anemoi/training/train/profiler.py
@@ -278,10 +278,12 @@ class AnemoiProfiler(AnemoiTrainer):
 
     @cached_property
     def callbacks(self) -> list[pl.callbacks.Callback]:
-        self.config.diagnostics.progress_bar["_target_"] = (
-            ProfilerProgressBar.__module__ + "." + ProfilerProgressBar.__name__
-        )
         callbacks = super().callbacks
+
+        # Force the profiler's own progress bar.
+        callbacks = [c for c in callbacks if not isinstance(c, pl.callbacks.ProgressBar)]
+        callbacks.append(ProfilerProgressBar())
+
         if self.config.diagnostics.benchmark_profiler.snapshot.enabled:
             from anemoi.training.diagnostics.callbacks.profiler import MemorySnapshotRecorder
             from anemoi.training.diagnostics.profilers import check_torch_version


### PR DESCRIPTION
## Description
`AnemoiProfiler.callbacks` forced its own progress bar by assigning into `config.diagnostics.progress_bar["_target_"]` before delegating to `super().callbacks`. When the config omits the `progress_bar` block (pydantic schema default `None`), this raises an error. The block is optional and valid to omit when running `anemoi-training train` so `profile` should too.

Fix:
Stop mutating the config. Instead, let `super().callbacks` resolve the progress bar through the existing shared null-safe guard (`_get_progress_bar_callback`), then filter out whatever `ProgressBar` it produced and substitute the profiler's own `ProfilerProgressBar`. This keeps exactly one `ProgressBar` for Lightning (satisfies the Lightning ≥ 2.6 single-bar requirement) without duplicating the `None`-handling logic.

## What issue or task does this change relate to?
#1276

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)
