### PR TITLE
fix(graphs): use weights_only=True when loading graphs in anemoi-graphs

### DIFF
--- a/graphs/src/anemoi/graphs/create.py
+++ b/graphs/src/anemoi/graphs/create.py
@@ -174,27 +174,3 @@ class GraphCreator:
             self.save(graph, save_path, overwrite)
 
         return graph
-
-
-def load_graph_from_file(graph_filename: Path) -> HeteroData:
-    """Load a serialized graph on the currently active distributed device."""
-    try:
-        from anemoi.graphs.utils import get_distributed_device
-
-        map_location = get_distributed_device()
-    except Exception:
-        map_location = "cpu"
-
-    LOGGER.info("Loading graph data from %s", graph_filename)
-    return torch.load(graph_filename, map_location=map_location, weights_only=False)
-
-
-def validate_loaded_graph(graph_data: HeteroData, required_dataset_names: list[str]) -> None:
-    """Ensure the loaded graph contains the required dataset node types."""
-    missing = [n for n in required_dataset_names if n not in graph_data.node_types]
-    if missing:
-        msg = (
-            "Loaded graph is missing dataset node types required by the dataloader. "
-            f"Missing {missing}; available nodes are {graph_data.node_types}."
-        )
-        raise ValueError(msg)

--- a/graphs/src/anemoi/graphs/describe.py
+++ b/graphs/src/anemoi/graphs/describe.py
@@ -11,9 +11,9 @@ import math
 from itertools import chain
 from pathlib import Path
 
-from anemoi.graphs.utils import load_graph_from_file
 import torch
 
+from anemoi.graphs.utils import load_graph_from_file
 from anemoi.utils.humanize import bytes
 from anemoi.utils.text import table
 

--- a/graphs/src/anemoi/graphs/describe.py
+++ b/graphs/src/anemoi/graphs/describe.py
@@ -11,6 +11,7 @@ import math
 from itertools import chain
 from pathlib import Path
 
+from anemoi.graphs.utils import load_graph_from_file
 import torch
 
 from anemoi.utils.humanize import bytes
@@ -22,7 +23,7 @@ class GraphDescriptor:
 
     def __init__(self, path: str | Path, **kwargs):
         self.path = path
-        self.graph = torch.load(self.path, weights_only=False, map_location="cpu")
+        self.graph = load_graph_from_file(self.path)
 
     @property
     def total_size(self):

--- a/graphs/src/anemoi/graphs/export.py
+++ b/graphs/src/anemoi/graphs/export.py
@@ -9,7 +9,6 @@
 
 import os
 from collections.abc import Iterable
-from anemoi.graphs.utils import load_graph_from_file
 from pathlib import Path
 
 import scipy.sparse as sp
@@ -18,6 +17,7 @@ from omegaconf import DictConfig
 from torch_geometric.data import HeteroData
 
 from anemoi.graphs.create import GraphCreator
+from anemoi.graphs.utils import load_graph_from_file
 from anemoi.utils.config import DotDict
 
 

--- a/graphs/src/anemoi/graphs/export.py
+++ b/graphs/src/anemoi/graphs/export.py
@@ -9,6 +9,7 @@
 
 import os
 from collections.abc import Iterable
+from anemoi.graphs.utils import load_graph_from_file
 from pathlib import Path
 
 import scipy.sparse as sp
@@ -36,7 +37,7 @@ class GraphExporter:
         elif isinstance(graph, (Path, str)):
             graph_path = Path(graph)
             if graph_path.suffix == ".pt":
-                self.graph = torch.load(graph_path, weights_only=False, map_location="cpu")
+                self.graph = load_graph_from_file(graph_path)
             elif graph_path.suffix in (".yaml", ".yml"):
                 self.graph = GraphCreator(graph).create(save_path=None).to("cpu")
             else:

--- a/graphs/src/anemoi/graphs/inspect.py
+++ b/graphs/src/anemoi/graphs/inspect.py
@@ -11,8 +11,6 @@ import logging
 import os
 from pathlib import Path
 
