### PR TITLE
perf(models): keep torch off the anemoi-training CLI import path

### DIFF
--- a/models/src/anemoi/models/schemas/models.py
+++ b/models/src/anemoi/models/schemas/models.py
@@ -25,10 +25,6 @@ from pydantic import PositiveFloat
 from pydantic import PositiveInt
 from pydantic import model_validator
 
-from anemoi.models.transport.settings import EdmSettings
-from anemoi.models.transport.settings import NoiseConditioningSettings
-from anemoi.models.transport.settings import StochasticInterpolantSettings
-from anemoi.models.transport.settings import TransportSourceSettings
 from anemoi.utils.schemas import BaseModel
 
 from .decoder import GNNDecoderSchema  # noqa: TC001
@@ -87,47 +83,52 @@ class SparseProjectorSchema(BaseModel):
 
 
 class TransportSourceConfig(BaseModel):
-    kind: Literal["default", "zero", "gaussian", "reference_state"] = TransportSourceSettings.kind
+    """Configuration of the starting/source field for transport objectives.
+
+    The defaults map 1:1 to :class:`TransportSourceSettings` in
+    ``anemoi.models.transport.settings`` and are restated here so that importing
+    the schemas does not pull in the model code.
+    """
+
+    kind: Literal["default", "zero", "gaussian", "reference_state"] = "default"
     "Starting field used before the transport objective moves toward the target."
-    scale: NonNegativeFloat = Field(default=TransportSourceSettings.scale, examples=[TransportSourceSettings.scale])
+    scale: NonNegativeFloat = Field(default=1.0, examples=[1.0])
     "Multiplier applied to the starting/source field."
-    noise_scale: NonNegativeFloat = Field(default=TransportSourceSettings.noise_scale, examples=[0.1])
+    noise_scale: NonNegativeFloat = Field(default=0.0, examples=[0.1])
     "Additional additive Gaussian noise applied to the starting/source field."
 
 
 class TransportConfig(BaseModel):
+    """Configuration of the transport objective, path, conditioning and inference.
+
+    The defaults map 1:1 to :class:`EdmSettings`, :class:`NoiseConditioningSettings`
+    and :class:`StochasticInterpolantSettings` in ``anemoi.models.transport.settings``
+    and are restated here so that importing the schemas does not pull in the model code.
+    """
+
     objective: Literal["edm_diffusion", "stochastic_interpolant"] = "edm_diffusion"
     "Training and sampling objective used by the transport model."
-    sigma_data: PositiveFloat = Field(default=EdmSettings.sigma_data, examples=[EdmSettings.sigma_data])
+    sigma_data: PositiveFloat = Field(default=1.0, examples=[1.0])
     "Typical data scale used by EDM diffusion."
-    noise_channels: PositiveInt = Field(
-        default=NoiseConditioningSettings.channels,
-        examples=[NoiseConditioningSettings.channels],
-    )
+    noise_channels: PositiveInt = Field(default=32, examples=[32])
     "Number of channels in the noise or bridge-time embedding."
-    noise_cond_dim: PositiveInt = Field(
-        default=NoiseConditioningSettings.cond_dim,
-        examples=[NoiseConditioningSettings.cond_dim],
-    )
+    noise_cond_dim: PositiveInt = Field(default=16, examples=[16])
     "Size of the conditioning vector passed to conditional layers."
-    sigma_max: PositiveFloat = Field(default=EdmSettings.sigma_max, examples=[EdmSettings.sigma_max])
+    sigma_max: PositiveFloat = Field(default=100.0, examples=[100.0])
     "Maximum EDM diffusion noise level used during training."
-    sigma_min: PositiveFloat = Field(default=EdmSettings.sigma_min, examples=[EdmSettings.sigma_min])
+    sigma_min: PositiveFloat = Field(default=0.02, examples=[0.02])
     "Minimum EDM diffusion noise level used during training."
-    rho: PositiveFloat = Field(default=EdmSettings.rho, examples=[EdmSettings.rho])
+    rho: PositiveFloat = Field(default=7.0, examples=[7.0])
     "Shape parameter for the Karras EDM noise schedule."
