### PR TITLE
perf(training): skip redundant `advance_input`

### DIFF
--- a/training/src/anemoi/training/train/methods/ensemble.py
+++ b/training/src/anemoi/training/train/methods/ensemble.py
@@ -243,7 +243,7 @@ class EnsembleTraining(BaseTrainingModule):
         x = self._expand_ens_dim(x)
 
         task_steps = self.task.steps("training" if not validation_mode else "validation")
-        for task_step_kwargs in task_steps:
+        for i, task_step_kwargs in enumerate(task_steps):
             y_pred = self(x, **task_step_kwargs)
 
             y = self.task.get_targets(batch, **task_step_kwargs)
@@ -259,16 +259,17 @@ class EnsembleTraining(BaseTrainingModule):
                 use_reentrant=False,
             )
 
-            # Advance input state for each dataset
-            x = self.task.advance_input(
-                x,
-                y_pred,
-                batch,
-                **task_step_kwargs,
-                data_indices=self.data_indices,
-                output_mask=self.output_mask,
-                grid_shard_slice=self.grid_shard_slice,
-            )
+            # Advance input state for each dataset if another step follows
+            if i < len(task_steps) - 1:
+                x = self.task.advance_input(
+                    x,
+                    y_pred,
+                    batch,
+                    **task_step_kwargs,
+                    data_indices=self.data_indices,
+                    output_mask=self.output_mask,
+                    grid_shard_slice=self.grid_shard_slice,
+                )
 
             loss = loss + loss_next
             metrics.update(metrics_next)

--- a/training/src/anemoi/training/train/methods/single.py
+++ b/training/src/anemoi/training/train/methods/single.py
@@ -38,7 +38,7 @@ class SingleTraining(BaseTrainingModule):
         x = self.task.get_inputs(batch, data_indices=self.data_indices)
 
         task_steps = self.task.steps("training" if not validation_mode else "validation")
-        for task_kwargs in task_steps:
+        for i, task_kwargs in enumerate(task_steps):
             y_pred = self(x)
 
             y = self.task.get_targets(batch, **task_kwargs)
@@ -54,16 +54,17 @@ class SingleTraining(BaseTrainingModule):
                 use_reentrant=False,
             )
 
-            # Advance input state for each dataset
-            x = self.task.advance_input(
-                x,
-                y_preds_next,
-                batch,
-                **task_kwargs,
-                data_indices=self.data_indices,
-                output_mask=self.output_mask,
-                grid_shard_slice=self.grid_shard_slice,
-            )
+            # Advance input state for each dataset if another step follows
+            if i < len(task_steps) - 1:
+                x = self.task.advance_input(
+                    x,
+                    y_preds_next,
+                    batch,
+                    **task_kwargs,
+                    data_indices=self.data_indices,
+                    output_mask=self.output_mask,
+                    grid_shard_slice=self.grid_shard_slice,
+                )
 
             loss = loss + loss_next
             metrics.update(metrics_next)

--- a/training/tests/unit/train/test_methods.py
+++ b/training/tests/unit/train/test_methods.py
@@ -955,10 +955,10 @@ def test_single_training_loss_is_averaged_over_num_steps(
     assert torch.isclose(output.loss, torch.tensor(3.0)), f"Expected 3.0, got {output.loss.item()}"
 
 
-def test_single_training_advance_input_called_once_per_step(
+def test_single_training_advance_input_called_between_rollout_steps(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """advance_input is invoked exactly once per rollout step."""
+    """advance_input is invoked once for each rollout step except the last."""
     data_indices = _data_indices_single()
     task = Forecaster(
         multistep_input=1,
@@ -991,7 +991,7 @@ def test_single_training_advance_input_called_once_per_step(
     batch = {"data": torch.randn(b, 2, e, g, v)}
     module._step(batch, validation_mode=False)
 
-    assert len(advance_calls) == task.num_steps
+    assert len(advance_calls) == task.num_steps - 1
     for kwargs in advance_calls:
         assert kwargs["output_mask"] is module.output_mask
         assert kwargs["grid_shard_slice"] is module.grid_shard_slice

--- a/training/tests/unit/train/test_methods.py
+++ b/training/tests/unit/train/test_methods.py
@@ -997,6 +997,59 @@ def test_single_training_advance_input_called_between_rollout_steps(
         assert kwargs["grid_shard_slice"] is module.grid_shard_slice
 
 
+def test_single_training_forcing_advances_across_rollout_steps(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Each forcing variables in input are refreshed from the batch before each rollout step."""
+    name_to_index = {"prog": 0, "force": 1}
+    data_indices = {"data": _make_minimal_index_collection(name_to_index, forcing=["force"])}
+
+    task = Forecaster(
+        multistep_input=2,
+        multistep_output=1,
+        timestep="6h",
+        rollout={"start": 3, "maximum": 3},
+    )
+    module = _make_single_training(task, data_indices)
+
+    # Capture the model input tensor at each rollout step by wrapping forward.
+    captured: list[torch.Tensor] = []
+    real_forward = module.forward
+
+    def spy_forward(x: dict[str, torch.Tensor], *args: Any, **kwargs: Any) -> dict[str, torch.Tensor]:
+        captured.append(x["data"].clone())
+        return real_forward(x, *args, **kwargs)
+
+    monkeypatch.setattr(module, "forward", spy_forward)
+    monkeypatch.setattr("torch.utils.checkpoint.checkpoint", lambda fn, *a, **kw: fn(*a, **kw))
+    monkeypatch.setattr(
+        module,
+        "compute_loss_metrics",
+        lambda y_pred, _y, **_kw: (torch.tensor(0.0), {}, y_pred),
+    )
+
+    # Full training offsets are [-6h, 0h, 6h, 12h, 18h] -> batch time dim of 5.
+    # Forcing (variable index 1) carries a distinctive value per time step so we can
+    # verify which batch time each advanced input pulled its forcing from.
+    force_col = name_to_index["force"]
+    b, e, g, v = 1, 1, 3, len(name_to_index)
+    batch_data = torch.zeros(b, 5, e, g, v)
+    for t in range(5):
+        batch_data[:, t, ..., force_col] = 100.0 + 10.0 * t
+    batch = {"data": batch_data}
+
+    module._step(batch, validation_mode=False)
+
+    assert len(captured) == 3
+    expected_forcing = [110.0, 120.0, 130.0]
+    for step, (x_in, expected) in enumerate(zip(captured, expected_forcing, strict=True)):
+        got = x_in[:, -1, ..., force_col]
+        assert torch.all(got == expected), (
+            f"rollout step {step}: newest input forcing should be {expected} "
+            f"(refreshed from batch), got {got.unique().tolist()}."
+        )
+
+
 # ── TransportTraining EDM transport _step integration ─────────────────────────────
 
 


### PR DESCRIPTION
## Description
Remove redundant call of `advance_input` in the last step for the `single` and `ensemble` methods.

## What issue or task does this change relate to?
#1284

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)