-import torch
-
 from anemoi.graphs.plotting.displots import plot_distribution_edge_attributes
 from anemoi.graphs.plotting.displots import plot_distribution_node_attributes
 from anemoi.graphs.plotting.displots import plot_distribution_node_derived_attributes
@@ -21,6 +19,7 @@ from anemoi.graphs.plotting.interactive_2d_html import plot_interactive_subgraph
 from anemoi.graphs.plotting.interactive_2d_html import plot_isolated_nodes_2d
 from anemoi.graphs.plotting.interactive_3d_html import plot_interactive_graph_3d
 from anemoi.graphs.processors.post_process import SubsetNodesInArea
+from anemoi.graphs.utils import load_graph_from_file
 
 LOGGER = logging.getLogger(__name__)
 
@@ -50,7 +49,7 @@ class GraphInspector:
         **kwargs,
     ):
         self.path = path
-        self.graph = torch.load(self.path, weights_only=False, map_location="cpu")
+        self.graph = load_graph_from_file(path)
         self.area = area
         self.output_path = output_path
         self.show_attribute_distributions = show_attribute_distributions

--- a/graphs/src/anemoi/graphs/utils.py
+++ b/graphs/src/anemoi/graphs/utils.py
@@ -9,11 +9,37 @@
 
 
 from enum import Enum
+from pathlib import Path
+import logging
 
 import torch
+from torch_geometric.data.hetero_data import HeteroData
+from torch_geometric.data.storage import EdgeStorage
+from torch_geometric.data.storage import BaseStorage
+from torch_geometric.data.storage import NodeStorage
+
 from sklearn.neighbors import NearestNeighbors
 
 from anemoi.graphs.generate.transforms import latlon_rad_to_cartesian
+
+
+LOGGER = logging.getLogger(__name__)
+
+# Add HeteroData and its storage classes to the safe globals for torch serialization
+# This prevents code execution when loading a graph from a file, which is a security risk.
+torch.serialization.add_safe_globals([HeteroData, BaseStorage, NodeStorage, EdgeStorage])
+
+
+def load_graph_from_file(graph_filename: Path | str) -> HeteroData:
+    """Load a serialized graph on the currently active distributed device."""
+    try:
+        map_location = get_distributed_device()
+    except Exception:
+        map_location = "cpu"
+
+    LOGGER.info("Loading graph data from %s", graph_filename)
+    return torch.load(graph_filename, map_location=map_location, weights_only=True)
+
 
 
 def get_distributed_device() -> torch.device:

--- a/graphs/src/anemoi/graphs/utils.py
+++ b/graphs/src/anemoi/graphs/utils.py
@@ -8,24 +8,22 @@
 # nor does it submit to any jurisdiction.
 
 
+import logging
 from enum import Enum
 from pathlib import Path
-import logging
 
 import torch
-from torch_geometric.data.hetero_data import HeteroData
-from torch_geometric.data.storage import EdgeStorage
-from torch_geometric.data.storage import BaseStorage
-from torch_geometric.data.storage import NodeStorage
-
 from sklearn.neighbors import NearestNeighbors
+from torch_geometric.data.hetero_data import HeteroData
+from torch_geometric.data.storage import BaseStorage
+from torch_geometric.data.storage import EdgeStorage
+from torch_geometric.data.storage import NodeStorage
 
 from anemoi.graphs.generate.transforms import latlon_rad_to_cartesian
 
-
 LOGGER = logging.getLogger(__name__)
 
-# Add HeteroData and its storage classes to the safe globals for torch serialization
+# Add HeteroData and its storage classes to the safe globals for torch serialization
 # This prevents code execution when loading a graph from a file, which is a security risk.
 torch.serialization.add_safe_globals([HeteroData, BaseStorage, NodeStorage, EdgeStorage])
 
@@ -39,7 +37,6 @@ def load_graph_from_file(graph_filename: Path | str) -> HeteroData:
 
     LOGGER.info("Loading graph data from %s", graph_filename)
     return torch.load(graph_filename, map_location=map_location, weights_only=True)
