### PR TITLE
perf(training): use tensor.sum() on the scaling mask in ReweightedGraphNodeAttributeScaler

### DIFF
--- a/training/src/anemoi/training/losses/scalers/node_attributes.py
+++ b/training/src/anemoi/training/losses/scalers/node_attributes.py
@@ -105,7 +105,7 @@ class ReweightedGraphNodeAttributeScaler(GraphNodeAttributeScaler):
         scaling_mask = self.nodes[self.scaling_mask_attribute_name].squeeze()
         unmasked_sum = torch.sum(values[~scaling_mask])
         weight_per_masked_node = (
-            self.weight_frac_of_total / (1 - self.weight_frac_of_total) * unmasked_sum / sum(scaling_mask)
+            self.weight_frac_of_total / (1 - self.weight_frac_of_total) * unmasked_sum / scaling_mask.sum()
         )
         values[scaling_mask] = weight_per_masked_node
 


### PR DESCRIPTION
## Description

`ReweightedGraphNodeAttributeScaler.reweight_attribute_values` divided by `sum(scaling_mask)` — Python's builtin `sum`, which iterates the boolean node mask one element at a time. Replacing it with `scaling_mask.sum()` gives the identical result at a fraction of the cost.

## What problem does this change solve?

Performance. On a ~1.7M-node grid this single line cost 6.7s of every training startup (found with py-spy); a microbenchmark on that size drops from 6.29s to 40ms. The scaler runs once per training start, so the saving is per-job, but it is paid on every debug iteration and grows with the number of nodes.

## What issue or task does this change relate to?

Related to #1327. Found while profiling `anemoi-training train` startup.

## Additional notes

Behaviour is unchanged: `torch.Tensor.sum` on a bool tensor returns the same count. The 18 tests in `training/tests/unit/losses/test_loss_scaling.py` pass.

This change was developed in tandem with AI coding agents.

---

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)
