### PR TITLE
feat: Optional usage of min_level. Often helpful for ICON-LAM hidden meshes…

### DIFF
--- a/graphs/src/anemoi/graphs/generate/icon_mesh.py
+++ b/graphs/src/anemoi/graphs/generate/icon_mesh.py
@@ -128,7 +128,7 @@ class ICONMultiMesh:
     def multi_mesh_edges(self) -> np.ndarray:
         """Returns the multi-mesh edges as an arrays of vertex indices."""
         # concatenate edge-vertex lists (= edges of the multi-level mesh):
-        edges = np.concatenate([edges for edges in self.edge_vertices[: self.max_level] if (edges.size > 0)], axis=0)
+        edges = np.concatenate([edges for edges in self.edge_vertices if (edges.size > 0)], axis=0)
         return np.concatenate([edges, np.fliplr(edges)])
 
     def _read_vertices_data(self):

--- a/graphs/src/anemoi/graphs/generate/icon_mesh.py
+++ b/graphs/src/anemoi/graphs/generate/icon_mesh.py
@@ -98,7 +98,7 @@ class ICONMultiMesh:
 
         self.reflvl_vertex = reflvl_vertex
         self.max_level = max_level if max_level is not None else reflvl_vertex.max()
-        self.min_level = min_level
+        self.min_level = min_level if min_level is not None else 0
 
         # restrict edge-vertex list to multi_mesh level "max_level":
         if self.max_level < self.reflvl_vertex.max():

--- a/graphs/src/anemoi/graphs/generate/icon_mesh.py
+++ b/graphs/src/anemoi/graphs/generate/icon_mesh.py
@@ -274,9 +274,10 @@ class ICONCellDataGrid:
     uuidOfHGrid: str
     nodeset: NodeSet  # set of ICON cell circumcenters
     max_level: int
+    min_level: int
     select_c: np.ndarray
 
-    def __init__(self, icon_grid_filename: str, max_level: int | None = None):
+    def __init__(self, icon_grid_filename: str, max_level: int | None = None, min_level: int | None = None):
         self.grid_filename = icon_grid_filename
 
         # open file, representing the finest level
@@ -292,6 +293,7 @@ class ICONCellDataGrid:
             self.uuidOfHGrid = ncfile.uuidOfHGrid
 
         self.max_level = max_level if max_level is not None else reflvl_cell.max()
+        self.min_level = min_level if min_level is not None else 0
 
         # restrict to level `max_level`:
         self.select_c = np.argwhere(reflvl_cell <= self.max_level)

--- a/graphs/src/anemoi/graphs/generate/icon_mesh.py
+++ b/graphs/src/anemoi/graphs/generate/icon_mesh.py
@@ -128,7 +128,7 @@ class ICONMultiMesh:
     def multi_mesh_edges(self) -> np.ndarray:
         """Returns the multi-mesh edges as an arrays of vertex indices."""
         # concatenate edge-vertex lists (= edges of the multi-level mesh):
-        edges = np.concatenate([edges for edges in self.edge_vertices[:self.max_level] if (edges.size>0)], axis=0)
+        edges = np.concatenate([edges for edges in self.edge_vertices[: self.max_level] if (edges.size > 0)], axis=0)
         return np.concatenate([edges, np.fliplr(edges)])
 
     def _read_vertices_data(self):
@@ -153,8 +153,8 @@ class ICONMultiMesh:
         num_vertices = vertex_mask.shape[0]
         vertex_glb2loc = np.full(num_vertices, -1, dtype=int)
         vertex_glb2loc[vertex_mask] = np.arange(vertex_mask.sum())
