### PR TITLE
perf(training): minimise broadcasts from lightning checkpoints

### DIFF
--- a/training/src/anemoi/training/config/diagnostics/evaluation.yaml
+++ b/training/src/anemoi/training/config/diagnostics/evaluation.yaml
@@ -16,7 +16,7 @@ debug:
 enable_checkpointing: True
 checkpoint:
   every_n_minutes:
-    save_frequency: 30 # Approximate, as this is checked at the end of training steps
+    save_frequency: 30 # Approximate, as this is checked at the end of every 10 training steps
     num_models_saved: 3 # If set to k, saves the 'last' k model weights in the training.
 
   every_n_epochs:

--- a/training/src/anemoi/training/config/diagnostics/evaluation.yaml
+++ b/training/src/anemoi/training/config/diagnostics/evaluation.yaml
@@ -16,7 +16,7 @@ debug:
 enable_checkpointing: True
 checkpoint:
   every_n_minutes:
-    save_frequency: 30 # Approximate, as this is checked at the end of every 10 training steps
+    save_frequency: 30 # Approximate, as this is checked at the end of every 50 training steps
     num_models_saved: 3 # If set to k, saves the 'last' k model weights in the training.
 
   every_n_epochs:

--- a/training/src/anemoi/training/config/diagnostics/evaluation_ens.yaml
+++ b/training/src/anemoi/training/config/diagnostics/evaluation_ens.yaml
@@ -78,7 +78,7 @@ debug:
 enable_checkpointing: True
 checkpoint:
   every_n_minutes:
-    save_frequency: 30 # Approximate, as this is checked at the end of training steps
+    save_frequency: 30 # Approximate, as this is checked at the end of every 10 training steps
     num_models_saved: 3 # If set to k, saves the 'last' k model weights in the training.
 
   every_n_epochs:

--- a/training/src/anemoi/training/config/diagnostics/evaluation_ens.yaml
+++ b/training/src/anemoi/training/config/diagnostics/evaluation_ens.yaml
@@ -78,7 +78,7 @@ debug:
 enable_checkpointing: True
 checkpoint:
   every_n_minutes:
-    save_frequency: 30 # Approximate, as this is checked at the end of every 10 training steps
+    save_frequency: 30 # Approximate, as this is checked at the end of every 50 training steps
     num_models_saved: 3 # If set to k, saves the 'last' k model weights in the training.
 
   every_n_epochs:

--- a/training/src/anemoi/training/config/diagnostics/evaluation_multi.yaml
+++ b/training/src/anemoi/training/config/diagnostics/evaluation_multi.yaml
@@ -16,7 +16,7 @@ debug:
 enable_checkpointing: True
 checkpoint:
   every_n_minutes:
-    save_frequency: 30 # Approximate, as this is checked at the end of training steps
+    save_frequency: 30 # Approximate, as this is checked at the end of every 10 training steps
     num_models_saved: 3 # If set to k, saves the 'last' k model weights in the training.
 
   every_n_epochs:

--- a/training/src/anemoi/training/config/diagnostics/evaluation_multi.yaml
+++ b/training/src/anemoi/training/config/diagnostics/evaluation_multi.yaml
@@ -16,7 +16,7 @@ debug:
 enable_checkpointing: True
 checkpoint:
   every_n_minutes:
-    save_frequency: 30 # Approximate, as this is checked at the end of every 10 training steps
+    save_frequency: 30 # Approximate, as this is checked at the end of every 50 training steps
     num_models_saved: 3 # If set to k, saves the 'last' k model weights in the training.
 
   every_n_epochs:

--- a/training/src/anemoi/training/diagnostics/callbacks/checkpoint.py
+++ b/training/src/anemoi/training/diagnostics/callbacks/checkpoint.py
@@ -18,6 +18,7 @@ import torch
 import torchinfo
 from pytorch_lightning.callbacks.model_checkpoint import ModelCheckpoint
 from pytorch_lightning.utilities import rank_zero_only
+from pytorch_lightning.utilities.types import STEP_OUTPUT
 
 from anemoi.training.utils.checkpoint import check_classes
 from anemoi.training.utils.checkpoint import clear_imputer_runtime_state
@@ -48,7 +49,7 @@ class AnemoiCheckpoint(ModelCheckpoint):
         # when checkpointing by time, round to
         # the nearest N steps
         # This reduces broadcasts by a factor
-        # of
+        # of self._time_check_every_n_steps
         self._time_check_every_n_steps = 10
 
     @staticmethod
@@ -78,7 +79,14 @@ class AnemoiCheckpoint(ModelCheckpoint):
 
         return self._model_metadata
 
-    def on_train_batch_end(self, trainer, pl_module, outputs, batch, batch_idx) -> None:
+    def on_train_batch_end(
+        self,
+        trainer: "pl.Trainer",
+        pl_module: "pl.LightningModule",
+        outputs: STEP_OUTPUT,
+        batch: any,
+        batch_idx: int,
+    ) -> None:
         # when using time-based checkpointing there is a broadcast each iteration
         # This can get quite expensive when sharding to a large number of GPUs
         # per model

--- a/training/src/anemoi/training/diagnostics/callbacks/checkpoint.py
+++ b/training/src/anemoi/training/diagnostics/callbacks/checkpoint.py
@@ -45,6 +45,12 @@ class AnemoiCheckpoint(ModelCheckpoint):
         self._tracker_metadata = None
         self._tracker_name = None
 
