### PR TITLE
fix(graphs): replace qhull joggle with merged facets in PlanarAreaWeights

### DIFF
--- a/graphs/src/anemoi/graphs/nodes/attributes/area_weights.py
+++ b/graphs/src/anemoi/graphs/nodes/attributes/area_weights.py
@@ -166,10 +166,7 @@ class PlanarAreaWeights(BaseAreaWeights):
         SciPy returns each 2-D region's vertices in boundary order, so for a convex cell
         this matches ``ConvexHull(...).volume`` to float-rounding level. A region whose
         stored vertex order is not convex would make shoelace under-count, so those are
-        detected and recomputed exactly with ``ConvexHull``. Under the merged-facet qhull
-        options used by :meth:`compute_area_weights` this guard is not expected to fire
-        (it does not on N320 or on 1.7M-node stretched grids); it is kept as a cheap
-        safety net against near-collinear cell vertices.
+        detected and recomputed exactly with ``ConvexHull``.
 
         Parameters
         ----------
@@ -242,14 +239,8 @@ class PlanarAreaWeights(BaseAreaWeights):
         boundary_points = self._get_boundary_ring(latlons, resolution)
 
         # Build the Voronoi tessellation over all points (boundary ring included).
-        #
-        # "Qbb Qc Qz" is qhull's merged-facet precision handling (SciPy's own default for
-        # 2-D Voronoi) and "Pp" silences its precision warnings. Do NOT swap this for the
-        # joggle ("QJ"): joggle displaces every input coordinate by up to 1% of the
-        # *bounding box*, which is unrelated to the node spacing. On a stretched grid
-        # (global extent, 1 km nodes) that is ~40x the spacing, so qhull fails to build a
-        # hull at all and asks for a larger joggle -- and raising it, as QH6229 suggests,
-        # returns silently meaningless areas rather than fixing anything. See #690.
+        # Merged facets, not the joggle: joggle scales with the bounding box rather than
+        # the node spacing, so it fails on stretched grids (#690).
         extended_points = np.vstack([latlons, boundary_points])
         v = Voronoi(extended_points, qhull_options="Qbb Qc Qz Pp")
 

--- a/graphs/src/anemoi/graphs/nodes/attributes/area_weights.py
+++ b/graphs/src/anemoi/graphs/nodes/attributes/area_weights.py
@@ -164,9 +164,12 @@ class PlanarAreaWeights(BaseAreaWeights):
 
         Uses the shoelace formula instead of a per-node :class:`scipy.spatial.ConvexHull`.
         SciPy returns each 2-D region's vertices in boundary order, so for a convex cell
-        this matches ``ConvexHull(...).volume`` to float-rounding level. Heavy joggling
-        (qhull ``QJ``) can yield degenerate, non-convex regions where shoelace
-        under-counts; those are detected and recomputed exactly with ``ConvexHull``.
+        this matches ``ConvexHull(...).volume`` to float-rounding level. A region whose
+        stored vertex order is not convex would make shoelace under-count, so those are
+        detected and recomputed exactly with ``ConvexHull``. Under the merged-facet qhull
+        options used by :meth:`compute_area_weights` this guard is not expected to fire
+        (it does not on N320 or on 1.7M-node stretched grids); it is kept as a cheap
+        safety net against near-collinear cell vertices.
 
         Parameters
         ----------
@@ -238,9 +241,17 @@ class PlanarAreaWeights(BaseAreaWeights):
         resolution = self._compute_mean_nearest_distance(latlons)
         boundary_points = self._get_boundary_ring(latlons, resolution)
 
-        # Build the Voronoi tessellation over all points (boundary ring included)
+        # Build the Voronoi tessellation over all points (boundary ring included).
+        #
+        # "Qbb Qc Qz" is qhull's merged-facet precision handling (SciPy's own default for
+        # 2-D Voronoi) and "Pp" silences its precision warnings. Do NOT swap this for the
+        # joggle ("QJ"): joggle displaces every input coordinate by up to 1% of the
+        # *bounding box*, which is unrelated to the node spacing. On a stretched grid
+        # (global extent, 1 km nodes) that is ~40x the spacing, so qhull fails to build a
+        # hull at all and asks for a larger joggle -- and raising it, as QH6229 suggests,
+        # returns silently meaningless areas rather than fixing anything. See #690.
         extended_points = np.vstack([latlons, boundary_points])