-
 
 
 def get_distributed_device() -> torch.device:

--- a/graphs/src/anemoi/graphs/utils.py
+++ b/graphs/src/anemoi/graphs/utils.py
@@ -39,6 +39,17 @@ def load_graph_from_file(graph_filename: Path | str) -> HeteroData:
     return torch.load(graph_filename, map_location=map_location, weights_only=True)
 
 
+def validate_loaded_graph(graph_data: HeteroData, required_dataset_names: list[str]) -> None:
+    """Ensure the loaded graph contains the required dataset node types."""
+    missing = [n for n in required_dataset_names if n not in graph_data.node_types]
+    if missing:
+        msg = (
+            "Loaded graph is missing dataset node types required by the dataloader. "
+            f"Missing {missing}; available nodes are {graph_data.node_types}."
+        )
+        raise ValueError(msg)
+
+
 def get_distributed_device() -> torch.device:
     """Get the distributed device.
 

--- a/graphs/tests/test_create.py
+++ b/graphs/tests/test_create.py
@@ -9,6 +9,7 @@
 
 
 from pathlib import Path
+from anemoi.graphs.utils import load_graph_from_file
 
 import pytest
 import torch
@@ -51,6 +52,6 @@ class TestGraphCreator:
 
         if graph_path is not None:
             assert graph_path.exists()
-            graph_saved = torch.load(graph_path, weights_only=False)
+            graph_saved = load_graph_from_file(graph_path)
             assert graph.node_types == graph_saved.node_types
             assert graph.edge_types == graph_saved.edge_types

--- a/graphs/tests/test_create.py
+++ b/graphs/tests/test_create.py
@@ -9,13 +9,13 @@
 
 
 from pathlib import Path
-from anemoi.graphs.utils import load_graph_from_file
 
 import pytest
 import torch
 from torch_geometric.data import HeteroData
 
 from anemoi.graphs.create import GraphCreator
+from anemoi.graphs.utils import load_graph_from_file
 
 
 class TestGraphCreator:

--- a/training/src/anemoi/training/train/train.py
+++ b/training/src/anemoi/training/train/train.py
@@ -30,10 +30,10 @@ from pytorch_lightning.utilities.rank_zero import rank_zero_only
 from torch_geometric.data import HeteroData
 
 from anemoi.graphs.create import GraphCreator
-from anemoi.graphs.utils import load_graph_from_file
-from anemoi.graphs.utils import validate_loaded_graph
 from anemoi.graphs.projection_helpers import DEFAULT_DATASET_NAME
 from anemoi.graphs.projection_helpers import uses_fused_dataset_graph
+from anemoi.graphs.utils import load_graph_from_file
+from anemoi.graphs.utils import validate_loaded_graph
 from anemoi.models.utils.config import get_multiple_datasets_config
 from anemoi.training.data.datamodule import AnemoiDatasetsDataModule
 from anemoi.training.diagnostics.callbacks import CallbacksContext

--- a/training/src/anemoi/training/train/train.py
+++ b/training/src/anemoi/training/train/train.py
@@ -30,8 +30,8 @@ from pytorch_lightning.utilities.rank_zero import rank_zero_only
 from torch_geometric.data import HeteroData
 
 from anemoi.graphs.create import GraphCreator
-from anemoi.graphs.create import load_graph_from_file
-from anemoi.graphs.create import validate_loaded_graph
+from anemoi.graphs.utils import load_graph_from_file
+from anemoi.graphs.utils import validate_loaded_graph
 from anemoi.graphs.projection_helpers import DEFAULT_DATASET_NAME
 from anemoi.graphs.projection_helpers import uses_fused_dataset_graph
 from anemoi.models.utils.config import get_multiple_datasets_config


### PR DESCRIPTION
## Description
<!-- What issue or task does this change relate to? -->

Use `torch.load("....", weights_only=True)` when loading graphs. This prevents code execution from third parties.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)