+        # when checkpointing by time, round to
+        # the nearest N steps
+        # This reduces broadcasts by a factor
+        # of 
+        self._time_check_every_n_steps = 10
+
     @staticmethod
     def _torch_drop_down(trainer: pl.Trainer) -> torch.nn.Module:
         # Get the model from the DataParallel wrapper, for single and multi-gpu cases
@@ -71,6 +77,16 @@ class AnemoiCheckpoint(ModelCheckpoint):
         }
 
         return self._model_metadata
+
+     def on_train_batch_end(self, trainer, pl_module, outputs, batch, batch_idx) -> None:
+         # when using time-based checkpointing there is a broadcast each iteration
+         # This can get quite expensive when sharding to a large number of GPUs
+         # per model
+         # To minimise the cost, we round the time interval up to the next N steps
+         # This reduces broadcasts by a factor of N
+         if self._train_time_interval is not None and trainer.global_step % self._time_check_every_n_steps != 0:
+             return
+         super().on_train_batch_end(trainer, pl_module, outputs, batch, batch_idx)
 
     def _adjust_epoch_progress(self, trainer: pl.Trainer) -> None:
         """Adjust the epoch progress when saving a mid-epoch checkpoint.

--- a/training/src/anemoi/training/diagnostics/callbacks/checkpoint.py
+++ b/training/src/anemoi/training/diagnostics/callbacks/checkpoint.py
@@ -50,7 +50,7 @@ class AnemoiCheckpoint(ModelCheckpoint):
         # the nearest N steps
         # This reduces broadcasts by a factor
         # of self._time_check_every_n_steps
-        self._time_check_every_n_steps = 10
+        self._time_check_every_n_steps = 50
 
     @staticmethod
     def _torch_drop_down(trainer: pl.Trainer) -> torch.nn.Module:

--- a/training/src/anemoi/training/diagnostics/callbacks/checkpoint.py
+++ b/training/src/anemoi/training/diagnostics/callbacks/checkpoint.py
@@ -48,7 +48,7 @@ class AnemoiCheckpoint(ModelCheckpoint):
         # when checkpointing by time, round to
         # the nearest N steps
         # This reduces broadcasts by a factor
-        # of 
+        # of
         self._time_check_every_n_steps = 10
 
     @staticmethod
@@ -79,14 +79,14 @@ class AnemoiCheckpoint(ModelCheckpoint):
         return self._model_metadata
 
     def on_train_batch_end(self, trainer, pl_module, outputs, batch, batch_idx) -> None:
-         # when using time-based checkpointing there is a broadcast each iteration
-         # This can get quite expensive when sharding to a large number of GPUs
-         # per model
-         # To minimise the cost, we round the time interval up to the next N steps
-         # This reduces broadcasts by a factor of N
-         if self._train_time_interval is not None and trainer.global_step % self._time_check_every_n_steps != 0:
-             return
-         super().on_train_batch_end(trainer, pl_module, outputs, batch, batch_idx)
+        # when using time-based checkpointing there is a broadcast each iteration
+        # This can get quite expensive when sharding to a large number of GPUs
+        # per model
+        # To minimise the cost, we round the time interval up to the next N steps
+        # This reduces broadcasts by a factor of N
+        if self._train_time_interval is not None and trainer.global_step % self._time_check_every_n_steps != 0:
+            return
+        super().on_train_batch_end(trainer, pl_module, outputs, batch, batch_idx)
 
     def _adjust_epoch_progress(self, trainer: pl.Trainer) -> None:
         """Adjust the epoch progress when saving a mid-epoch checkpoint.

--- a/training/src/anemoi/training/diagnostics/callbacks/checkpoint.py
+++ b/training/src/anemoi/training/diagnostics/callbacks/checkpoint.py
@@ -78,7 +78,7 @@ class AnemoiCheckpoint(ModelCheckpoint):
 
         return self._model_metadata
 
-     def on_train_batch_end(self, trainer, pl_module, outputs, batch, batch_idx) -> None:
+    def on_train_batch_end(self, trainer, pl_module, outputs, batch, batch_idx) -> None:
          # when using time-based checkpointing there is a broadcast each iteration
          # This can get quite expensive when sharding to a large number of GPUs
          # per model


### PR DESCRIPTION
## Description
When we use time based checkpointing, pytorch lightning adds a global broadcast across all ranks at the end of each batch. When running over many gpus, this can become noticeable 
```
# this will enable the broadcasts each step
diagnostics:
  checkpoint:
    every_n_minutes:
      save_frequency: 30
```
The purpose of the constant broadcasting is to keep the ranks in sync, so that the non-zero ranks know when rank 0 is checkpointing.

for an n320-o96 model across 16 GPUs you can see the broadcasts in light green, before the forward in purple, it takes up about 10% of the forward pass
<img width="572" height="165" alt="Screenshot 2026-07-30 at 09 17 47" src="https://github.com/user-attachments/assets/a05165e5-6bb5-41ee-bd2e-a961e4bfcf2f" />
If I disable the broadcast, throughput increases from 6.27 to 6.4it/s

[Here](https://github.com/Lightning-AI/pytorch-lightning/blob/f9751d2726a1e838fabe5faf90c138112beeb57c/src/lightning/pytorch/callbacks/model_checkpoint.py#L435) is the underlying pytorch lightning code

one possible way to fix this would be to only do the broadcast every N steps. This means that your checkpoint wouldn't be produced exactly at frequency T, instead it would be written at the first multiple of step N after time T. 
I have suggested N=10 in this PR

the integration tests [pass](https://github.com/ecmwf/anemoi-core/actions/runs/30527146377/job/90822543998), except for an unrelated error

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)