-        v = Voronoi(extended_points, qhull_options="QJ Pp")
+        v = Voronoi(extended_points, qhull_options="Qbb Qc Qz Pp")
 
         # Area of each node's Voronoi cell (boundary-ring points excluded), vectorised.
         return self._voronoi_region_areas(v, len(latlons))

--- a/graphs/tests/nodes/attributes/test_weights.py
+++ b/graphs/tests/nodes/attributes/test_weights.py
@@ -187,30 +187,3 @@ def test_planar_area_weights_degenerate_fallback():
     # The production method must detect the non-convex region and fall back to ConvexHull.
     areas = PlanarAreaWeights._voronoi_region_areas(v, n)
     np.testing.assert_allclose(areas[target], hull_area, rtol=1e-9, atol=0.0)
-
-
-def test_planar_area_weights_exact_on_regular_grid():
-    """Interior cells of a regular grid have exactly dlat * dlon area.
-
-    Regression test for the qhull options (#690). A regular grid is massively cocircular,
-    which is precisely the degeneracy merged facets ("Qbb Qc Qz") handles exactly and the
-    joggle ("QJ") only approximates: joggle reproduces this to ~1e-6 and raising it, as
-    QH6229 suggests, to ~1e+3. Both blow through this tolerance, so reinstating a joggle
-    fails here loudly instead of silently returning meaningless weights.
-    """
-    import numpy as np
-
-    spacing = 0.01
-    lats = 0.5 + np.arange(60) * spacing
-    lons = 0.1 + np.arange(60) * spacing
-    grid_lat, grid_lon = np.meshgrid(lats, lons, indexing="ij")
-    latlons = np.column_stack([grid_lat.ravel(), grid_lon.ravel()])
-
-    areas = PlanarAreaWeights().compute_area_weights(latlons)
-
-    # Only interior cells are exact squares; the outer ring is bounded by the added
-    # boundary ring rather than by neighbouring nodes.
-    interior = ((grid_lat > lats[0]) & (grid_lat < lats[-1]) & (grid_lon > lons[0]) & (grid_lon < lons[-1])).ravel()
-    assert interior.sum() == 58 * 58
-
-    np.testing.assert_allclose(areas[interior], spacing**2, rtol=1e-9, atol=0.0)

--- a/graphs/tests/nodes/attributes/test_weights.py
+++ b/graphs/tests/nodes/attributes/test_weights.py
@@ -122,7 +122,7 @@ def test_planar_area_weights_shoelace_matches_convexhull():
     resolution = attr._compute_mean_nearest_distance(latlons)
     boundary_points = attr._get_boundary_ring(latlons, resolution)
     extended_points = np.vstack([latlons, boundary_points])
-    v = Voronoi(extended_points, qhull_options="QJ Pp")
+    v = Voronoi(extended_points, qhull_options="Qbb Qc Qz Pp")
 
     # Reference: the original per-node implementation.
     reference = np.array([ConvexHull(v.vertices[v.regions[v.point_region[idx]]]).volume for idx in range(len(latlons))])
@@ -136,12 +136,11 @@ def test_planar_area_weights_shoelace_matches_convexhull():
 def test_planar_area_weights_degenerate_fallback():
     """A region with an interior vertex falls back to the exact ConvexHull area.
 
-    Heavy qhull joggling can emit interior Voronoi vertices, making a stored region
-    polygon non-convex so plain shoelace under-counts its area (observed on real
-    stretched-grid data: up to ~21% on a few cells). The detector must flag such a
-    region and the ConvexHull fallback must recover the exact hull area. Small random
-    fixtures rarely emit a genuine (non-collinear) interior vertex, so we inject one
-    into a real Voronoi region to exercise that path deterministically.
+    A stored region polygon that is not convex makes plain shoelace under-count its
+    area. The detector must flag such a region and the ConvexHull fallback must recover
+    the exact hull area. The merged-facet qhull options are not expected to emit such a
+    region in practice, so we inject one into a real Voronoi region to exercise that
+    path deterministically -- this pins the guard's behaviour, not its frequency.
     """
     import numpy as np
     from scipy.spatial import ConvexHull