-    si_alpha_schedule: Literal["linear"] = StochasticInterpolantSettings.alpha_schedule
+    si_alpha_schedule: Literal["linear"] = "linear"
     "Schedule for how strongly the SI bridge keeps the source field."
-    si_beta_schedule: Literal["linear", "quadratic"] = StochasticInterpolantSettings.beta_schedule
+    si_beta_schedule: Literal["linear", "quadratic"] = "linear"
     "Schedule for how strongly the SI bridge moves toward the target field."
-    si_sigma_schedule: Literal["brownian_bridge", "quadratic_bridge"] = StochasticInterpolantSettings.sigma_schedule
+    si_sigma_schedule: Literal["brownian_bridge", "quadratic_bridge"] = "brownian_bridge"
     "Schedule for the SI bridge-noise amplitude."
     source: TransportSourceConfig = Field(default_factory=TransportSourceConfig)
     "Configuration for the starting/source field."
-    si_noise_scale: NonNegativeFloat = Field(
-        default=StochasticInterpolantSettings.noise_scale,
-        examples=[StochasticInterpolantSettings.noise_scale],
-    )
+    si_noise_scale: NonNegativeFloat = Field(default=1.0, examples=[1.0])
     "Overall scale of the stochastic-interpolant bridge noise."
     training_condition: dict = Field(default_factory=dict)
     "Distribution used to sample one training noise level or bridge time per sample."

--- a/models/tests/schemas/test_transport_schema_defaults.py
+++ b/models/tests/schemas/test_transport_schema_defaults.py
@@ -1,0 +1,35 @@
+# (C) Copyright 2026- Anemoi contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+from anemoi.models.schemas.models import TransportConfig
+from anemoi.models.schemas.models import TransportSourceConfig
+from anemoi.models.transport.settings import EdmSettings
+from anemoi.models.transport.settings import NoiseConditioningSettings
+from anemoi.models.transport.settings import StochasticInterpolantSettings
+from anemoi.models.transport.settings import TransportSourceSettings
+
+
+def test_schema_defaults_match_transport_settings() -> None:
+    """The schema defaults are restated literals, so pin them to the dataclasses."""
+    source = TransportSourceConfig()
+    assert source.kind == TransportSourceSettings.kind
+    assert source.scale == TransportSourceSettings.scale
+    assert source.noise_scale == TransportSourceSettings.noise_scale
+
+    transport = TransportConfig()
+    assert transport.sigma_data == EdmSettings.sigma_data
+    assert transport.sigma_max == EdmSettings.sigma_max
+    assert transport.sigma_min == EdmSettings.sigma_min
+    assert transport.rho == EdmSettings.rho
+    assert transport.noise_channels == NoiseConditioningSettings.channels
+    assert transport.noise_cond_dim == NoiseConditioningSettings.cond_dim
+    assert transport.si_alpha_schedule == StochasticInterpolantSettings.alpha_schedule
+    assert transport.si_beta_schedule == StochasticInterpolantSettings.beta_schedule
+    assert transport.si_sigma_schedule == StochasticInterpolantSettings.sigma_schedule
+    assert transport.si_noise_scale == StochasticInterpolantSettings.noise_scale


### PR DESCRIPTION
## Description

Inline the 13 transport default values as literals in the pydantic fields of `TransportSourceConfig` and `TransportConfig`, instead of importing them from `anemoi.models.transport.settings`. Nothing else changes.

## What problem does this change solve?

The schemas sit on the CLI path, and importing `anemoi.models.transport.settings` runs the `transport` package `__init__`, which imports torch. So every `anemoi-training` invocation — including `--help` — imported torch. With this change the CLI no longer imports torch: `import anemoi.training.__main__` goes from 1.93s to 0.51s warm, and much more is saved on a cold filesystem cache. `anemoi-training train` is unaffected (it imports torch anyway).

## What issue or task does this change relate to?

Related to #1327.

## Additional notes

`PlotSettingsSchema` already inlines its defaults the same way. A new test (`models/tests/schemas/test_transport_schema_defaults.py`) checks every inlined default against the corresponding dataclass attribute, so the two cannot drift apart. `model_dump()` output is unchanged and both existing import paths keep working.

This change was developed in tandem with AI coding agents.

---

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)