-        vertex_glb2loc_tmp= [vertex_glb2loc[vertices] for vertices in edge_vertices[: self.max_level+1]]
-        for i in range(0,self.max_level+1):
+        vertex_glb2loc_tmp = [vertex_glb2loc[vertices] for vertices in edge_vertices[: self.max_level + 1]]
+        for i in range(0, self.max_level + 1):
             vertex_glb2loc_tmp[i] = np.array([sublist for sublist in vertex_glb2loc_tmp[i] if -1 not in sublist])
 
         return (
@@ -183,7 +183,7 @@ class ICONMultiMesh:
         selected_vertex_coarse = scipy.sparse.diags(np.ones(num_vertices), dtype=bool)
 
         # coarsen edge-vertex list from level `ilevel -> ilevel - 1`:
-        for ilevel in reversed(range(max(self.min_level,1), self.reflvl_vertex.max() + 1)):
+        for ilevel in reversed(range(max(self.min_level, 1), self.reflvl_vertex.max() + 1)):
             LOGGER.debug(f"  edges[{ilevel}] = {edge_vertices[0].shape[0] : >9}")
 
             # define edge selection matrix (selecting only edges of which have

--- a/graphs/src/anemoi/graphs/generate/icon_mesh.py
+++ b/graphs/src/anemoi/graphs/generate/icon_mesh.py
@@ -77,9 +77,10 @@ class ICONMultiMesh:
     uuidOfHGrid: str
     reflvl_vertex: np.ndarray
     max_level: int
+    min_level: int
     nodeset: NodeSet  # set of ICON grid vertices
 
-    def __init__(self, icon_grid_filename: str, max_level: int | None = None):
+    def __init__(self, icon_grid_filename: str, max_level: int | None = None, min_level: int | None = 0):
         self.grid_filename = icon_grid_filename
 
         # open file, representing the finest level
@@ -97,6 +98,7 @@ class ICONMultiMesh:
 
         self.reflvl_vertex = reflvl_vertex
         self.max_level = max_level if max_level is not None else reflvl_vertex.max()
+        self.min_level = min_level
 
         # restrict edge-vertex list to multi_mesh level "max_level":
         if self.max_level < self.reflvl_vertex.max():
@@ -126,7 +128,7 @@ class ICONMultiMesh:
     def multi_mesh_edges(self) -> np.ndarray:
         """Returns the multi-mesh edges as an arrays of vertex indices."""
         # concatenate edge-vertex lists (= edges of the multi-level mesh):
-        edges = np.concatenate([edges for edges in self.edge_vertices], axis=0)
+        edges = np.concatenate([edges for edges in self.edge_vertices[:self.max_level] if (edges.size>0)], axis=0)
         return np.concatenate([edges, np.fliplr(edges)])
 
     def _read_vertices_data(self):
@@ -151,8 +153,12 @@ class ICONMultiMesh:
         num_vertices = vertex_mask.shape[0]
         vertex_glb2loc = np.full(num_vertices, -1, dtype=int)
         vertex_glb2loc[vertex_mask] = np.arange(vertex_mask.sum())
+        vertex_glb2loc_tmp= [vertex_glb2loc[vertices] for vertices in edge_vertices[: self.max_level+1]]
+        for i in range(0,self.max_level+1):
+            vertex_glb2loc_tmp[i] = np.array([sublist for sublist in vertex_glb2loc_tmp[i] if -1 not in sublist])
+
         return (
-            [vertex_glb2loc[vertices] for vertices in edge_vertices[: self.max_level + 1]],
+            vertex_glb2loc_tmp,
             # cell_vertices: preserve negative indices (incomplete cells)
             np.where(cell_vertices >= 0, vertex_glb2loc[cell_vertices], cell_vertices),
         )
@@ -177,7 +183,7 @@ class ICONMultiMesh:
         selected_vertex_coarse = scipy.sparse.diags(np.ones(num_vertices), dtype=bool)
 
         # coarsen edge-vertex list from level `ilevel -> ilevel - 1`:
-        for ilevel in reversed(range(1, self.reflvl_vertex.max() + 1)):
+        for ilevel in reversed(range(max(self.min_level,1), self.reflvl_vertex.max() + 1)):
             LOGGER.debug(f"  edges[{ilevel}] = {edge_vertices[0].shape[0] : >9}")
 
             # define edge selection matrix (selecting only edges of which have

--- a/graphs/src/anemoi/graphs/nodes/builders/from_icon.py
+++ b/graphs/src/anemoi/graphs/nodes/builders/from_icon.py
@@ -22,7 +22,9 @@ class BaseICONNodeBuilder(BaseNodeBuilder):
     icon_node_class: type[ICONCellDataGrid] | type[ICONMultiMesh]
 
     def __init__(self, name: str, grid_filename: str, max_level: int, min_level: int | None = 0) -> None:
-        self.icon_nodes = self.icon_node_class(icon_grid_filename=grid_filename, max_level=max_level, min_level=min_level)
+        self.icon_nodes = self.icon_node_class(
+            icon_grid_filename=grid_filename, max_level=max_level, min_level=min_level
+        )
         super().__init__(name)
         self.hidden_attributes = BaseNodeBuilder.hidden_attributes | {"icon_nodes"}
 

--- a/graphs/src/anemoi/graphs/nodes/builders/from_icon.py
+++ b/graphs/src/anemoi/graphs/nodes/builders/from_icon.py
@@ -21,8 +21,8 @@ class BaseICONNodeBuilder(BaseNodeBuilder):
 
     icon_node_class: type[ICONCellDataGrid] | type[ICONMultiMesh]
 
-    def __init__(self, name: str, grid_filename: str, max_level: int) -> None:
-        self.icon_nodes = self.icon_node_class(icon_grid_filename=grid_filename, max_level=max_level)
+    def __init__(self, name: str, grid_filename: str, max_level: int, min_level: int | None = 0) -> None:
+        self.icon_nodes = self.icon_node_class(icon_grid_filename=grid_filename, max_level=max_level, min_level=min_level)
         super().__init__(name)
         self.hidden_attributes = BaseNodeBuilder.hidden_attributes | {"icon_nodes"}
 

--- a/graphs/src/anemoi/graphs/schemas/node_schemas.py
+++ b/graphs/src/anemoi/graphs/schemas/node_schemas.py
@@ -85,6 +85,8 @@ class ICONMeshNodeSchema(BaseModel):
     "Name of NetCDF ICON grid file."
     max_level: int
     "Maximum refinement level of the multi mesh / cell grid."
+    min_level: int | None = 0
+    "Minimum refinement level of the multi mesh / cell grid. (Usually 0)"
 
 
 class LimitedAreaNPZFileNodesSchema(BaseModel):

--- a/graphs/src/anemoi/graphs/schemas/node_schemas.py
+++ b/graphs/src/anemoi/graphs/schemas/node_schemas.py
@@ -85,7 +85,7 @@ class ICONMeshNodeSchema(BaseModel):
     "Name of NetCDF ICON grid file."
     max_level: int
     "Maximum refinement level of the multi mesh / cell grid."
-    min_level: int | None = 0
+    min_level: int = 0
     "Minimum refinement level of the multi mesh / cell grid. (Usually 0)"
 
 


### PR DESCRIPTION
add optional `min_level` argument for hidden LAM meshes

## Description
The optional argument min_level allows to define a coasening level up to which the connections are defined.

## What problem does this change solve?
For small LAM areas the coarsening to the base icosaeder does not work and triggers a crash in icon_mesh.py .
This code does not resolve this issue in all cases, but for some like DWD's ICON-D2 grid.

## What issue or task does this change relate to?
<!-- link to Issue Number -->

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)
