### PR TITLE
perf(training): all-to-all interface for torch.compile() 

### DIFF
--- a/models/src/anemoi/models/distributed/primitives.py
+++ b/models/src/anemoi/models/distributed/primitives.py
@@ -294,89 +294,91 @@ def _alltoallwrapper(output_list: list, input_list: list, group: ProcessGroup):
                 reqs.append(dist.isend(input_list[j], group_dst=j, group=group))
                 reqs.append(dist.irecv(output_list[j], group_src=j, group=group))
             else:
-                output_list[rank].copy_(input_list[rank])
+                output_list[rank] = input_list[rank]
         for req in reqs:
             req.wait()
     else:
         dist.all_to_all(output_list, input_list, group=group)
 
 
-@torch.library.custom_op("anemoi_distributed::alltoall", mutates_args=())
-def _alltoall_op(
-    input_list: list[Tensor],
+# TODO(Cathal): add 'torch.library.opcheck' test once distibuted testing infrastructure is in place.
+@torch.library.custom_op("anemoi_distributed::alltoall_transpose", mutates_args=())
+def _alltoall_transpose_op(
+    input_: Tensor,
     dim_split: int,
     split_sizes: list[int],
     dim_concat: int,
     concat_sizes: list[int],
     group_name: str,
-) -> list[Tensor]:
+) -> Tensor:
     """torch.compile-traceable wrapper around the list-based ``dist.all_to_all``.
 
     Dynamo cannot trace the list variant of ``dist.all_to_all`` (it fails while
-    constructing the pybind ``AllToAllOptions``). Registering only the collective
-    exchange as a custom op makes Dynamo emit an opaque node and run it eagerly at
-    runtime, while the surrounding split/concat in ``_alltoall_transpose`` remain
-    traceable. A ``ProcessGroup`` is not a valid custom-op argument, so the group's
-    registered name is passed and resolved here.
+    constructing the pybind ``AllToAllOptions``). Registering it as a custom op makes
+    Dynamo emit an opaque node and run the collective eagerly at runtime. A
+    ``ProcessGroup`` is not a valid custom-op argument, so the group's registered name
+    is passed and resolved here.
     """
     group = _resolve_process_group(group_name)
-    comm_size = dist.get_world_size(group=group)
-    myrank = dist.get_rank(group=group)
 
-    ref = input_list[0]
-    ndim = ref.dim()
+    # normalise negative dims
+    ndim = input_.dim()
     dim_split = dim_split % ndim
     dim_concat = dim_concat % ndim
-    input_format = get_memory_format(ref)
+    assert dim_split != dim_concat, "Error, all-to-all split and concat dimensions must be different."
 
-    # build output tensors: each has the shape of the input pieces but with
+    comm_size = dist.get_world_size(group=group)
+    if comm_size == 1:
+        return input_
+
+    myrank = dist.get_rank(group=group)
+    input_format = get_memory_format(input_)
+
+    # split input along dim_split
+    input_list = [x.contiguous() for x in torch.split(input_, split_sizes, dim=dim_split)]
+
+    # build output tensors: each has the shape of input_ but with
     # dim_split size = split_sizes[myrank] and dim_concat size = concat_sizes[rank]
     output_list = []
     for rank in range(comm_size):
-        out_shape = list(ref.shape)
+        out_shape = list(input_.shape)
         out_shape[dim_split] = split_sizes[myrank]
         out_shape[dim_concat] = concat_sizes[rank]
         output_list.append(
             torch.empty(
                 out_shape,
-                dtype=ref.dtype,
-                layout=ref.layout,
-                device=ref.device,
+                dtype=input_.dtype,
+                layout=input_.layout,
+                device=input_.device,
                 memory_format=input_format,
             )
         )
 
     _alltoallwrapper(output_list, input_list, group=group)
 
-    return output_list
+    return torch.cat(output_list, dim=dim_concat).contiguous(memory_format=input_format)
 
 
-@_alltoall_op.register_fake
+@_alltoall_transpose_op.register_fake
 def _(
-    input_list: list[Tensor],
+    input_: Tensor,
     dim_split: int,
     split_sizes: list[int],
     dim_concat: int,
     concat_sizes: list[int],
     group_name: str,
-) -> list[Tensor]:
-    # Output shapes are fully determined by the (static) shard sizes: dim_split becomes
-    # this rank's split size, dim_concat becomes the received rank's concat size.
+) -> Tensor:
+    # Output shape is fully determined by the (static) shard sizes: dim_split becomes
+    # this rank's split size, dim_concat becomes the sum of received concat sizes.
     group = _resolve_process_group(group_name)
     myrank = group.rank()
-    comm_size = group.size()
-    ref = input_list[0]
-    ndim = ref.dim()
+    ndim = input_.dim()
     dim_split = dim_split % ndim
     dim_concat = dim_concat % ndim
-
-    output_list = []
-    for rank in range(comm_size):
-        out_shape = list(ref.shape)
-        out_shape[dim_split] = split_sizes[myrank]
-        out_shape[dim_concat] = concat_sizes[rank]
-        output_list.append(ref.new_empty(out_shape))
-    return output_list
+    out_shape = list(input_.shape)
+    out_shape[dim_split] = split_sizes[myrank]
+    out_shape[dim_concat] = sum(concat_sizes)
+    return input_.new_empty(out_shape)
 
 
 def _resolve_group_name(group: Optional[ProcessGroup]) -> str:
