### PR TITLE
perf(training): disable broadcast buffers

### DIFF
--- a/training/src/anemoi/training/config/model/graphtransformer.yaml
+++ b/training/src/anemoi/training/config/model/graphtransformer.yaml
@@ -111,6 +111,7 @@ trainable_parameters:
 # options (dict): a dict of further options which can be passed to torch.compile
 compile:
   - module: anemoi.models.layers.conv.GraphTransformerConv
+recompile_limit: 32 # need to increase to try get _forward_edge_sharding_attention to compile w dynamic false
 
 attributes:
   edges:

--- a/training/src/anemoi/training/config/model/graphtransformer.yaml
+++ b/training/src/anemoi/training/config/model/graphtransformer.yaml
@@ -111,7 +111,6 @@ trainable_parameters:
 # options (dict): a dict of further options which can be passed to torch.compile
 compile:
   - module: anemoi.models.layers.conv.GraphTransformerConv
-recompile_limit: 32 # need to increase to try get _forward_edge_sharding_attention to compile w dynamic false
 
 attributes:
   edges:

--- a/training/src/anemoi/training/config/training/ensemble.yaml
+++ b/training/src/anemoi/training/config/training/ensemble.yaml
@@ -54,6 +54,7 @@ strategy:
   num_gpus_per_model: ${system.hardware.num_gpus_per_model}
   read_group_size: ${dataloader.read_group_size}
   use_local_synchronization: True
+  broadcast_buffers: False
 
 # loss functions
 

--- a/training/src/anemoi/training/config/training/lam.yaml
+++ b/training/src/anemoi/training/config/training/lam.yaml
@@ -52,6 +52,7 @@ strategy:
   num_gpus_per_model: ${system.hardware.num_gpus_per_model}
   read_group_size: ${dataloader.read_group_size}
   use_local_synchronization: True
+  broadcast_buffers: False
 
 # loss functions
 

--- a/training/src/anemoi/training/config/training/multi.yaml
+++ b/training/src/anemoi/training/config/training/multi.yaml
@@ -54,6 +54,7 @@ strategy:
   num_gpus_per_model: ${system.hardware.num_gpus_per_model}
   read_group_size: ${dataloader.read_group_size}
   use_local_synchronization: True
+  broadcast_buffers: False
 
 # loss functions
 

--- a/training/src/anemoi/training/config/training/single.yaml
+++ b/training/src/anemoi/training/config/training/single.yaml
@@ -50,6 +50,7 @@ strategy:
   num_gpus_per_model: ${system.hardware.num_gpus_per_model}
   read_group_size: ${dataloader.read_group_size}
   use_local_synchronization: True
+  broadcast_buffers: False
 
 # dynamic rescaling of the loss gradient
 # see https://arxiv.org/pdf/2306.06079.pdf, section 4.3.2

--- a/training/src/anemoi/training/config/training/stretched.yaml
+++ b/training/src/anemoi/training/config/training/stretched.yaml
@@ -53,6 +53,7 @@ strategy:
   num_gpus_per_model: ${system.hardware.num_gpus_per_model}
   read_group_size: ${dataloader.read_group_size}
   use_local_synchronization: True
+  broadcast_buffers: False
 
 # loss functions
 

--- a/training/src/anemoi/training/config/training/transport.yaml
+++ b/training/src/anemoi/training/config/training/transport.yaml
@@ -40,6 +40,7 @@ strategy:
   num_gpus_per_model: ${system.hardware.num_gpus_per_model}
   read_group_size: ${dataloader.read_group_size}
   use_local_synchronization: True
+  broadcast_buffers: False
 
 loss_gradient_scaling: False
 

--- a/training/src/anemoi/training/distributed/strategy.py
+++ b/training/src/anemoi/training/distributed/strategy.py
@@ -93,6 +93,7 @@ class BaseDDPStrategy(DDPStrategy):
         num_gpus_per_model: int,
         read_group_size: int,
         use_local_synchronization: bool = True,
+        broadcast_buffers: bool = False,
         **kwargs: dict,
     ) -> None:
         """Initialise the distributed strategy.
@@ -105,10 +106,12 @@ class BaseDDPStrategy(DDPStrategy):
             Number of GPUs per reader group.
         use_local_synchronization : bool, optional
             Use synchronization local to the group when creating process groups.
+        broadcast_buffers : bool, optional
+            Whether to broadcast module buffers at the start of each iteration. Defaults to False.
         **kwargs : dict
             Additional keyword arguments.
         """
-        super().__init__(**kwargs, broadcast_buffers=False)
+        super().__init__(**kwargs, broadcast_buffers=broadcast_buffers)
         self.model_comm_group_size = num_gpus_per_model
         self.read_group_size = read_group_size
         self.use_local_synchronization = use_local_synchronization

--- a/training/src/anemoi/training/distributed/strategy.py
+++ b/training/src/anemoi/training/distributed/strategy.py
@@ -108,7 +108,7 @@ class BaseDDPStrategy(DDPStrategy):
         **kwargs : dict
             Additional keyword arguments.
         """
-        super().__init__(**kwargs)
+        super().__init__(**kwargs, broadcast_buffers=False)
         self.model_comm_group_size = num_gpus_per_model
         self.read_group_size = read_group_size
         self.use_local_synchronization = use_local_synchronization

--- a/training/src/anemoi/training/schemas/training.py
+++ b/training/src/anemoi/training/schemas/training.py
@@ -651,6 +651,8 @@ class BaseDDPStrategySchema(BaseModel):
     "Number of GPUs per reader group. Defaults to number of GPUs."
     use_local_synchronization: bool = Field(default=True, example=True)
     "Use synchronization local to the group when creating process groups."
+    broadcast_buffers: bool = Field(default=False, example=False)
+    "Broadcast model buffers at the start of each iteration. Defaults to False."
 
 
 class DDPEnsGroupStrategyStrategySchema(BaseDDPStrategySchema):


### PR DESCRIPTION
## Description
by default when using DDP all the registered buffers are broadcast from rank 0 to all other ranks at the start of every iteration. this synchronisation is required for batchNorm, but we dont use that. so it should be fine to disable.

when sharding over multiple nodes, the broadcasts start to hurt

**16 gpus per model, 1024c n320-l6 forward pass. the broadcast is 10% of the forward pass**
<img width="424" height="202" alt="Screenshot 2026-07-30 at 08 58 47" src="https://github.com/user-attachments/assets/3d15f18d-8473-4616-969e-990b3333db4c" />

after this PR, the broadcasts are gone. Throughput has increased from 6.15it/s to 6.27it/s
<img width="342" height="153" alt="Screenshot 2026-07-30 at 09 20 29" src="https://github.com/user-attachments/assets/6177abf0-531c-4ce5-985a-97738746d279" />


***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)
