### PR TITLE
perf(training): reuse shared env for integration test 

### DIFF
--- a/.github/workflows/integration-tests-hpc.yml
+++ b/.github/workflows/integration-tests-hpc.yml
@@ -22,18 +22,66 @@ jobs:
         name: check latest commit is less than a day
         if: ${{ github.event_name == 'schedule' }}
         run: test -z $(git rev-list  --after="24 hours"  ${{ github.sha }}) && echo "::set-output name=should_run::false"
+  build-env:
+    name: build-env
+    runs-on: hpc
+    timeout-minutes: 120
+    needs: check_date
+    if: ${{ needs.check_date.outputs.should_run != 'false' }}
+    steps:
+      - uses: ecmwf-actions/reusable-workflows/ci-hpc-generic@v2
+        with:
+          template: |
+            env | grep SLURM # helps with debugging
+            set -eux
+            module load python3/3.12.9-01
+            # Shared per-commit working dir on $PERM. The clone + virtualenv are
+            # built once here and reused by every benchmark job, then removed by
+            # the cleanup-env job. Keyed on the commit sha so parallel runs of
+            # different commits do not collide.
+            WORKDIR="$PERM/TESTING/integration-venvs/${{ github.sha }}"
+            REPO_NAME=anemoi-core
+            REPO_BRANCH=${{ github.head_ref || github.ref_name }}
+            # Build off /dev/shm: the default $TMPDIR is RAM-backed tmpfs and counts
+            # against the SLURM --mem cgroup, so installing torch + the nvidia CUDA
+            # stack into it stalls. Redirect to a disk-backed per-job scratch dir.
+            export TMPDIR="$SCRATCH/ci-tmp/$SLURM_JOB_ID"
+            mkdir -p "$TMPDIR"
+            trap 'rm -rf "$TMPDIR"' EXIT
+            # Start from a clean shared dir so a rebuild is always reproducible.
+            rm -rf "$WORKDIR"
+            mkdir -p "$WORKDIR"
+            cd "$WORKDIR"
+            git clone -b $REPO_BRANCH https://${{ secrets.GH_REPO_READ_TOKEN }}@github.com/ecmwf/${REPO_NAME}.git
+            python3 -m venv .venv
+            source .venv/bin/activate
+            pip install --upgrade pip
+            # Install the superset of extras required by all benchmark jobs
+            # (profile is only needed by test_benchmark). Editable installs point
+            # at the shared clone, so the clone must persist until cleanup.
+            cd "$REPO_NAME"
+            pip install -e ./training[all,tests,profile] -e ./models[all,tests] -e ./graphs[all,tests]
+            deactivate
+          sbatch_options: |
+            #SBATCH --job-name=anemoi_core_build_env
+            #SBATCH --nodes=1
+            #SBATCH --cpus-per-task=32
+            #SBATCH --time=01:00:00
+            #SBATCH --qos=nf
+            #SBATCH --mem=64G
+          troika_user: ${{ secrets.HPC_CI_INTEGRATION_USER }}
+
   integration-tests:
     name: ${{ matrix.test_name }}
     runs-on: hpc
     timeout-minutes: ${{ matrix.timeout_minutes }}
