### PR TITLE
fix(training): honour diagnostics.enable_checkpointing in the trainer

### DIFF
--- a/training/src/anemoi/training/train/evaluate.py
+++ b/training/src/anemoi/training/train/evaluate.py
@@ -77,6 +77,7 @@ class AnemoiEvaluator(AnemoiTrainer):
             limit_val_batches=self.config.dataloader.limit_batches.validation,
             use_distributed_sampler=False,
             enable_progress_bar=self.config.diagnostics.enable_progress_bar,
+            enable_checkpointing=False,
         )
 
         LOGGER.debug("Starting evaluation..")

--- a/training/src/anemoi/training/train/train.py
+++ b/training/src/anemoi/training/train/train.py
@@ -739,6 +739,7 @@ class AnemoiTrainer(ABC):
             # we have our own DDP-compliant sampler logic baked into the dataset
             use_distributed_sampler=False,
             enable_progress_bar=self.config.diagnostics.enable_progress_bar,
+            enable_checkpointing=self.config.diagnostics.enable_checkpointing,
             check_val_every_n_epoch=getattr(self.config.diagnostics, "check_val_every_n_epoch", 1),
         )
 


### PR DESCRIPTION

## Description

`diagnostics.enable_checkpointing: false` did not stop checkpoints from being written: `pl.Trainer` was never given `enable_checkpointing`, so it kept Lightning's default of `True`. This PR forwards the config value.

## What problem does this change solve?

With the flag false there is no `ModelCheckpoint` in the callbacks, so Lightning appends its own default one — no `dirpath`, a full checkpoint every epoch in the working directory, `system.output.checkpoints.root` ignored. We hit this as a disk-quota failure. `AnemoiEvaluator` had the same gap and now passes `enable_checkpointing=False`.

##  Additional notes ##

This change was developed in tandem with AI coding agents.

---

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)