@@ -424,21 +426,7 @@ def _alltoall_transpose(
     if comm_size == 1:
         return input_
 
-    # normalise negative dims
-    ndim = input_.dim()
-    dim_split = dim_split % ndim
-    dim_concat = dim_concat % ndim
-    assert dim_split != dim_concat, "Error, all-to-all split and concat dimensions must be different."
-
-    input_format = get_memory_format(input_)
-
-    # Only the collective exchange is opaque to Dynamo; the split and concat remain
-    # traceable by torch.compile.
-    input_list = [x.contiguous() for x in torch.split(input_, split_sizes, dim=dim_split)]
-
-    output_list = _alltoall_op(input_list, dim_split, split_sizes, dim_concat, concat_sizes, _resolve_group_name(group))
-
-    return torch.cat(output_list, dim=dim_concat).contiguous(memory_format=input_format)
+    return _alltoall_transpose_op(input_, dim_split, split_sizes, dim_concat, concat_sizes, _resolve_group_name(group))
 
 
 def _halo_exchange(

--- a/models/src/anemoi/models/distributed/primitives.py
+++ b/models/src/anemoi/models/distributed/primitives.py
@@ -294,91 +294,89 @@ def _alltoallwrapper(output_list: list, input_list: list, group: ProcessGroup):
                 reqs.append(dist.isend(input_list[j], group_dst=j, group=group))
                 reqs.append(dist.irecv(output_list[j], group_src=j, group=group))
             else:
-                output_list[rank] = input_list[rank]
+                output_list[rank].copy_(input_list[rank])
         for req in reqs:
             req.wait()
     else:
         dist.all_to_all(output_list, input_list, group=group)
 
 
-# TODO(Cathal): add 'torch.library.opcheck' test once distibuted testing infrastructure is in place.
-@torch.library.custom_op("anemoi_distributed::alltoall_transpose", mutates_args=())
-def _alltoall_transpose_op(
-    input_: Tensor,
+@torch.library.custom_op("anemoi_distributed::alltoall", mutates_args=())
+def _alltoall_op(
+    input_list: list[Tensor],
     dim_split: int,
     split_sizes: list[int],
     dim_concat: int,
     concat_sizes: list[int],
     group_name: str,
-) -> Tensor:
+) -> list[Tensor]:
     """torch.compile-traceable wrapper around the list-based ``dist.all_to_all``.
 
     Dynamo cannot trace the list variant of ``dist.all_to_all`` (it fails while
-    constructing the pybind ``AllToAllOptions``). Registering it as a custom op makes
-    Dynamo emit an opaque node and run the collective eagerly at runtime. A
-    ``ProcessGroup`` is not a valid custom-op argument, so the group's registered name
-    is passed and resolved here.
+    constructing the pybind ``AllToAllOptions``). Registering only the collective
+    exchange as a custom op makes Dynamo emit an opaque node and run it eagerly at
+    runtime, while the surrounding split/concat in ``_alltoall_transpose`` remain
+    traceable. A ``ProcessGroup`` is not a valid custom-op argument, so the group's
+    registered name is passed and resolved here.
     """
     group = _resolve_process_group(group_name)
+    comm_size = dist.get_world_size(group=group)
+    myrank = dist.get_rank(group=group)
 
-    # normalise negative dims
-    ndim = input_.dim()
+    ref = input_list[0]
+    ndim = ref.dim()
     dim_split = dim_split % ndim
     dim_concat = dim_concat % ndim
-    assert dim_split != dim_concat, "Error, all-to-all split and concat dimensions must be different."
+    input_format = get_memory_format(ref)
 
-    comm_size = dist.get_world_size(group=group)
-    if comm_size == 1:
-        return input_
-
-    myrank = dist.get_rank(group=group)
-    input_format = get_memory_format(input_)
-
-    # split input along dim_split
-    input_list = [x.contiguous() for x in torch.split(input_, split_sizes, dim=dim_split)]
-
-    # build output tensors: each has the shape of input_ but with
+    # build output tensors: each has the shape of the input pieces but with
     # dim_split size = split_sizes[myrank] and dim_concat size = concat_sizes[rank]
     output_list = []
     for rank in range(comm_size):
-        out_shape = list(input_.shape)
+        out_shape = list(ref.shape)
         out_shape[dim_split] = split_sizes[myrank]
         out_shape[dim_concat] = concat_sizes[rank]
         output_list.append(
             torch.empty(
                 out_shape,
-                dtype=input_.dtype,
-                layout=input_.layout,
-                device=input_.device,
+                dtype=ref.dtype,
+                layout=ref.layout,
+                device=ref.device,
                 memory_format=input_format,
             )
         )
 
     _alltoallwrapper(output_list, input_list, group=group)
 
-    return torch.cat(output_list, dim=dim_concat).contiguous(memory_format=input_format)
+    return output_list
 
 
-@_alltoall_transpose_op.register_fake
+@_alltoall_op.register_fake
 def _(
-    input_: Tensor,
+    input_list: list[Tensor],
     dim_split: int,
     split_sizes: list[int],
     dim_concat: int,
     concat_sizes: list[int],
     group_name: str,
-) -> Tensor:
-    # Output shape is fully determined by the (static) shard sizes: dim_split becomes
-    # this rank's split size, dim_concat becomes the sum of received concat sizes.
+) -> list[Tensor]:
+    # Output shapes are fully determined by the (static) shard sizes: dim_split becomes
+    # this rank's split size, dim_concat becomes the received rank's concat size.
     group = _resolve_process_group(group_name)
     myrank = group.rank()
-    ndim = input_.dim()
+    comm_size = group.size()
+    ref = input_list[0]
+    ndim = ref.dim()
     dim_split = dim_split % ndim
     dim_concat = dim_concat % ndim
-    out_shape = list(input_.shape)
-    out_shape[dim_split] = split_sizes[myrank]
-    out_shape[dim_concat] = sum(concat_sizes)
-    return input_.new_empty(out_shape)
+
+    output_list = []
+    for rank in range(comm_size):
+        out_shape = list(ref.shape)
+        out_shape[dim_split] = split_sizes[myrank]
+        out_shape[dim_concat] = concat_sizes[rank]
+        output_list.append(ref.new_empty(out_shape))
+    return output_list
 
 
 def _resolve_group_name(group: Optional[ProcessGroup]) -> str:
@@ -426,7 +424,21 @@ def _alltoall_transpose(
     if comm_size == 1:
         return input_
 
-    return _alltoall_transpose_op(input_, dim_split, split_sizes, dim_concat, concat_sizes, _resolve_group_name(group))
+    # normalise negative dims
+    ndim = input_.dim()
+    dim_split = dim_split % ndim
+    dim_concat = dim_concat % ndim
+    assert dim_split != dim_concat, "Error, all-to-all split and concat dimensions must be different."
+
+    input_format = get_memory_format(input_)
+
+    # Only the collective exchange is opaque to Dynamo; the split and concat remain
+    # traceable by torch.compile.
+    input_list = [x.contiguous() for x in torch.split(input_, split_sizes, dim=dim_split)]
+
+    output_list = _alltoall_op(input_list, dim_split, split_sizes, dim_concat, concat_sizes, _resolve_group_name(group))
+
+    return torch.cat(output_list, dim=dim_concat).contiguous(memory_format=input_format)
 
 
 def _halo_exchange(

--- a/models/src/anemoi/models/distributed/primitives.py
+++ b/models/src/anemoi/models/distributed/primitives.py
@@ -294,9 +294,7 @@ def _alltoallwrapper(output_list: list, input_list: list, group: ProcessGroup):
                 reqs.append(dist.isend(input_list[j], group_dst=j, group=group))
                 reqs.append(dist.irecv(output_list[j], group_src=j, group=group))
             else:
-                # copy into the pre-allocated buffer rather than rebinding the
-                # reference, so no output tensor aliases an input (which would
-                # violate the custom-op aliasing constraint in _alltoall_op).
+                # when using custom operators, return tensors must not alias any input
                 output_list[rank].copy_(input_list[rank])
         for req in reqs:
             req.wait()
@@ -313,17 +311,8 @@ def _alltoall_op(
 ) -> list[Tensor]:
     """torch.compile-traceable wrapper around the list-based ``dist.all_to_all``.
 
-    Dynamo cannot trace the list variant of ``dist.all_to_all`` (it fails while
-    constructing the pybind ``AllToAllOptions``). Registering only the collective
-    exchange as a custom op makes Dynamo emit an opaque node and run it eagerly at
-    runtime, while any surrounding split/concat stays traceable. A ``ProcessGroup``
-    is not a valid custom-op argument, so the group's registered name is passed and
-    resolved here.
-
-    ``output_shapes_flat`` is the per-rank received shapes flattened into a single
-    ``list[int]`` (custom-op schemas don't support ``list[list[int]]``); it is
-    regrouped into ``ndim``-sized chunks. The output buffers are allocated here and
-    filled by the exchange.
+    torch.compile() cannot trace ``dist.all_to_all`` with list inputs.
+    so we register a custom operator that wraps the list-based all_to_all and can be traced by torch.compile().
     """
     group = _resolve_process_group(group_name)
     ref = input_list[0]
@@ -413,8 +402,6 @@ def _alltoall_transpose(
     myrank = dist.get_rank(group=group)
     input_format = get_memory_format(input_)
 
-    # Only the collective exchange is opaque to Dynamo; the split and concat remain
-    # traceable by torch.compile.
     input_list = [x.contiguous() for x in torch.split(input_, split_sizes, dim=dim_split)]
 
     # shape received from each rank: dim_split = this rank's split size,

--- a/models/src/anemoi/models/distributed/primitives.py
+++ b/models/src/anemoi/models/distributed/primitives.py
@@ -294,91 +294,69 @@ def _alltoallwrapper(output_list: list, input_list: list, group: ProcessGroup):
                 reqs.append(dist.isend(input_list[j], group_dst=j, group=group))
                 reqs.append(dist.irecv(output_list[j], group_src=j, group=group))
             else:
-                output_list[rank] = input_list[rank]
+                # copy into the pre-allocated buffer rather than rebinding the
+                # reference, so no output tensor aliases an input (which would
+                # violate the custom-op aliasing constraint in _alltoall_op).
+                output_list[rank].copy_(input_list[rank])
         for req in reqs:
             req.wait()
     else:
         dist.all_to_all(output_list, input_list, group=group)
 
 
-# TODO(Cathal): add 'torch.library.opcheck' test once distibuted testing infrastructure is in place.
-@torch.library.custom_op("anemoi_distributed::alltoall_transpose", mutates_args=())
-def _alltoall_transpose_op(
-    input_: Tensor,
-    dim_split: int,
-    split_sizes: list[int],
-    dim_concat: int,
-    concat_sizes: list[int],
+@torch.library.custom_op("anemoi_distributed::alltoall", mutates_args=())
+def _alltoall_op(
+    input_list: list[Tensor],
+    output_shapes_flat: list[int],
+    ndim: int,
     group_name: str,
-) -> Tensor:
+) -> list[Tensor]:
     """torch.compile-traceable wrapper around the list-based ``dist.all_to_all``.
 
     Dynamo cannot trace the list variant of ``dist.all_to_all`` (it fails while
-    constructing the pybind ``AllToAllOptions``). Registering it as a custom op makes
-    Dynamo emit an opaque node and run the collective eagerly at runtime. A
-    ``ProcessGroup`` is not a valid custom-op argument, so the group's registered name
-    is passed and resolved here.
+    constructing the pybind ``AllToAllOptions``). Registering only the collective
+    exchange as a custom op makes Dynamo emit an opaque node and run it eagerly at
+    runtime, while any surrounding split/concat stays traceable. A ``ProcessGroup``
+    is not a valid custom-op argument, so the group's registered name is passed and
+    resolved here.
+
+    ``output_shapes_flat`` is the per-rank received shapes flattened into a single
+    ``list[int]`` (custom-op schemas don't support ``list[list[int]]``); it is
+    regrouped into ``ndim``-sized chunks. The output buffers are allocated here and
+    filled by the exchange.
     """
     group = _resolve_process_group(group_name)
+    ref = input_list[0]
+    input_format = get_memory_format(ref)
 
-    # normalise negative dims
-    ndim = input_.dim()
-    dim_split = dim_split % ndim
-    dim_concat = dim_concat % ndim
-    assert dim_split != dim_concat, "Error, all-to-all split and concat dimensions must be different."
-
-    comm_size = dist.get_world_size(group=group)
-    if comm_size == 1:
-        return input_
-
-    myrank = dist.get_rank(group=group)
-    input_format = get_memory_format(input_)
-
-    # split input along dim_split
-    input_list = [x.contiguous() for x in torch.split(input_, split_sizes, dim=dim_split)]
-
-    # build output tensors: each has the shape of input_ but with
-    # dim_split size = split_sizes[myrank] and dim_concat size = concat_sizes[rank]
-    output_list = []
-    for rank in range(comm_size):
-        out_shape = list(input_.shape)
-        out_shape[dim_split] = split_sizes[myrank]
-        out_shape[dim_concat] = concat_sizes[rank]
-        output_list.append(
-            torch.empty(
-                out_shape,
-                dtype=input_.dtype,
-                layout=input_.layout,
-                device=input_.device,
-                memory_format=input_format,
-            )
+    output_shapes = [output_shapes_flat[i * ndim : (i + 1) * ndim] for i in range(len(output_shapes_flat) // ndim)]
+    output_list = [
+        torch.empty(
+            shape,
+            dtype=ref.dtype,
+            layout=ref.layout,
+            device=ref.device,
+            memory_format=input_format,
         )
+        for shape in output_shapes
+    ]
 
     _alltoallwrapper(output_list, input_list, group=group)
 
-    return torch.cat(output_list, dim=dim_concat).contiguous(memory_format=input_format)
+    return output_list
 
 
-@_alltoall_transpose_op.register_fake
+@_alltoall_op.register_fake
 def _(
-    input_: Tensor,
-    dim_split: int,
-    split_sizes: list[int],
-    dim_concat: int,
-    concat_sizes: list[int],
+    input_list: list[Tensor],
+    output_shapes_flat: list[int],
+    ndim: int,
     group_name: str,
-) -> Tensor:
-    # Output shape is fully determined by the (static) shard sizes: dim_split becomes
-    # this rank's split size, dim_concat becomes the sum of received concat sizes.
-    group = _resolve_process_group(group_name)
-    myrank = group.rank()
-    ndim = input_.dim()
-    dim_split = dim_split % ndim
-    dim_concat = dim_concat % ndim
-    out_shape = list(input_.shape)
-    out_shape[dim_split] = split_sizes[myrank]
-    out_shape[dim_concat] = sum(concat_sizes)
-    return input_.new_empty(out_shape)
+) -> list[Tensor]:
+    # Output shapes are provided explicitly, so the fake result is fully determined.
+    ref = input_list[0]
+    output_shapes = [output_shapes_flat[i * ndim : (i + 1) * ndim] for i in range(len(output_shapes_flat) // ndim)]
+    return [ref.new_empty(shape) for shape in output_shapes]
 
 
 def _resolve_group_name(group: Optional[ProcessGroup]) -> str:
@@ -426,7 +404,32 @@ def _alltoall_transpose(
     if comm_size == 1:
         return input_
 
-    return _alltoall_transpose_op(input_, dim_split, split_sizes, dim_concat, concat_sizes, _resolve_group_name(group))
+    # normalise negative dims
+    ndim = input_.dim()
+    dim_split = dim_split % ndim
+    dim_concat = dim_concat % ndim
+    assert dim_split != dim_concat, "Error, all-to-all split and concat dimensions must be different."
+
+    myrank = dist.get_rank(group=group)
+    input_format = get_memory_format(input_)
+
+    # Only the collective exchange is opaque to Dynamo; the split and concat remain
+    # traceable by torch.compile.
+    input_list = [x.contiguous() for x in torch.split(input_, split_sizes, dim=dim_split)]
+
+    # shape received from each rank: dim_split = this rank's split size,
+    # dim_concat = that rank's concat size. Flattened into a single list[int]
+    # because custom-op schemas don't support list[list[int]].
+    output_shapes_flat: list[int] = []
+    for rank in range(comm_size):
+        out_shape = list(input_.shape)
+        out_shape[dim_split] = split_sizes[myrank]
+        out_shape[dim_concat] = concat_sizes[rank]
+        output_shapes_flat.extend(out_shape)
+
+    output_list = _alltoall_op(input_list, output_shapes_flat, ndim, _resolve_group_name(group))
+
+    return torch.cat(output_list, dim=dim_concat).contiguous(memory_format=input_format)
 
 
 def _halo_exchange(

--- a/models/src/anemoi/models/distributed/primitives.py
+++ b/models/src/anemoi/models/distributed/primitives.py
@@ -301,15 +301,25 @@ def _alltoallwrapper(output_list: list, input_list: list, group: ProcessGroup):
         dist.all_to_all(output_list, input_list, group=group)
 
 
-def _alltoall_transpose_impl(
+@torch.library.custom_op("anemoi_distributed::alltoall_transpose", mutates_args=())
+def _alltoall_transpose_op(
     input_: Tensor,
     dim_split: int,
     split_sizes: list[int],
     dim_concat: int,
     concat_sizes: list[int],
-    group: Optional[ProcessGroup] = None,
+    group_name: str,
 ) -> Tensor:
-    """Eager implementation of the all-to-all transpose (see ``_alltoall_transpose``)."""
+    """torch.compile-traceable wrapper around the list-based ``dist.all_to_all``.
+
+    Dynamo cannot trace the list variant of ``dist.all_to_all`` (it fails while
+    constructing the pybind ``AllToAllOptions``). Registering it as a custom op makes
+    Dynamo emit an opaque node and run the collective eagerly at runtime. A
+    ``ProcessGroup`` is not a valid custom-op argument, so the group's registered name
+    is passed and resolved here.
+    """
+    group = _resolve_process_group(group_name)
+
     # normalise negative dims
     ndim = input_.dim()
     dim_split = dim_split % ndim
@@ -346,27 +356,6 @@ def _alltoall_transpose_impl(
     _alltoallwrapper(output_list, input_list, group=group)
 
     return torch.cat(output_list, dim=dim_concat).contiguous(memory_format=input_format)
-
-
-@torch.library.custom_op("anemoi_distributed::alltoall_transpose", mutates_args=())
-def _alltoall_transpose_op(
-    input_: Tensor,
-    dim_split: int,
-    split_sizes: list[int],
-    dim_concat: int,
-    concat_sizes: list[int],
-    group_name: str,
-) -> Tensor:
-    """torch.compile-traceable wrapper around the list-based ``dist.all_to_all``.
-
-    Dynamo cannot trace the list variant of ``dist.all_to_all`` (it fails while
-    constructing the pybind ``AllToAllOptions``). Registering it as a custom op makes
-    Dynamo emit an opaque node and run the collective eagerly at runtime. A
-    ``ProcessGroup`` is not a valid custom-op argument, so the group's registered name
-    is passed and resolved here.
-    """
-    group = _resolve_process_group(group_name)
-    return _alltoall_transpose_impl(input_, dim_split, split_sizes, dim_concat, concat_sizes, group)
 
 
 @_alltoall_transpose_op.register_fake
@@ -436,14 +425,7 @@ def _alltoall_transpose(
     if comm_size == 1:
         return input_
 
-    if torch.compiler.is_compiling():
-        # Route through the custom op so Dynamo does not trace into dist.all_to_all
-        # (the list variant is untraceable — it constructs a pybind AllToAllOptions).
-        return _alltoall_transpose_op(
-            input_, dim_split, split_sizes, dim_concat, concat_sizes, _resolve_group_name(group)
-        )
-
-    return _alltoall_transpose_impl(input_, dim_split, split_sizes, dim_concat, concat_sizes, group)
+    return _alltoall_transpose_op(input_, dim_split, split_sizes, dim_concat, concat_sizes, _resolve_group_name(group))
 
 
 def _halo_exchange(

--- a/models/src/anemoi/models/distributed/primitives.py
+++ b/models/src/anemoi/models/distributed/primitives.py
@@ -301,6 +301,7 @@ def _alltoallwrapper(output_list: list, input_list: list, group: ProcessGroup):
         dist.all_to_all(output_list, input_list, group=group)
 
 
+# TODO(Cathal): add 'torch.library.opcheck' test once distibuted testing infrastructure is in place.
 @torch.library.custom_op("anemoi_distributed::alltoall_transpose", mutates_args=())
 def _alltoall_transpose_op(
     input_: Tensor,

--- a/models/src/anemoi/models/distributed/primitives.py
+++ b/models/src/anemoi/models/distributed/primitives.py
@@ -14,6 +14,7 @@ import torch
 import torch.distributed as dist
 from torch import Tensor
 from torch.distributed.distributed_c10d import ProcessGroup
+from torch.distributed.distributed_c10d import _resolve_process_group
 
 from anemoi.models.distributed.shapes import ShardSizes
 from anemoi.models.distributed.shapes import expand_shard_sizes_to_shapes
@@ -273,7 +274,8 @@ def _alltoallwrapper(output_list: list, input_list: list, group: ProcessGroup):
     """
     comm_size = dist.get_world_size(group=group)
 
-    if dist.get_backend(group) == "gloo":
+    # cant call dist.get_backend(group) in torch.compile() so we check is_compiling first
+    if (not torch.compiler.is_compiling()) and dist.get_backend(group) == "gloo":
 
         # Need to check torch version here bc the syntax for dist.send/recv changed in torch v2.6
         torch_version = torch.__version__.split(".")
@@ -297,6 +299,102 @@ def _alltoallwrapper(output_list: list, input_list: list, group: ProcessGroup):
             req.wait()
     else:
         dist.all_to_all(output_list, input_list, group=group)
+
+
+def _alltoall_transpose_impl(
+    input_: Tensor,
+    dim_split: int,
+    split_sizes: list[int],
+    dim_concat: int,
+    concat_sizes: list[int],
+    group: Optional[ProcessGroup] = None,
+) -> Tensor:
+    """Eager implementation of the all-to-all transpose (see ``_alltoall_transpose``)."""
+    # normalise negative dims
+    ndim = input_.dim()
+    dim_split = dim_split % ndim
+    dim_concat = dim_concat % ndim
+    assert dim_split != dim_concat, "Error, all-to-all split and concat dimensions must be different."
+
+    comm_size = dist.get_world_size(group=group)
+    if comm_size == 1:
+        return input_
+
+    myrank = dist.get_rank(group=group)
+    input_format = get_memory_format(input_)
+
+    # split input along dim_split
+    input_list = [x.contiguous() for x in torch.split(input_, split_sizes, dim=dim_split)]
+
+    # build output tensors: each has the shape of input_ but with
+    # dim_split size = split_sizes[myrank] and dim_concat size = concat_sizes[rank]
+    output_list = []
+    for rank in range(comm_size):
+        out_shape = list(input_.shape)
+        out_shape[dim_split] = split_sizes[myrank]
+        out_shape[dim_concat] = concat_sizes[rank]
+        output_list.append(
+            torch.empty(
+                out_shape,
+                dtype=input_.dtype,
+                layout=input_.layout,
+                device=input_.device,
+                memory_format=input_format,
+            )
+        )
+
+    _alltoallwrapper(output_list, input_list, group=group)
+
+    return torch.cat(output_list, dim=dim_concat).contiguous(memory_format=input_format)
+
+
+@torch.library.custom_op("anemoi_distributed::alltoall_transpose", mutates_args=())
+def _alltoall_transpose_op(
+    input_: Tensor,
+    dim_split: int,
+    split_sizes: list[int],
+    dim_concat: int,
+    concat_sizes: list[int],
+    group_name: str,
+) -> Tensor:
+    """torch.compile-traceable wrapper around the list-based ``dist.all_to_all``.
+
+    Dynamo cannot trace the list variant of ``dist.all_to_all`` (it fails while
+    constructing the pybind ``AllToAllOptions``). Registering it as a custom op makes
+    Dynamo emit an opaque node and run the collective eagerly at runtime. A
+    ``ProcessGroup`` is not a valid custom-op argument, so the group's registered name
+    is passed and resolved here.
+    """
+    group = _resolve_process_group(group_name)
+    return _alltoall_transpose_impl(input_, dim_split, split_sizes, dim_concat, concat_sizes, group)
+
+
+@_alltoall_transpose_op.register_fake
+def _(
+    input_: Tensor,
+    dim_split: int,
+    split_sizes: list[int],
+    dim_concat: int,
+    concat_sizes: list[int],
+    group_name: str,
+) -> Tensor:
+    # Output shape is fully determined by the (static) shard sizes: dim_split becomes
+    # this rank's split size, dim_concat becomes the sum of received concat sizes.
+    group = _resolve_process_group(group_name)
+    myrank = group.rank()
+    ndim = input_.dim()
+    dim_split = dim_split % ndim
+    dim_concat = dim_concat % ndim
+    out_shape = list(input_.shape)
+    out_shape[dim_split] = split_sizes[myrank]
+    out_shape[dim_concat] = sum(concat_sizes)
+    return input_.new_empty(out_shape)
+
+
+def _resolve_group_name(group: Optional[ProcessGroup]) -> str:
+    if group is None:
+        group = dist.distributed_c10d._get_default_group()
+    return group.group_name
 
 
 def _alltoall_transpose(
@@ -334,42 +432,18 @@ def _alltoall_transpose(
     Tensor
         Result of the all-to-all exchange
     """
-    # normalise negative dims
-    ndim = input_.dim()
-    dim_split = dim_split % ndim
-    dim_concat = dim_concat % ndim
-    assert dim_split != dim_concat, "Error, all-to-all split and concat dimensions must be different."
-
     comm_size = dist.get_world_size(group=group)
     if comm_size == 1:
         return input_
 
-    myrank = dist.get_rank(group=group)
-    input_format = get_memory_format(input_)
-
-    # split input along dim_split
-    input_list = [x.contiguous() for x in torch.split(input_, split_sizes, dim=dim_split)]
-
-    # build output tensors: each has the shape of input_ but with
-    # dim_split size = split_sizes[myrank] and dim_concat size = concat_sizes[rank]
-    output_list = []
-    for rank in range(comm_size):
-        out_shape = list(input_.shape)
-        out_shape[dim_split] = split_sizes[myrank]
-        out_shape[dim_concat] = concat_sizes[rank]
-        output_list.append(
-            torch.empty(
-                out_shape,
-                dtype=input_.dtype,
-                layout=input_.layout,
-                device=input_.device,
-                memory_format=input_format,
-            )
+    if torch.compiler.is_compiling():
+        # Route through the custom op so Dynamo does not trace into dist.all_to_all
+        # (the list variant is untraceable — it constructs a pybind AllToAllOptions).
+        return _alltoall_transpose_op(
+            input_, dim_split, split_sizes, dim_concat, concat_sizes, _resolve_group_name(group)
         )
 
-    _alltoallwrapper(output_list, input_list, group=group)
-
-    return torch.cat(output_list, dim=dim_concat).contiguous(memory_format=input_format)
+    return _alltoall_transpose_impl(input_, dim_split, split_sizes, dim_concat, concat_sizes, group)
 
 
 def _halo_exchange(

--- a/models/tests/distributed/test_communication_primitives.py
+++ b/models/tests/distributed/test_communication_primitives.py
@@ -27,10 +27,12 @@ from distributed_runner import run_distributed_test
 
 from anemoi.models.distributed.balanced_partition import get_balanced_partition_sizes
 from anemoi.models.distributed.primitives import _alltoall_transpose
+from anemoi.models.distributed.primitives import _alltoall_transpose_op
 from anemoi.models.distributed.primitives import _alltoallwrapper
 from anemoi.models.distributed.primitives import _expand_sharded_tensor
 from anemoi.models.distributed.primitives import _gather
 from anemoi.models.distributed.primitives import _reduce
+from anemoi.models.distributed.primitives import _resolve_group_name
 from anemoi.models.distributed.primitives import _split
 
 GLOBAL_DEFAULT_ATOL = 1e-12
@@ -753,4 +755,74 @@ def test_alltoallwrapper_exchanges_rank_ordered_tensor_lists(
         _test_alltoallwrapper_rank,
         backend=distributed_backend,
         world_size=distributed_world_size,
+    )
+
+
+def _test_alltoall_transpose_opcheck_rank(
+    *,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    group: dist.ProcessGroup,
+    shape: tuple[int, ...],
+    dim_split: int,
+    dim_concat: int,
+) -> None:
+    from torch._subclasses.fake_tensor import FakeTensorMode
+
+    full = torch.arange(torch.Size(shape).numel(), dtype=torch.float32, device=device).reshape(shape)
+    split_sizes = get_balanced_partition_sizes(full.size(dim_split), world_size)
+    concat_sizes = get_balanced_partition_sizes(full.size(dim_concat), world_size)
+    local = torch.split(full, concat_sizes, dim=dim_concat)[rank].contiguous()
+
+    group_name = _resolve_group_name(group)
+    args = (local, dim_split, split_sizes, dim_concat, concat_sizes, group_name)
+
+    # Validate the custom op registration: schema, fake/meta implementation and
+    # (where applicable) autograd registration are all exercised by opcheck.
+    torch.library.opcheck(_alltoall_transpose_op, args)
+
+    # Explicitly verify the registered fake implementation returns the same shape,
+    # dtype and device metadata as the real (eager) implementation.
+    real = _alltoall_transpose_op(*args)
+    with FakeTensorMode(allow_non_fake_inputs=True) as fake_mode:
+        fake_local = fake_mode.from_tensor(local)
+        fake = _alltoall_transpose_op(fake_local, dim_split, split_sizes, dim_concat, concat_sizes, group_name)
+
+    assert fake.shape == real.shape, f"fake shape {fake.shape} != real shape {real.shape}"
+    assert fake.dtype == real.dtype, f"fake dtype {fake.dtype} != real dtype {real.dtype}"
+    assert fake.device == real.device, f"fake device {fake.device} != real device {real.device}"
+
+
+@pytest.mark.distributed
+@pytest.mark.parametrize(
+    ("shape", "dim_split", "dim_concat"),
+    [
+        pytest.param((1024, 1024), 0, 1, id="even_split_even_concat_1m"),
+        pytest.param((1025, 1024), 0, 1, id="uneven_split_even_concat_1m"),
+        pytest.param((1024, 1025), 0, 1, id="even_split_uneven_concat_1m"),
+        pytest.param((1025, 1025), 0, 1, id="uneven_split_uneven_concat_1m"),
+        pytest.param((64, 129, 128), 1, 2, id="3d_middle_to_last_1m"),
+        pytest.param((64, 128, 129), 1, -1, id="negative_concat_dim_1m"),
+    ],
+)
+def test_alltoall_transpose_interface(
+    shape: tuple[int, ...],
+    dim_split: int,
+    dim_concat: int,
+    distributed_backend: str,
+    distributed_world_size: int,
+) -> None:
+    """Uses torch.library.opcheck to validate the registered custom op interface for alltoall_transpose.
+    and checks the fake shapes match the real shapes produced.
+    """
+    if distributed_backend == "gloo" and _torch_version_less_than(2, 6):
+        pytest.skip("Gloo alltoall_transpose requires torch >= 2.6.")
+    run_distributed_test(
+        _test_alltoall_transpose_opcheck_rank,
+        backend=distributed_backend,
+        world_size=distributed_world_size,
+        shape=shape,
+        dim_split=dim_split,
+        dim_concat=dim_concat,
     )

--- a/models/tests/distributed/test_communication_primitives.py
+++ b/models/tests/distributed/test_communication_primitives.py
@@ -27,12 +27,10 @@ from distributed_runner import run_distributed_test
 
 from anemoi.models.distributed.balanced_partition import get_balanced_partition_sizes
 from anemoi.models.distributed.primitives import _alltoall_transpose
-from anemoi.models.distributed.primitives import _alltoall_transpose_op
 from anemoi.models.distributed.primitives import _alltoallwrapper
 from anemoi.models.distributed.primitives import _expand_sharded_tensor
 from anemoi.models.distributed.primitives import _gather
 from anemoi.models.distributed.primitives import _reduce
-from anemoi.models.distributed.primitives import _resolve_group_name
 from anemoi.models.distributed.primitives import _split
 
 GLOBAL_DEFAULT_ATOL = 1e-12
@@ -755,74 +753,4 @@ def test_alltoallwrapper_exchanges_rank_ordered_tensor_lists(
         _test_alltoallwrapper_rank,
         backend=distributed_backend,
         world_size=distributed_world_size,
-    )
-
-
-def _test_alltoall_transpose_opcheck_rank(
-    *,
-    rank: int,
-    world_size: int,
-    device: torch.device,
-    group: dist.ProcessGroup,
-    shape: tuple[int, ...],
-    dim_split: int,
-    dim_concat: int,
-) -> None:
-    from torch._subclasses.fake_tensor import FakeTensorMode
-
-    full = torch.arange(torch.Size(shape).numel(), dtype=torch.float32, device=device).reshape(shape)
-    split_sizes = get_balanced_partition_sizes(full.size(dim_split), world_size)
-    concat_sizes = get_balanced_partition_sizes(full.size(dim_concat), world_size)
-    local = torch.split(full, concat_sizes, dim=dim_concat)[rank].contiguous()
-
-    group_name = _resolve_group_name(group)
-    args = (local, dim_split, split_sizes, dim_concat, concat_sizes, group_name)
-
-    # Validate the custom op registration: schema, fake/meta implementation and
-    # (where applicable) autograd registration are all exercised by opcheck.
-    torch.library.opcheck(_alltoall_transpose_op, args)
-
-    # Explicitly verify the registered fake implementation returns the same shape,
-    # dtype and device metadata as the real (eager) implementation.
-    real = _alltoall_transpose_op(*args)
-    with FakeTensorMode(allow_non_fake_inputs=True) as fake_mode:
-        fake_local = fake_mode.from_tensor(local)
-        fake = _alltoall_transpose_op(fake_local, dim_split, split_sizes, dim_concat, concat_sizes, group_name)
-
-    assert fake.shape == real.shape, f"fake shape {fake.shape} != real shape {real.shape}"
-    assert fake.dtype == real.dtype, f"fake dtype {fake.dtype} != real dtype {real.dtype}"
-    assert fake.device == real.device, f"fake device {fake.device} != real device {real.device}"
-
-
-@pytest.mark.distributed
-@pytest.mark.parametrize(
-    ("shape", "dim_split", "dim_concat"),
-    [
-        pytest.param((1024, 1024), 0, 1, id="even_split_even_concat_1m"),
-        pytest.param((1025, 1024), 0, 1, id="uneven_split_even_concat_1m"),
-        pytest.param((1024, 1025), 0, 1, id="even_split_uneven_concat_1m"),
-        pytest.param((1025, 1025), 0, 1, id="uneven_split_uneven_concat_1m"),
-        pytest.param((64, 129, 128), 1, 2, id="3d_middle_to_last_1m"),
-        pytest.param((64, 128, 129), 1, -1, id="negative_concat_dim_1m"),
-    ],
-)
-def test_alltoall_transpose_interface(
-    shape: tuple[int, ...],
-    dim_split: int,
-    dim_concat: int,
-    distributed_backend: str,
-    distributed_world_size: int,
-) -> None:
-    """Uses torch.library.opcheck to validate the registered custom op interface for alltoall_transpose.
-    and checks the fake shapes match the real shapes produced.
-    """
-    if distributed_backend == "gloo" and _torch_version_less_than(2, 6):
-        pytest.skip("Gloo alltoall_transpose requires torch >= 2.6.")
-    run_distributed_test(
-        _test_alltoall_transpose_opcheck_rank,
-        backend=distributed_backend,
-        world_size=distributed_world_size,
-        shape=shape,
-        dim_split=dim_split,
-        dim_concat=dim_concat,
     )

--- a/models/tests/distributed/test_interfaces.py
+++ b/models/tests/distributed/test_interfaces.py
@@ -1,0 +1,113 @@
+# (C) Copyright 2026 Anemoi contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Distributed tests for communication interfaces
+
+Tests the distributed communication interfaces compile and the output matches the eager output.
+
+These tests are skipped by default. Pass ``--distributed`` to run them. Use
+``--distributed-backend`` and ``--distributed-world-size`` to select the backend
+and rank count.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+import torch.distributed as dist
+from distributed_runner import run_distributed_test
+
+from anemoi.models.distributed.balanced_partition import get_balanced_partition_sizes
+from anemoi.models.distributed.primitives import _alltoall_op
+from anemoi.models.distributed.primitives import _resolve_group_name
+
+GLOBAL_DEFAULT_ATOL = 1e-12
+GLOBAL_DEFAULT_RTOL = 1e-12
+
+
+def _torch_version_less_than(major: int, minor: int) -> bool:
+    # TODO: Move to shared util or remove.
+    version_parts = torch.__version__.split("+", maxsplit=1)[0].split(".")
+    return (int(version_parts[0]), int(version_parts[1])) < (major, minor)
+
+
+def _test_alltoall_opcheck_rank(
+    *,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    group: dist.ProcessGroup,
+    shape: tuple[int, ...],
+    dim_split: int,
+    dim_concat: int,
+) -> None:
+    from torch._subclasses.fake_tensor import FakeTensorMode
+
+    full = torch.arange(torch.Size(shape).numel(), dtype=torch.float32, device=device).reshape(shape)
+    split_sizes = get_balanced_partition_sizes(full.size(dim_split), world_size)
+    concat_sizes = get_balanced_partition_sizes(full.size(dim_concat), world_size)
+    local = torch.split(full, concat_sizes, dim=dim_concat)[rank].contiguous()
+
+    # The custom op operates on the already-split input list; split/concat live
+    # outside the op in _alltoall_transpose and stay traceable by torch.compile.
+    input_list = [x.contiguous() for x in torch.split(local, split_sizes, dim=dim_split)]
+
+    group_name = _resolve_group_name(group)
+    args = (input_list, dim_split, split_sizes, dim_concat, concat_sizes, group_name)
+
+    # Validate the custom op registration: schema, fake/meta implementation and
+    # (where applicable) autograd registration are all exercised by opcheck.
+    torch.library.opcheck(_alltoall_op, args)
+
+    # Explicitly verify the registered fake implementation returns the same shapes,
+    # dtypes and devices as the real (eager) implementation for every output tensor.
+    real = _alltoall_op(*args)
+    with FakeTensorMode(allow_non_fake_inputs=True) as fake_mode:
+        fake_input_list = [fake_mode.from_tensor(t) for t in input_list]
+        fake = _alltoall_op(fake_input_list, dim_split, split_sizes, dim_concat, concat_sizes, group_name)
+
+    assert len(fake) == len(real), f"fake returned {len(fake)} tensors, real returned {len(real)}"
+    for i, (fake_t, real_t) in enumerate(zip(fake, real)):
+        assert fake_t.shape == real_t.shape, f"output {i}: fake shape {fake_t.shape} != real shape {real_t.shape}"
+        assert fake_t.dtype == real_t.dtype, f"output {i}: fake dtype {fake_t.dtype} != real dtype {real_t.dtype}"
+        assert fake_t.device == real_t.device, f"output {i}: fake device {fake_t.device} != real device {real_t.device}"
+
+
+@pytest.mark.distributed
+@pytest.mark.parametrize(
+    ("shape", "dim_split", "dim_concat"),
+    [
+        pytest.param((1024, 1024), 0, 1, id="even_split_even_concat_1m"),
+        pytest.param((1025, 1024), 0, 1, id="uneven_split_even_concat_1m"),
+        pytest.param((1024, 1025), 0, 1, id="even_split_uneven_concat_1m"),
+        pytest.param((1025, 1025), 0, 1, id="uneven_split_uneven_concat_1m"),
+        pytest.param((64, 129, 128), 1, 2, id="3d_middle_to_last_1m"),
+        pytest.param((64, 128, 129), 1, -1, id="negative_concat_dim_1m"),
+    ],
+)
+def test_alltoall_op_interface(
+    shape: tuple[int, ...],
+    dim_split: int,
+    dim_concat: int,
+    distributed_backend: str,
+    distributed_world_size: int,
+) -> None:
+    """Uses torch.library.opcheck to validate the registered custom op interface for the alltoall exchange
+    and checks the fake shapes match the real shapes produced.
+    """
+    if distributed_backend == "gloo" and _torch_version_less_than(2, 6):
+        pytest.skip("Gloo alltoall requires torch >= 2.6.")
+    run_distributed_test(
+        _test_alltoall_opcheck_rank,
+        backend=distributed_backend,
+        world_size=distributed_world_size,
+        shape=shape,
+        dim_split=dim_split,
+        dim_concat=dim_concat,
+    )

--- a/models/tests/distributed/test_interfaces.py
+++ b/models/tests/distributed/test_interfaces.py
@@ -24,7 +24,7 @@ import torch.distributed as dist
 from distributed_runner import run_distributed_test
 
 from anemoi.models.distributed.balanced_partition import get_balanced_partition_sizes
-from anemoi.models.distributed.primitives import _alltoall_op
+from anemoi.models.distributed.primitives import _alltoall_transpose_op
 from anemoi.models.distributed.primitives import _resolve_group_name
 
 GLOBAL_DEFAULT_ATOL = 1e-12
@@ -54,29 +54,23 @@ def _test_alltoall_opcheck_rank(
     concat_sizes = get_balanced_partition_sizes(full.size(dim_concat), world_size)
     local = torch.split(full, concat_sizes, dim=dim_concat)[rank].contiguous()
 
-    # The custom op operates on the already-split input list; split/concat live
-    # outside the op in _alltoall_transpose and stay traceable by torch.compile.
-    input_list = [x.contiguous() for x in torch.split(local, split_sizes, dim=dim_split)]
-
     group_name = _resolve_group_name(group)
-    args = (input_list, dim_split, split_sizes, dim_concat, concat_sizes, group_name)
+    args = (local, dim_split, split_sizes, dim_concat, concat_sizes, group_name)
 
     # Validate the custom op registration: schema, fake/meta implementation and
     # (where applicable) autograd registration are all exercised by opcheck.
-    torch.library.opcheck(_alltoall_op, args)
+    torch.library.opcheck(_alltoall_transpose_op, args)
 
-    # Explicitly verify the registered fake implementation returns the same shapes,
-    # dtypes and devices as the real (eager) implementation for every output tensor.
-    real = _alltoall_op(*args)
+    # Explicitly verify the registered fake implementation returns the same shape,
+    # dtype and device metadata as the real (eager) implementation.
+    real = _alltoall_transpose_op(*args)
     with FakeTensorMode(allow_non_fake_inputs=True) as fake_mode:
-        fake_input_list = [fake_mode.from_tensor(t) for t in input_list]
-        fake = _alltoall_op(fake_input_list, dim_split, split_sizes, dim_concat, concat_sizes, group_name)
+        fake_local = fake_mode.from_tensor(local)
+        fake = _alltoall_transpose_op(fake_local, dim_split, split_sizes, dim_concat, concat_sizes, group_name)
 
-    assert len(fake) == len(real), f"fake returned {len(fake)} tensors, real returned {len(real)}"
-    for i, (fake_t, real_t) in enumerate(zip(fake, real)):
-        assert fake_t.shape == real_t.shape, f"output {i}: fake shape {fake_t.shape} != real shape {real_t.shape}"
-        assert fake_t.dtype == real_t.dtype, f"output {i}: fake dtype {fake_t.dtype} != real dtype {real_t.dtype}"
-        assert fake_t.device == real_t.device, f"output {i}: fake device {fake_t.device} != real device {real_t.device}"
+    assert fake.shape == real.shape, f"fake shape {fake.shape} != real shape {real.shape}"
+    assert fake.dtype == real.dtype, f"fake dtype {fake.dtype} != real dtype {real.dtype}"
+    assert fake.device == real.device, f"fake device {fake.device} != real device {real.device}"
 
 
 @pytest.mark.distributed
@@ -91,18 +85,18 @@ def _test_alltoall_opcheck_rank(
         pytest.param((64, 128, 129), 1, -1, id="negative_concat_dim_1m"),
     ],
 )
-def test_alltoall_op_interface(
+def test_alltoall_transpose_interface(
     shape: tuple[int, ...],
     dim_split: int,
     dim_concat: int,
     distributed_backend: str,
     distributed_world_size: int,
 ) -> None:
-    """Uses torch.library.opcheck to validate the registered custom op interface for the alltoall exchange
+    """Uses torch.library.opcheck to validate the registered custom op interface for alltoall_transpose
     and checks the fake shapes match the real shapes produced.
     """
     if distributed_backend == "gloo" and _torch_version_less_than(2, 6):
-        pytest.skip("Gloo alltoall requires torch >= 2.6.")
+        pytest.skip("Gloo alltoall_transpose requires torch >= 2.6.")
     run_distributed_test(
         _test_alltoall_opcheck_rank,
         backend=distributed_backend,

--- a/models/tests/distributed/test_interfaces.py
+++ b/models/tests/distributed/test_interfaces.py
@@ -24,7 +24,8 @@ import torch.distributed as dist
 from distributed_runner import run_distributed_test
 
 from anemoi.models.distributed.balanced_partition import get_balanced_partition_sizes
-from anemoi.models.distributed.primitives import _alltoall_transpose_op
+from anemoi.models.distributed.primitives import _alltoall_op
+from anemoi.models.distributed.primitives import _alltoall_transpose
 from anemoi.models.distributed.primitives import _resolve_group_name
 
 GLOBAL_DEFAULT_ATOL = 1e-12
@@ -54,23 +55,42 @@ def _test_alltoall_opcheck_rank(
     concat_sizes = get_balanced_partition_sizes(full.size(dim_concat), world_size)
     local = torch.split(full, concat_sizes, dim=dim_concat)[rank].contiguous()
 
+    # The custom op operates on the already-split input list; split/concat live
+    # outside the op in _alltoall_transpose and stay traceable by torch.compile.
+    ndim = local.dim()
+    norm_split = dim_split % ndim
+    norm_concat = dim_concat % ndim
+    input_list = [x.contiguous() for x in torch.split(local, split_sizes, dim=norm_split)]
+
+    # shape received from each rank: dim_split = this rank's split size,
+    # dim_concat = that rank's concat size. Flattened into a single list[int]
+    # because custom-op schemas don't support list[list[int]].
+    output_shapes_flat: list[int] = []
+    for src in range(world_size):
+        out_shape = list(local.shape)
+        out_shape[norm_split] = split_sizes[rank]
+        out_shape[norm_concat] = concat_sizes[src]
+        output_shapes_flat.extend(out_shape)
+
     group_name = _resolve_group_name(group)
-    args = (local, dim_split, split_sizes, dim_concat, concat_sizes, group_name)
+    args = (input_list, output_shapes_flat, ndim, group_name)
 
     # Validate the custom op registration: schema, fake/meta implementation and
     # (where applicable) autograd registration are all exercised by opcheck.
-    torch.library.opcheck(_alltoall_transpose_op, args)
+    torch.library.opcheck(_alltoall_op, args)
 
-    # Explicitly verify the registered fake implementation returns the same shape,
-    # dtype and device metadata as the real (eager) implementation.
-    real = _alltoall_transpose_op(*args)
+    # Explicitly verify the registered fake implementation returns the same shapes,
+    # dtypes and devices as the real (eager) implementation for every output tensor.
+    real = _alltoall_op(*args)
     with FakeTensorMode(allow_non_fake_inputs=True) as fake_mode:
-        fake_local = fake_mode.from_tensor(local)
-        fake = _alltoall_transpose_op(fake_local, dim_split, split_sizes, dim_concat, concat_sizes, group_name)
+        fake_input_list = [fake_mode.from_tensor(t) for t in input_list]
+        fake = _alltoall_op(fake_input_list, output_shapes_flat, ndim, group_name)
 
-    assert fake.shape == real.shape, f"fake shape {fake.shape} != real shape {real.shape}"
-    assert fake.dtype == real.dtype, f"fake dtype {fake.dtype} != real dtype {real.dtype}"
-    assert fake.device == real.device, f"fake device {fake.device} != real device {real.device}"
+    assert len(fake) == len(real), f"fake returned {len(fake)} tensors, real returned {len(real)}"
+    for i, (fake_t, real_t) in enumerate(zip(fake, real)):
+        assert fake_t.shape == real_t.shape, f"output {i}: fake shape {fake_t.shape} != real shape {real_t.shape}"
+        assert fake_t.dtype == real_t.dtype, f"output {i}: fake dtype {fake_t.dtype} != real dtype {real_t.dtype}"
+        assert fake_t.device == real_t.device, f"output {i}: fake device {fake_t.device} != real device {real_t.device}"
 
 
 @pytest.mark.distributed
@@ -85,20 +105,111 @@ def _test_alltoall_opcheck_rank(
         pytest.param((64, 128, 129), 1, -1, id="negative_concat_dim_1m"),
     ],
 )
-def test_alltoall_transpose_interface(
+def test_alltoall_op_interface(
     shape: tuple[int, ...],
     dim_split: int,
     dim_concat: int,
     distributed_backend: str,
     distributed_world_size: int,
 ) -> None:
-    """Uses torch.library.opcheck to validate the registered custom op interface for alltoall_transpose
+    """Uses torch.library.opcheck to validate the registered custom op interface for the alltoall exchange
     and checks the fake shapes match the real shapes produced.
     """
     if distributed_backend == "gloo" and _torch_version_less_than(2, 6):
-        pytest.skip("Gloo alltoall_transpose requires torch >= 2.6.")
+        pytest.skip("Gloo alltoall requires torch >= 2.6.")
     run_distributed_test(
         _test_alltoall_opcheck_rank,
+        backend=distributed_backend,
+        world_size=distributed_world_size,
+        shape=shape,
+        dim_split=dim_split,
+        dim_concat=dim_concat,
+    )
+
+
+def _test_alltoall_transpose_compile_matches_eager_rank(
+    *,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    group: dist.ProcessGroup,
+    shape: tuple[int, ...],
+    dim_split: int,
+    dim_concat: int,
+    atol: float = GLOBAL_DEFAULT_ATOL,
+    rtol: float = GLOBAL_DEFAULT_RTOL,
+) -> None:
+    full = torch.arange(torch.Size(shape).numel(), dtype=torch.float32, device=device).reshape(shape)
+    split_sizes = get_balanced_partition_sizes(full.size(dim_split), world_size)
+    concat_sizes = get_balanced_partition_sizes(full.size(dim_concat), world_size)
+    local = torch.split(full, concat_sizes, dim=dim_concat)[rank].contiguous()
+
+    eager = _alltoall_transpose(
+        local,
+        dim_split=dim_split,
+        split_sizes=split_sizes,
+        dim_concat=dim_concat,
+        concat_sizes=concat_sizes,
+        group=group,
+    )
+
+    # Wrapping the collective in the _alltoall_op custom op should let the surrounding
+    # split/concat compile into a single full graph. fullgraph=True raises (rather than
+    # silently graph-breaking) if the function cannot be captured, so a compile failure
+    # surfaces here as an explicit error.
+    torch._dynamo.reset()
+    try:
+        compiled_transpose = torch.compile(
+            _alltoall_transpose,
+            fullgraph=True,
+            dynamic=False,
+            mode="max-autotune",
+        )
+        compiled = compiled_transpose(
+            local,
+            dim_split=dim_split,
+            split_sizes=split_sizes,
+            dim_concat=dim_concat,
+            concat_sizes=concat_sizes,
+            group=group,
+        )
+    except Exception as err:
+        msg = f"_alltoall_transpose failed to compile with fullgraph=True: {err}"
+        raise AssertionError(msg) from err
+
+    assert compiled.size() == eager.size()
+    assert compiled.dtype == eager.dtype
+    assert compiled.device == eager.device
+    torch.testing.assert_close(compiled, eager, atol=atol, rtol=rtol)
+
+
+@pytest.mark.distributed
+@pytest.mark.parametrize(
+    ("shape", "dim_split", "dim_concat"),
+    [
+        pytest.param((1024, 1024), 0, 1, id="even_split_even_concat_1m"),
+        pytest.param((1025, 1024), 0, 1, id="uneven_split_even_concat_1m"),
+        pytest.param((1024, 1025), 0, 1, id="even_split_uneven_concat_1m"),
+        pytest.param((1025, 1025), 0, 1, id="uneven_split_uneven_concat_1m"),
+        pytest.param((64, 129, 128), 1, 2, id="3d_middle_to_last_1m"),
+        pytest.param((64, 128, 129), 1, -1, id="negative_concat_dim_1m"),
+    ],
+)
+def test_alltoall_transpose_compiles_and_matches_eager(
+    shape: tuple[int, ...],
+    dim_split: int,
+    dim_concat: int,
+    distributed_backend: str,
+    distributed_world_size: int,
+) -> None:
+    """Compile _alltoall_transpose (which wraps the all-to-all collective as a custom op)
+    with fullgraph=True, dynamic=False, mode='max-autotune' and check it both compiles
+    and produces the same result as the eager implementation.
+    """
+    if distributed_backend == "gloo" and _torch_version_less_than(2, 6):
+        pytest.skip("Gloo alltoall requires torch >= 2.6.")
+    run_distributed_test(
+        _test_alltoall_transpose_compile_matches_eager_rank,
         backend=distributed_backend,
         world_size=distributed_world_size,
         shape=shape,


### PR DESCRIPTION
## Description
Makes torch compile able to trace through all-to-all-transpose(). this is required to run the compiled processor across multiple nodes

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)