-    needs: check_date
+    needs: [check_date, build-env]
     if: ${{ needs.check_date.outputs.should_run != 'false' }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - test_name: test_benchmark
-            pip_extras: all,tests,profile
             pytest_cmd: srun python -m pytest -v training/tests/integration/test_benchmark.py --slow --multigpu
             timeout_minutes: 360
             sbatch_options: |
@@ -46,7 +94,6 @@ jobs:
               #SBATCH --qos=ng
               #SBATCH --mem=0
           - test_name: test_training_cycle
-            pip_extras: all,tests
             pytest_cmd: python3 -m pytest -v training/tests/integration/test_training_cycle.py --slow --mlflow --mlflow-server=$MLFLOW_TEST_URL
             timeout_minutes: 120
             sbatch_options: |
@@ -57,7 +104,6 @@ jobs:
               #SBATCH --gres=gpu:1
               #SBATCH --mem=64G
           - test_name: test_accuracy
-            pip_extras: all,tests
             pytest_cmd: python3 -m pytest -v training/tests/integration/test_accuracy.py --slow --mlflow --mlflow-server=$MLFLOW_TEST_URL
             timeout_minutes: 120
             sbatch_options: |
@@ -74,33 +120,43 @@ jobs:
             env | grep SLURM # helps with debugging
             set -eux
             module load python3/3.12.9-01
-            # Build off /dev/shm: the default $TMPDIR is RAM-backed tmpfs and counts
-            # against the SLURM --mem cgroup, so installing torch + the nvidia CUDA
-            # stack into it stalls. Redirect to a disk-backed per-job scratch dir.
-            export TMPDIR="$SCRATCH/ci-tmp/$SLURM_JOB_ID"
-            mkdir -p "$TMPDIR"
-            trap 'rm -rf "$TMPDIR"' EXIT
-            REPO_NAME=anemoi-core
-            REPO_BRANCH=${{ github.head_ref || github.ref_name }}
-            cd $TMPDIR
-            git clone -b $REPO_BRANCH https://${{ secrets.GH_REPO_READ_TOKEN }}@github.com/ecmwf/${REPO_NAME}.git
-            cd $REPO_NAME
-            python3 -m venv .venv
-            source .venv/bin/activate
-            pip install --upgrade pip
-            pip install -e ./training[${{ matrix.pip_extras }}] -e ./models[all,tests] -e ./graphs[all,tests]
+            # Reuse the shared clone + virtualenv built by the build-env job.
+            WORKDIR="$PERM/integration-venvs/${{ github.sha }}"
+            cd "$WORKDIR/anemoi-core"
+            source "$WORKDIR/.venv/bin/activate"
             # Inject the MLflow URL here (not via job-level env:, which does not
             # propagate to the sbatch job); secrets are valid inside this template.
             export MLFLOW_TEST_URL=${{ secrets.MLFLOW_TEST_URL }}
             export DATASET_ROOT_PATH=${{ secrets.DATASET_ROOT_PATH }}
             ${{ matrix.pytest_cmd }}
             deactivate
-            rm -rf $REPO_NAME
           sbatch_options: ${{ matrix.sbatch_options }}
           troika_user: ${{ secrets.HPC_CI_INTEGRATION_USER }}
 
+  cleanup-env:
+    name: cleanup-env
+    runs-on: hpc
+    timeout-minutes: 30
+    needs: [check_date, integration-tests]
+    # Always run (even if a benchmark failed) so the shared venv is not left
+    # behind, but only when the env was actually built.
+    if: ${{ always() && needs.check_date.outputs.should_run != 'false' }}
+    steps:
+      - uses: ecmwf-actions/reusable-workflows/ci-hpc-generic@v2
+        with:
+          template: |
+            set -eux
+            WORKDIR="$PERM/integration-venvs/${{ github.sha }}"
+            rm -rf "$WORKDIR"
+          sbatch_options: |
+            #SBATCH --job-name=anemoi_core_cleanup_env
+            #SBATCH --time=00:15:00
+            #SBATCH --qos=nf
+            #SBATCH --mem=8G
+          troika_user: ${{ secrets.HPC_CI_INTEGRATION_USER }}
+
   notify-team:
-    needs: integration-tests
+    needs: [build-env, integration-tests]
     if: failure() && github.event_name == 'schedule'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/integration-tests-hpc.yml
+++ b/.github/workflows/integration-tests-hpc.yml
@@ -13,10 +13,16 @@ jobs:
     name: Check latest commit
     outputs:
       should_run: ${{ steps.should_run.outputs.should_run }}
+      date: ${{ steps.date.outputs.date }}
     steps:
       - uses: actions/checkout@v4
       - name: print latest_commit
         run: echo ${{ github.sha }}
+      - id: date
+        name: compute shared venv date key
+        # Computed once here and shared with every job so all jobs agree on the
+        # same WORKDIR even if a long-running test crosses midnight.
+        run: echo "date=$(date +%F)" >> "$GITHUB_OUTPUT"
       - id: should_run
         continue-on-error: true
         name: check latest commit is less than a day
@@ -35,20 +41,31 @@ jobs:
             env | grep SLURM # helps with debugging
             set -eux
             module load python3/3.12.9-01
-            # Shared per-commit working dir on $PERM. The clone + virtualenv are
-            # built once here and reused by every benchmark job, then removed by
-            # the cleanup-env job. Keyed on the commit sha so parallel runs of
-            # different commits do not collide.
-            WORKDIR="$PERM/TESTING/integration-venvs/${{ github.sha }}"
+            # Shared working dir on $PERM. The clone + virtualenv are built once
+            # here and reused by every benchmark job, then removed by the
+            # cleanup-env job. Keyed on the run date (computed once in check_date
+            # and shared) so all jobs agree on the same path.
+            WORKDIR="$PERM/TESTING/integration-venvs/${{ needs.check_date.outputs.date }}"
             REPO_NAME=anemoi-core
             REPO_BRANCH=${{ github.head_ref || github.ref_name }}
+            # If a venv dir already exists, another job is building it (or has
+            # built it): wait for the '.finished' sentinel, then reuse it instead
+            # of rebuilding.
+            if [ -d "$WORKDIR/.venv" ]; then
+              echo "Env dir exists at $WORKDIR; waiting for .finished sentinel..."
+              while [ ! -f "$WORKDIR/.finished" ]; do
+                sleep 5
+              done
+              echo "Env ready at $WORKDIR"
+              exit 0
+            fi
             # Build off /dev/shm: the default $TMPDIR is RAM-backed tmpfs and counts
             # against the SLURM --mem cgroup, so installing torch + the nvidia CUDA
             # stack into it stalls. Redirect to a disk-backed per-job scratch dir.
             export TMPDIR="$SCRATCH/ci-tmp/$SLURM_JOB_ID"
             mkdir -p "$TMPDIR"
             trap 'rm -rf "$TMPDIR"' EXIT
-            # Start from a clean shared dir so a rebuild is always reproducible.
+            # No usable env yet: build from a clean dir so it is reproducible.
             rm -rf "$WORKDIR"
             mkdir -p "$WORKDIR"
             cd "$WORKDIR"
@@ -62,6 +79,10 @@ jobs:
             cd "$REPO_NAME"
             pip install -e ./training[all,tests,profile] -e ./models[all,tests] -e ./graphs[all,tests]
             deactivate
+            # Written last: marks the env as fully built so other build-env jobs
+            # (and reruns) reuse it instead of rebuilding. set -e guarantees we
+            # never reach this line if any install step above failed.
+            touch "$WORKDIR/.finished"
           sbatch_options: |
             #SBATCH --job-name=anemoi_core_build_env
             #SBATCH --nodes=1
@@ -121,7 +142,7 @@ jobs:
             set -eux
             module load python3/3.12.9-01
             # Reuse the shared clone + virtualenv built by the build-env job.
-            WORKDIR="$PERM/integration-venvs/${{ github.sha }}"
+            WORKDIR="$PERM/TESTING/integration-venvs/${{ needs.check_date.outputs.date }}"
             cd "$WORKDIR/anemoi-core"
             source "$WORKDIR/.venv/bin/activate"
             # Inject the MLflow URL here (not via job-level env:, which does not
@@ -132,29 +153,6 @@ jobs:
             deactivate
           sbatch_options: ${{ matrix.sbatch_options }}
           troika_user: ${{ secrets.HPC_CI_INTEGRATION_USER }}
-
-  cleanup-env:
-    name: cleanup-env
-    runs-on: hpc
-    timeout-minutes: 30
-    needs: [check_date, integration-tests]
-    # Always run (even if a benchmark failed) so the shared venv is not left
-    # behind, but only when the env was actually built.
-    if: ${{ always() && needs.check_date.outputs.should_run != 'false' }}
-    steps:
-      - uses: ecmwf-actions/reusable-workflows/ci-hpc-generic@v2
-        with:
-          template: |
-            set -eux
-            WORKDIR="$PERM/integration-venvs/${{ github.sha }}"
-            rm -rf "$WORKDIR"
-          sbatch_options: |
-            #SBATCH --job-name=anemoi_core_cleanup_env
-            #SBATCH --time=00:15:00
-            #SBATCH --qos=nf
-            #SBATCH --mem=8G
-          troika_user: ${{ secrets.HPC_CI_INTEGRATION_USER }}
-
   notify-team:
     needs: [build-env, integration-tests]
     if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/integration-tests-hpc.yml
+++ b/.github/workflows/integration-tests-hpc.yml
@@ -43,46 +43,22 @@ jobs:
             module load python3/3.12.9-01
             # Shared working dir on $PERM. The clone + virtualenv are built once
             # here and reused by every benchmark job, then removed by the
-            # cleanup-env job. Keyed on the run date (computed once in check_date
-            # and shared) so all jobs agree on the same path.
-            WORKDIR="$PERM/TESTING/integration-venvs/${{ needs.check_date.outputs.date }}"
+            # cleanup-env job. Keyed on github.run_id (unique per workflow run and
+            # constant across all jobs in the run) so all jobs agree on the same
+            # path, and different runs/branches never collide on it.
+            WORKDIR="$PERM/TESTING/integration-venvs/${{ github.run_id }}"
             REPO_NAME=anemoi-core
             REPO_BRANCH=${{ github.head_ref || github.ref_name }}
-            # If a venv dir already exists, another job is building it (or has
-            # built it): wait for the '.finished' sentinel, then reuse it instead
-            # of rebuilding.
-            if [ -d "$WORKDIR/.venv" ]; then
-              echo "Env dir exists at $WORKDIR; waiting for .finished sentinel..."
-              while [ ! -f "$WORKDIR/.finished" ]; do
-                sleep 5
-              done
-              echo "Env ready at $WORKDIR"
-              exit 0
-            fi
-            # Build off /dev/shm: the default $TMPDIR is RAM-backed tmpfs and counts
-            # against the SLURM --mem cgroup, so installing torch + the nvidia CUDA
-            # stack into it stalls. Redirect to a disk-backed per-job scratch dir.
-            export TMPDIR="$SCRATCH/ci-tmp/$SLURM_JOB_ID"
-            mkdir -p "$TMPDIR"
-            trap 'rm -rf "$TMPDIR"' EXIT
-            # No usable env yet: build from a clean dir so it is reproducible.
             rm -rf "$WORKDIR"
             mkdir -p "$WORKDIR"
             cd "$WORKDIR"
             git clone -b $REPO_BRANCH https://${{ secrets.GH_REPO_READ_TOKEN }}@github.com/ecmwf/${REPO_NAME}.git
-            python3 -m venv .venv
-            source .venv/bin/activate
+            python3 -m venv venv
+            source venv/bin/activate
             pip install --upgrade pip
-            # Install the superset of extras required by all benchmark jobs
-            # (profile is only needed by test_benchmark). Editable installs point
-            # at the shared clone, so the clone must persist until cleanup.
             cd "$REPO_NAME"
-            pip install -e ./training[all,tests,profile] -e ./models[all,tests] -e ./graphs[all,tests]
+            pip install --no-cache-dir -e ./training[all,tests,profile] -e ./models[all,tests] -e ./graphs[all,tests]
             deactivate
-            # Written last: marks the env as fully built so other build-env jobs
-            # (and reruns) reuse it instead of rebuilding. set -e guarantees we
-            # never reach this line if any install step above failed.
-            touch "$WORKDIR/.finished"
           sbatch_options: |
             #SBATCH --job-name=anemoi_core_build_env
             #SBATCH --nodes=1
@@ -113,7 +89,7 @@ jobs:
               #SBATCH --gpus-per-node=2
               #SBATCH --time=1:00:00
               #SBATCH --qos=ng
-              #SBATCH --mem=0
+              #SBATCH --mem=120GB
           - test_name: test_training_cycle
             pytest_cmd: python3 -m pytest -v training/tests/integration/test_training_cycle.py --slow --mlflow --mlflow-server=$MLFLOW_TEST_URL
             timeout_minutes: 120
@@ -142,9 +118,9 @@ jobs:
             set -eux
             module load python3/3.12.9-01
             # Reuse the shared clone + virtualenv built by the build-env job.
-            WORKDIR="$PERM/TESTING/integration-venvs/${{ needs.check_date.outputs.date }}"
+            WORKDIR="$PERM/TESTING/integration-venvs/${{ github.run_id }}"
             cd "$WORKDIR/anemoi-core"
-            source "$WORKDIR/.venv/bin/activate"
+            source "$WORKDIR/venv/bin/activate"
             # Inject the MLflow URL here (not via job-level env:, which does not
             # propagate to the sbatch job); secrets are valid inside this template.
             export MLFLOW_TEST_URL=${{ secrets.MLFLOW_TEST_URL }}
@@ -153,6 +129,28 @@ jobs:
             deactivate
           sbatch_options: ${{ matrix.sbatch_options }}
           troika_user: ${{ secrets.HPC_CI_INTEGRATION_USER }}
+  cleanup-env:
+      name: cleanup-env
+      runs-on: hpc
+      timeout-minutes: 30
+      needs: [check_date, integration-tests]
+      # Only clean up when every integration test succeeded.
+      # if any test fails or is cancelled then failed/cancelled
+      # then leave the venv on filesystem to allow tests to be rerun.
+      if: ${{ success() && needs.check_date.outputs.should_run != 'false' }}
+      steps:
+        - uses: ecmwf-actions/reusable-workflows/ci-hpc-generic@v2
+          with:
+            template: |
+              set -eux
+              WORKDIR="$PERM/TESTING/integration-venvs/${{ github.run_id }}"
+              rm -rf "$WORKDIR"
+            sbatch_options: |
+              #SBATCH --job-name=anemoi_core_cleanup_env
+              #SBATCH --time=00:15:00
+              #SBATCH --qos=nf
+              #SBATCH --mem=8G
+            troika_user: ${{ secrets.HPC_CI_INTEGRATION_USER }}
   notify-team:
     needs: [build-env, integration-tests]
     if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/integration-tests-hpc.yml
+++ b/.github/workflows/integration-tests-hpc.yml
@@ -120,6 +120,7 @@ jobs:
             # Reuse the shared clone + virtualenv built by the build-env job.
             WORKDIR="$PERM/TESTING/integration-venvs/${{ github.run_id }}"
             cd "$WORKDIR/anemoi-core"
+            git pull # update to the latest commit on the branch
             source "$WORKDIR/venv/bin/activate"
             # Inject the MLflow URL here (not via job-level env:, which does not
             # propagate to the sbatch job); secrets are valid inside this template.

--- a/.github/workflows/integration-tests-hpc.yml
+++ b/.github/workflows/integration-tests-hpc.yml
@@ -18,11 +18,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: print latest_commit
         run: echo ${{ github.sha }}
-      - id: date
-        name: compute shared venv date key
-        # Computed once here and shared with every job so all jobs agree on the
-        # same WORKDIR even if a long-running test crosses midnight.
-        run: echo "date=$(date +%F)" >> "$GITHUB_OUTPUT"
       - id: should_run
         continue-on-error: true
         name: check latest commit is less than a day
@@ -121,7 +116,9 @@ jobs:
             WORKDIR="$PERM/TESTING/integration-venvs/${{ github.run_id }}"
             cd "$WORKDIR/anemoi-core"
             git pull # update to the latest commit on the branch
+            git log -1 --oneline #print last commit
             source "$WORKDIR/venv/bin/activate"
+            pip freeze #print dependent library versions
             # Inject the MLflow URL here (not via job-level env:, which does not
             # propagate to the sbatch job); secrets are valid inside this template.
             export MLFLOW_TEST_URL=${{ secrets.MLFLOW_TEST_URL }}

--- a/.github/workflows/integration-tests-hpc.yml
+++ b/.github/workflows/integration-tests-hpc.yml
@@ -116,7 +116,7 @@ jobs:
             WORKDIR="$PERM/TESTING/integration-venvs/${{ github.run_id }}"
             cd "$WORKDIR/anemoi-core"
             git pull # update to the latest commit on the branch
-            git log -1 --oneline #print last commit
+            git show -s --format=oneline #print latest commit info
             source "$WORKDIR/venv/bin/activate"
             pip freeze #print dependent library versions
             # Inject the MLflow URL here (not via job-level env:, which does not


### PR DESCRIPTION
## Description

This PR reuses a shared venv across the workflow, benchmark and correctness integration tests. It moves the venv from $SCRATCH to $PERM and builds it on a cpu job (fractional queue). so this saves about 30 minutes of GPU time.

before:
<img width="880" height="273" alt="Screenshot 2026-07-28 at 10 35 23" src="https://github.com/user-attachments/assets/d88523b3-5fcb-4f10-8d41-ec4ea62e6748" />
after:
<img width="864" height="243" alt="Screenshot 2026-07-28 at 10 35 06" src="https://github.com/user-attachments/assets/11b447ca-f65d-495f-98f5-b1d87870c89c" />

the env is deleted only once all 3 tests have passed. this allows you to rerun failing tests. When you rerun a test, git pull is used inside anemoi-core to fetch the latest commit.

there is 1 venv per integration test run.

the integration tests [pass](https://github.com/ecmwf/anemoi-core/actions/runs/30817207601)

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)
