### PR TITLE
fix: callbacks cache

### DIFF
--- a/training/src/anemoi/training/diagnostics/callbacks/plot.py
+++ b/training/src/anemoi/training/diagnostics/callbacks/plot.py
@@ -456,6 +456,12 @@ class BasePerBatchPlotCallback(BasePlotCallback):
                         )
                 self.post_processors[dataset_name] = self.post_processors[dataset_name].cpu()
 
+            # Share one processed_cache across all callbacks on the same batch
+            # so post-processing runs once per (dataset, members) pair.
+            if getattr(pl_module, "_plot_cache_batch_idx", None) != batch_idx:
+                pl_module._plot_cache = {}
+                pl_module._plot_cache_batch_idx = batch_idx
+
             plot_kwargs = self._plot_kwargs_from_output(pl_module, output)
             output = TrainingStepOutput(
                 loss=output.loss,
@@ -470,7 +476,7 @@ class BasePerBatchPlotCallback(BasePlotCallback):
                 batch,
                 batch_idx,
                 epoch=trainer.current_epoch,
-                processed_cache={},
+                processed_cache=pl_module._plot_cache,
                 **plot_kwargs,
                 **kwargs,
             )

--- a/training/tests/unit/diagnostics/test_plotting_callbacks.py
+++ b/training/tests/unit/diagnostics/test_plotting_callbacks.py
@@ -529,6 +529,10 @@ def test_process_temporal_downscaler_multi_out_squeeze():
 def test_process_cache_shared_across_callbacks():
     """A shared processed_cache avoids redundant post-processing across PlotSample, PlotSpectrum, PlotHistogram.
 
+    Note: this test exercises the process() caching mechanism in isolation by passing a dict directly.
+    It does not test the production wiring (pl_module._plot_cache shared via on_validation_batch_end);
+    that is covered by test_on_validation_batch_end_shares_cache_across_callbacks.
+
     Verifies:
     - post-processor called once per (dataset, members) pair despite N callbacks
     - cache hit returns the identical tuple object (not a copy)

--- a/training/tests/unit/diagnostics/test_plotting_callbacks.py
+++ b/training/tests/unit/diagnostics/test_plotting_callbacks.py
@@ -427,6 +427,39 @@ def test_plot_sample_uses_auxiliary_output_from_validation_output():
     assert plotted_output.plot_kwargs == {}
 
 
+def test_on_validation_batch_end_shares_cache_across_callbacks():
+    """Two callbacks on the same batch share pl_module._plot_cache; a new batch resets it."""
+    batch_size, n_ens, nlatlon, nvar = 2, 1, 20, 2
+    pl_module = _make_pl_module_forecaster(validation_rollout=1, nlatlon=nlatlon)
+    pl_module.allgather_batch = lambda tensor, _dataset_name: tensor
+    pl_module.model.post_processors = {"data": _IdentityProcessor()}
+
+    batch = {"data": torch.randn(batch_size, 3, n_ens, nlatlon, nvar)}
+    output = _step_output([{"data": torch.zeros(batch_size, 1, n_ens, nlatlon, nvar)}])
+    trainer = MagicMock()
+    trainer.current_epoch = 0
+
+    cb1 = PlotSample(sample_idx=0, parameters=["a", "b"], dataset_names=["data"], every_n_batches=1)
+    cb2 = PlotHistogram(sample_idx=0, parameters=["a", "b"], dataset_names=["data"], every_n_batches=1)
+    for cb in (cb1, cb2):
+        cb.plot = MagicMock()
+
+    cb1.on_validation_batch_end(trainer, pl_module, output, batch, batch_idx=0)
+    cb2.on_validation_batch_end(trainer, pl_module, output, batch, batch_idx=0)
+
+    assert hasattr(pl_module, "_plot_cache"), "pl_module should have _plot_cache after first callback"
+    assert pl_module._plot_cache_batch_idx == 0
+    cache_after_batch0 = pl_module._plot_cache
+
+    # same batch: cache object must be the same (shared, not replaced)
+    assert pl_module._plot_cache is cache_after_batch0
+
+    # new batch: cache must be reset
+    cb1.on_validation_batch_end(trainer, pl_module, output, batch, batch_idx=1)
+    assert pl_module._plot_cache_batch_idx == 1
+    assert pl_module._plot_cache is not cache_after_batch0
+
+
 def test_process_time_interpolator_output_shapes():
     """BasePlotAdditionalMetrics.process: time-interpolator task yields expected shapes."""
     callback = PlotSample(


### PR DESCRIPTION
## Description
This PR fixes redundant post-processing during validation plotting: previously each per-batch plot callback (PlotSample, PlotHistogram, etc.) created its own fresh processed_cache={}}, so post-processing ran once per callback per batch; now a shared _plot_cache dict is stashed on pl_module (keyed by _plot_cache_batch_idx, reset when the batch index changes), so all callbacks on the same validation batch reuse one cache and post-processing runs only once per (dataset, members) pair . A new unit test (test_on_validation_batch_end_shares_cache_across_callbacks) verifies the shared-cache behavior and reset-on-new-batch behavior, plus a clarifying docstring was added to the existing cache test

## What problem does this change solve?
Fix https://github.com/ecmwf/anemoi-core/issues/1280

## What issue or task does this change relate to?
<!-- link to Issue Number -->

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)