@@ -155,7 +154,7 @@ def test_planar_area_weights_degenerate_fallback():
     resolution = PlanarAreaWeights()._compute_mean_nearest_distance(points)
     boundary_points = PlanarAreaWeights()._get_boundary_ring(points, resolution)
     extended_points = np.vstack([points, boundary_points])
-    v = Voronoi(extended_points, qhull_options="QJ Pp")
+    v = Voronoi(extended_points, qhull_options="Qbb Qc Qz Pp")
     n = len(points)
 
     # Pick a bounded region (no -1) with >= 4 vertices to deform.
@@ -188,3 +187,30 @@ def test_planar_area_weights_degenerate_fallback():
     # The production method must detect the non-convex region and fall back to ConvexHull.
     areas = PlanarAreaWeights._voronoi_region_areas(v, n)
     np.testing.assert_allclose(areas[target], hull_area, rtol=1e-9, atol=0.0)
+
+
+def test_planar_area_weights_exact_on_regular_grid():
+    """Interior cells of a regular grid have exactly dlat * dlon area.
+
+    Regression test for the qhull options (#690). A regular grid is massively cocircular,
+    which is precisely the degeneracy merged facets ("Qbb Qc Qz") handles exactly and the
+    joggle ("QJ") only approximates: joggle reproduces this to ~1e-6 and raising it, as
+    QH6229 suggests, to ~1e+3. Both blow through this tolerance, so reinstating a joggle
+    fails here loudly instead of silently returning meaningless weights.
+    """
+    import numpy as np
+
+    spacing = 0.01
+    lats = 0.5 + np.arange(60) * spacing
+    lons = 0.1 + np.arange(60) * spacing
+    grid_lat, grid_lon = np.meshgrid(lats, lons, indexing="ij")
+    latlons = np.column_stack([grid_lat.ravel(), grid_lon.ravel()])
+
+    areas = PlanarAreaWeights().compute_area_weights(latlons)
+
+    # Only interior cells are exact squares; the outer ring is bounded by the added
+    # boundary ring rather than by neighbouring nodes.
+    interior = ((grid_lat > lats[0]) & (grid_lat < lats[-1]) & (grid_lon > lons[0]) & (grid_lon < lons[-1])).ravel()
+    assert interior.sum() == 58 * 58
+
+    np.testing.assert_allclose(areas[interior], spacing**2, rtol=1e-9, atol=0.0)


### PR DESCRIPTION
## Description

`PlanarAreaWeights` builds its Voronoi tessellation with `qhull_options="QJ Pp"`. This PR switches it to `Qbb Qc Qz Pp`, qhull's merged-facet precision handling and SciPy's own default for 2-D Voronoi.

* Allows creation of stretched-grid graphs that were previously failing unless one was manually patching the QHull joggle. 
* Brings a significant performance improvement: for our n320 + ICON 1km graph (~1.7M points) we go from ~300s to ~20s. When using a large joggle like 0.5 in main, we could start from lower values (~60s).

## What problem does this change solve?

No longer rely on joggle to be able to build very high-resolution stretched-grid graphs. It was taking longer and leading to wrong results (due to the joggle itself).

## What issue or task does this change relate to?

Closes #690. Same root cause as #698.

## Additional notes

**Could someone with a different stretched or LAM configuration confirm the graphs still look right on their side?** I have only checked a 1 km LAM cut into ERA5 N320.

This change was developed in tandem with AI coding agents.

---

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)
