### PR TITLE
fix(models,tests): wrong expected shapes in graphtransformer test

### DIFF
--- a/models/tests/layers/mapper/test_graphtransformer_mapper.py
+++ b/models/tests/layers/mapper/test_graphtransformer_mapper.py
@@ -322,7 +322,7 @@ class TestGraphTransformerBackwardMapper(TestGraphTransformerBaseMapper):
         device = next(mapper.parameters()).device
         x = (
             torch.rand(self.NUM_SRC_NODES, mapper_init.hidden_dim, device=device),
-            torch.rand(self.NUM_DST_NODES, mapper_init.in_channels_src, device=device),
+            torch.rand(self.NUM_DST_NODES, mapper_init.in_channels_dst, device=device),
         )
 
         edge_attr, edge_index, _ = graph_provider.get_edges(batch_size=batch_size)
@@ -359,7 +359,7 @@ class TestGraphTransformerBackwardMapper(TestGraphTransformerBaseMapper):
         device = next(mapper.parameters()).device
         x = (
             torch.rand(self.NUM_SRC_NODES, mapper_init.hidden_dim, device=device),
-            torch.rand(self.NUM_DST_NODES, mapper_init.in_channels_src, device=device),
+            torch.rand(self.NUM_DST_NODES, mapper_init.in_channels_dst, device=device),
         )
 
         edge_attr, edge_index, _ = graph_provider.get_edges(batch_size=batch_size)
@@ -379,7 +379,7 @@ class TestGraphTransformerBackwardMapper(TestGraphTransformerBaseMapper):
         device = next(mapper.parameters()).device
         x = (
             torch.rand(self.NUM_SRC_NODES, mapper_init.hidden_dim, device=device),
-            torch.rand(self.NUM_DST_NODES, mapper_init.in_channels_src, device=device),
+            torch.rand(self.NUM_DST_NODES, mapper_init.in_channels_dst, device=device),
         )
 
         edge_attr, edge_index, _ = graph_provider.get_edges(batch_size=batch_size)

--- a/models/tests/layers/mapper/test_graphtransformer_mapper.py
+++ b/models/tests/layers/mapper/test_graphtransformer_mapper.py
@@ -38,7 +38,7 @@ class ConcreteGraphTransformerBaseMapper(GraphTransformerBaseMapper):
 
 @dataclass
 class MapperConfig:
-    in_channels_src: int = 3
+    in_channels_src: int = 5
     in_channels_dst: int = 3
     hidden_dim: int = 256
     num_chunks: int = 2


### PR DESCRIPTION
## Description
<!-- What issue or task does this change relate to? -->

The test was passing because `in_channels_src` was equal to `in_channels_dst`.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)
