### PR TITLE
fix: Add AttrType to safe globals for torch serialisation

### DIFF
--- a/graphs/src/anemoi/graphs/create.py
+++ b/graphs/src/anemoi/graphs/create.py
@@ -9,6 +9,7 @@
 
 
 import logging
+from collections import defaultdict
 from itertools import chain
 from pathlib import Path
 
@@ -20,6 +21,32 @@ from torch_geometric.data import HeteroData
 from anemoi.utils.config import DotDict
 
 LOGGER = logging.getLogger(__name__)
+
+
+def _normalise_storage_caches(graph: HeteroData) -> None:
+    """Convert PyG storage caches from ``defaultdict`` to plain ``dict`` in place.
+
+    PyTorch Geometric populates ``BaseStorage._cached_attr`` as a ``collections.defaultdict(set)``
+    while a graph is being built. The strict ``weights_only=True`` unpickler used by
+    :func:`anemoi.graphs.utils.load_graph_from_file` cannot deserialize a ``defaultdict``
+    (it only allows ``SETITEMS`` on ``dict``, ``OrderedDict`` and ``Counter``), so a saved
+    graph containing one fails to load. Normalising the cache to a plain ``dict`` before
+    saving keeps the save/load round-trip working without weakening serialization safety.
+
+    Parameters
+    ----------
+    graph : HeteroData
+        The graph whose storage caches will be normalised in place.
+    """
+    stores = [
+        graph._global_store,
+        *graph._node_store_dict.values(),
+        *graph._edge_store_dict.values(),
+    ]
+    for store in stores:
+        cached_attr = store.__dict__.get("_cached_attr")
+        if isinstance(cached_attr, defaultdict):
+            store.__dict__["_cached_attr"] = dict(cached_attr)
 
 
 class GraphCreator:
@@ -139,6 +166,7 @@ class GraphCreator:
 
         if not save_path.exists() or overwrite:
             save_path.parent.mkdir(parents=True, exist_ok=True)
+            _normalise_storage_caches(graph)
             torch.save(graph, save_path)
             LOGGER.info(f"Graph saved at {save_path}.")
         else:

--- a/graphs/src/anemoi/graphs/utils.py
+++ b/graphs/src/anemoi/graphs/utils.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import torch
 from sklearn.neighbors import NearestNeighbors
 from torch_geometric.data.hetero_data import HeteroData
+from torch_geometric.data.storage import AttrType
 from torch_geometric.data.storage import BaseStorage
 from torch_geometric.data.storage import EdgeStorage
 from torch_geometric.data.storage import NodeStorage
@@ -25,7 +26,7 @@ LOGGER = logging.getLogger(__name__)
 
 # Add HeteroData and its storage classes to the safe globals for torch serialization
 # This prevents code execution when loading a graph from a file, which is a security risk.
-torch.serialization.add_safe_globals([HeteroData, BaseStorage, NodeStorage, EdgeStorage])
+torch.serialization.add_safe_globals([HeteroData, AttrType, BaseStorage, NodeStorage, EdgeStorage])
 
 
 def load_graph_from_file(graph_filename: Path | str) -> HeteroData:


### PR DESCRIPTION
## Description
Addresses failing integration tests caused by #1303 as seen in https://github.com/ecmwf/anemoi-core/actions/runs/31021131375/job/92360048174?pr=1295

> [!CAUTION]
> Integration tests failed
> https://github.com/ecmwf/anemoi-core/actions/runs/31024878202

## New graph to replace old test graph
https://sites.ecmwf.int/ecm1947/files/Anemoi/lam-graph-rebuilt.pt

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)
