### PR TITLE
feat: premixer

### DIFF
--- a/models/src/anemoi/models/layers/premixer.py
+++ b/models/src/anemoi/models/layers/premixer.py
@@ -1,0 +1,188 @@
+# (C) Copyright 2026 Anemoi contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+
+import logging
+from typing import Optional
+
+from torch import Tensor
+from torch import nn
+from torch.distributed.distributed_c10d import ProcessGroup
+from torch_geometric.typing import Adj
+
+from anemoi.models.distributed.shapes import GraphShardInfo
+from anemoi.models.layers.processor import GraphTransformerProcessor
+from anemoi.models.layers.utils import load_layer_kernels
+from anemoi.utils.config import DotDict
+
+LOGGER = logging.getLogger(__name__)
+
+
+class GraphTransformerPreMixer(nn.Module):
+    """Nonlinear point-to-point mixing on the data grid, ahead of the encoder.
+
+    Motivation
+    ----------
+    The encoder mapper is a *single* attention block, so each hidden node is
+
+        out_h = sum_{s in N(h)} alpha_hs * V(x_s),   V(x_s) = Linear(LayerNorm(Linear(x_s)))
+
+    Every nonlinearity is per-token and the aggregation is a softmax-weighted
+    sum, so a hidden node can only ever hold a data-dependent weighted *mean*
+    of its neighbourhood. Sub-grid variance, gradients and texture are not
+    representable, because they need products of *distinct* points' features.
+
+    This module runs graph-attention layers over a data -> data graph before
+    that pooling, so each point token becomes a nonlinear function of its own
+    neighbourhood. The encoder then pools nonlinear local descriptors rather
+    than linear point features, which is a strictly richer class of set
+    function (mean-of-nonlinear-local-features, not nonlinear-of-mean).
+
+    Shape and initialisation contract
+    ---------------------------------
+    The mixed signal is added back residually at the *input* width, so
+    ``input_dim`` is unchanged and every downstream module (encoder, decoder)
+    keeps its shapes. With ``initialise_out_zero`` the module is an exact
+    identity at initialisation, so a checkpoint trained without a pre-mixer can
+    be forked and reproduces its parent bit-for-bit on step 0.
+    """
+
+    def __init__(
+        self,
+        *,
+        in_channels: int,
+        num_channels: int,
+        num_layers: int,
+        num_chunks: int,
+        num_heads: int,
+        mlp_hidden_ratio: float,
+        edge_dim: int,
+        attn_channels: Optional[int] = None,
+        qk_norm: bool = False,
+        initialise_out_zero: bool = True,
+        cpu_offload: bool = False,
+        gradient_checkpointing: bool = True,
+        graph_attention_backend: str = "triton",
+        edge_pre_mlp: bool = False,
+        layer_kernels: DotDict,
+        **kwargs,  # accept unused extras like sub_graph_edge_attributes / trainable_size
+    ) -> None:
+        """Initialize GraphTransformerPreMixer.
+
+        Parameters
+        ----------
+        in_channels : int
+            Width of the data-node features, i.e. the model's ``input_dim``.
+            The module reads and writes at this width.
+        num_channels : int
+            Internal mixing width. Independent of ``model.num_channels``: the
+            data grid is several times larger than the hidden grid, so this is
+            normally set well below it.
+        num_layers : int
+            Number of graph-attention layers of point-to-point mixing.
+        num_chunks : int
+            Number of gradient-checkpointing chunks. Set equal to ``num_layers``
+            to checkpoint every layer.
+        num_heads : int
+            Number of attention heads.
+        mlp_hidden_ratio : float
+            Ratio of mlp hidden dimension to embedding dimension.
+        edge_dim : int
+            Edge feature dimension of the data -> data graph.
+        attn_channels : int, optional
+            Internal attention width for q/k/v, by default None (= num_channels).
+        qk_norm : bool, optional
+            Normalize query and key, by default False.
+        initialise_out_zero : bool, optional
+            Zero-initialise the output projection so the module starts as an
+            exact identity, by default True. Keep this True when forking a
+            checkpoint trained without a pre-mixer.
+        cpu_offload : bool, optional
+            Whether to offload processing to CPU, by default False.
+        gradient_checkpointing : bool, optional
+            Whether to enable gradient checkpointing, by default True.
+        graph_attention_backend : str, optional
+            Backend for the graph attention, "triton" or "pyg", by default "triton".
+        edge_pre_mlp : bool, optional
+            Allow for edge feature mixing, by default False.
+        layer_kernels : DotDict
+            A dict of layer implementations e.g. layer_kernels.Linear = "torch.nn.Linear"
+        """
+        super().__init__()
+
+        self.in_channels = in_channels
+        self.num_channels = num_channels
+        self.layer_factory = load_layer_kernels(layer_kernels)
+
+        self.emb_in = self.layer_factory.Linear(in_channels, num_channels)
+
+        self.proc = GraphTransformerProcessor(
+            num_layers=num_layers,
+            num_channels=num_channels,
+            num_chunks=num_chunks,
+            num_heads=num_heads,
+            mlp_hidden_ratio=mlp_hidden_ratio,
+            edge_dim=edge_dim,
+            attn_channels=attn_channels,
+            qk_norm=qk_norm,
+            cpu_offload=cpu_offload,
+            gradient_checkpointing=gradient_checkpointing,
+            layer_kernels=layer_kernels,
+            graph_attention_backend=graph_attention_backend,
+            edge_pre_mlp=edge_pre_mlp,
+        )
+
+        self.emb_out = self.layer_factory.Linear(num_channels, in_channels)
+        if initialise_out_zero:
+            nn.init.zeros_(self.emb_out.weight)
+            if self.emb_out.bias is not None:
+                nn.init.zeros_(self.emb_out.bias)
+
+    def forward(
+        self,
+        x: Tensor,
+        batch_size: int,
+        shard_info: GraphShardInfo,
+        edge_attr: Tensor,
+        edge_index: Adj,
+        model_comm_group: Optional[ProcessGroup] = None,
+    ) -> Tensor:
+        """Mix data-node features with those of their neighbours.
+
+        Parameters
+        ----------
+        x : Tensor
+            Data node features of width ``in_channels``.
+        batch_size : int
+            Batch size.
+        shard_info : GraphShardInfo
+            Shard metadata for the data nodes and the data -> data edges.
+            ``nodes=None`` means the data grid is replicated, not sharded.
+        edge_attr : Tensor
+            Edge attributes of the data -> data graph.
+        edge_index : Adj
+            Edge indices of the data -> data graph.
+        model_comm_group : ProcessGroup, optional
+            Model communication group.
+
+        Returns
+        -------
+        Tensor
+            Mixed features, same shape and shard layout as ``x``.
+        """
+        x_mixed = self.proc(
+            self.emb_in(x),
+            batch_size=batch_size,
+            shard_info=shard_info,
+            edge_attr=edge_attr,
+            edge_index=edge_index,
+            model_comm_group=model_comm_group,
+        )
+
+        return x + self.emb_out(x_mixed)

--- a/models/src/anemoi/models/models/autoencoder.py
+++ b/models/src/anemoi/models/models/autoencoder.py
@@ -168,6 +168,17 @@ class AnemoiModelAutoEncoder(AnemoiModelEncProcDec):
             )
             shard_sizes_data_dict[dataset_name] = shard_sizes_data
 
+            # Nonlinear point-to-point mixing before the encoder pools (no-op if unconfigured).
+            # The decoder never sees x_data_latent in the autoencoder, so this stays on the
+            # encoding side only and introduces no reconstruction shortcut.
+            x_data_latent = self._run_premixer(
+                x_data_latent,
+                dataset_name=dataset_name,
+                batch_size=batch_size,
+                shard_sizes_data=shard_sizes_data,
+                model_comm_group=model_comm_group,
+            )
+
             (
                 encoder_edge_attr,
                 encoder_edge_index,

--- a/models/src/anemoi/models/models/encoder_processor_decoder.py
+++ b/models/src/anemoi/models/models/encoder_processor_decoder.py
@@ -35,6 +35,10 @@ class AnemoiModelEncProcDec(BaseGraphModel):
 
     def _build_networks(self, model_config: DotDict) -> None:
         """Builds the model components."""
+        # Optional pre-mixer data -> data, applied before the encoder pools.
+        # Absent from the config => no modules built and the model is unchanged.
+        self._build_premixer(model_config)
+
         # Encoder data -> hidden
         self.encoder_graph_provider = torch.nn.ModuleDict()
         self.encoder = torch.nn.ModuleDict()
@@ -94,6 +98,73 @@ class AnemoiModelEncProcDec(BaseGraphModel):
                 out_channels_dst=self.output_dim[dataset_name],
                 edge_dim=self.decoder_graph_provider[dataset_name].edge_dim,
             )
+
+    def _build_premixer(self, model_config: DotDict) -> None:
+        """Build the optional data -> data pre-mixer, one per dataset.
+
+        The encoder is a single attention block, so a hidden node can only ever
+        hold a softmax-weighted sum of *linearly* embedded data points. The
+        pre-mixer runs graph attention over a data -> data graph first, so the
+        encoder pools nonlinear local descriptors instead. See
+        `anemoi.models.layers.premixer.GraphTransformerPreMixer`.
+        """
+        self.premixer_graph_provider = torch.nn.ModuleDict()
+        self.premixer = torch.nn.ModuleDict()
+
+        premixer_config = model_config.model.get("premixer", None)
+        if premixer_config is None:
+            return
+
+        for dataset_name in self.dataset_names:
+            self.premixer_graph_provider[dataset_name] = create_graph_provider(
+                graph=self._graph_data[(dataset_name, "to", dataset_name)],
+                edge_attributes=premixer_config.get("sub_graph_edge_attributes"),
+                src_size=self.node_attributes.num_nodes[dataset_name],
+                dst_size=self.node_attributes.num_nodes[dataset_name],
+                trainable_size=premixer_config.get("trainable_size", 0),
+            )
+
+            self.premixer[dataset_name] = instantiate(
+                premixer_config,
+                _recursive_=False,  # Avoids instantiation of layer_kernels here
+                in_channels=self.input_dim[dataset_name],
+                edge_dim=self.premixer_graph_provider[dataset_name].edge_dim,
+            )
+
+    def _run_premixer(
+        self,
+        x_data_latent: Tensor,
+        *,
+        dataset_name: str,
+        batch_size: int,
+        shard_sizes_data: ShardSizes,
+        model_comm_group: Optional[ProcessGroup] = None,
+    ) -> Tensor:
+        """Apply the data -> data pre-mixer, or pass through if it is not configured.
+
+        Returns a tensor of the same shape and shard layout as the input, so the
+        encoder and decoder call sites are unaffected either way.
+        """
+        if dataset_name not in self.premixer:
+            return x_data_latent
+
+        (
+            premixer_edge_attr,
+            premixer_edge_index,
+            premix_edge_shard_sizes,
+        ) = self.premixer_graph_provider[dataset_name].get_edges(
+            batch_size=batch_size,
+            model_comm_group=model_comm_group,
+        )
+
+        return self.premixer[dataset_name](
+            x_data_latent,
+            batch_size=batch_size,
+            shard_info=GraphShardInfo(nodes=shard_sizes_data, edges=premix_edge_shard_sizes),
+            edge_attr=premixer_edge_attr,
+            edge_index=premixer_edge_index,
+            model_comm_group=model_comm_group,
+        )
 
     def _assemble_input(
         self,
@@ -240,6 +311,15 @@ class AnemoiModelEncProcDec(BaseGraphModel):
             )
             x_skip_dict[dataset_name] = x_skip
             shard_sizes_data_dict[dataset_name] = shard_sizes_data
+
+            # Nonlinear point-to-point mixing before the encoder pools (no-op if unconfigured)
+            x_data_latent = self._run_premixer(
+                x_data_latent,
+                dataset_name=dataset_name,
+                batch_size=batch_size,
+                shard_sizes_data=shard_sizes_data,
+                model_comm_group=model_comm_group,
+            )
 
             (
                 encoder_edge_attr,

--- a/models/src/anemoi/models/schemas/models.py
+++ b/models/src/anemoi/models/schemas/models.py
@@ -35,6 +35,7 @@ from .encoder import GNNEncoderSchema  # noqa: TC001
 from .encoder import GraphTransformerEncoderSchema  # noqa: TC001
 from .encoder import PointWiseForwardMapperSchema  # noqa: TC001
 from .encoder import TransformerEncoderSchema  # noqa: TC001
+from .premixer import GraphTransformerPreMixerSchema  # noqa: TC001
 from .processor import GNNProcessorSchema  # noqa: TC001
 from .processor import GraphTransformerProcessorSchema  # noqa: TC001
 from .processor import NoOpProcessorSchema  # noqa: TC001
@@ -276,6 +277,8 @@ class BaseModelSchema(PydanticBaseModel):
         discriminator="target_",
     )
     "GNN processor schema."
+    premixer: Optional[GraphTransformerPreMixerSchema] = Field(default=None)
+    "Optional data -> data pre-mixer applied before the encoder pools. Omit to disable."
     encoder: Union[
         GNNEncoderSchema,
         GraphTransformerEncoderSchema,

--- a/models/src/anemoi/models/schemas/premixer.py
+++ b/models/src/anemoi/models/schemas/premixer.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2026- ECMWF.
+# (C) Copyright 2026 Anemoi contributors.
 #
 # This software is licensed under the terms of the Apache Licence Version 2.0
 # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.

--- a/models/src/anemoi/models/schemas/premixer.py
+++ b/models/src/anemoi/models/schemas/premixer.py
@@ -1,0 +1,39 @@
+# (C) Copyright 2026- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+#
+
+from typing import Literal
+
+from pydantic import Field
+from pydantic import NonNegativeInt
+from pydantic import PositiveInt
+
+from .common_components import TransformerModelComponent
+
+
+class GraphTransformerPreMixerSchema(TransformerModelComponent):
+    target_: Literal["anemoi.models.layers.premixer.GraphTransformerPreMixer"] = Field(..., alias="_target_")
+    "Graph transformer pre-mixer object from anemoi.models.layers.premixer."
+    num_channels: PositiveInt = Field(example=256)
+    "Internal mixing width. Independent of model.num_channels."
+    num_layers: PositiveInt = Field(example=4)
+    "Number of point-to-point mixing layers."
+    trainable_size: NonNegativeInt = Field(default=0)
+    "Size of trainable parameters vector on the data -> data edges. Default 0: that graph has "
+    "one edge per data node per neighbour, so a non-zero value adds millions of parameters."
+    sub_graph_edge_attributes: list[str] = Field(default_factory=list, examples=["edge_length", "edge_dirs"])
+    "Edge attributes to consider in the pre-mixer features."
+    qk_norm: bool = Field(default=False)
+    "Normalize the query and key vectors. Default to False."
+    initialise_out_zero: bool = Field(default=True)
+    "Zero-initialise the output projection so the module starts as an exact identity. "
+    "Keep True when forking a checkpoint trained without a pre-mixer."
+    graph_attention_backend: str = Field(default="triton")
+    "Backend for the graph attention, 'triton' or 'pyg'."
+    edge_pre_mlp: bool = Field(default=False)
+    "Allow for edge feature mixing. Default to False."

--- a/models/tests/layers/test_premixer.py
+++ b/models/tests/layers/test_premixer.py
@@ -1,0 +1,128 @@
+# (C) Copyright 2026 Anemoi contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+import pytest
+import torch
+from torch_geometric.data import HeteroData
+
+from anemoi.models.distributed.shapes import GraphShardInfo
+from anemoi.models.layers.graph_provider import create_graph_provider
+from anemoi.models.layers.premixer import GraphTransformerPreMixer
+from anemoi.models.layers.utils import load_layer_kernels
+
+
+class TestGraphTransformerPreMixer:
+    """Test the GraphTransformerPreMixer class."""
+
+    NUM_NODES: int = 64
+    IN_CHANNELS: int = 12
+    NUM_CHANNELS: int = 32
+    K: int = 4
+
+    @pytest.fixture
+    def fake_graph(self) -> HeteroData:
+        """A data -> data graph, as built by KNNEdges with source == target."""
+        torch.manual_seed(0)
+        graph = HeteroData()
+        graph["data"].x = torch.rand((self.NUM_NODES, 2))
+        # k edges per data node, dst-sorted, so every node is a target -- no orphans
+        target = torch.arange(self.NUM_NODES).repeat_interleave(self.K)
+        source = torch.randint(0, self.NUM_NODES, (self.NUM_NODES * self.K,))
+        graph[("data", "to", "data")].edge_index = torch.stack([source, target], dim=0)
+        graph[("data", "to", "data")].edge_length = torch.rand((self.NUM_NODES * self.K, 1))
+        graph[("data", "to", "data")].edge_dirs = torch.rand((self.NUM_NODES * self.K, 2))
+        return graph
+
+    @pytest.fixture
+    def graph_provider(self, fake_graph):
+        return create_graph_provider(
+            graph=fake_graph[("data", "to", "data")],
+            edge_attributes=["edge_length", "edge_dirs"],
+            src_size=self.NUM_NODES,
+            dst_size=self.NUM_NODES,
+            trainable_size=0,
+        )
+
+    def build(self, graph_provider, **overrides):
+        kwargs = {
+            "in_channels": self.IN_CHANNELS,
+            "num_channels": self.NUM_CHANNELS,
+            "num_layers": 2,
+            "num_chunks": 2,
+            "num_heads": 4,
+            "mlp_hidden_ratio": 2,
+            "edge_dim": graph_provider.edge_dim,
+            "layer_kernels": load_layer_kernels(instance=False),
+            "graph_attention_backend": "pyg",
+        }
+        kwargs.update(overrides)
+        return GraphTransformerPreMixer(**kwargs)
+
+    def run(self, premixer, graph_provider, x):
+        edge_attr, edge_index, edge_shard_sizes = graph_provider.get_edges(batch_size=1)
+        return premixer(
+            x,
+            batch_size=1,
+            shard_info=GraphShardInfo(nodes=None, edges=edge_shard_sizes),
+            edge_attr=edge_attr,
+            edge_index=edge_index,
+        )
+
+    def test_preserves_shape(self, graph_provider):
+        """Output width must equal input width so encoder/decoder shapes are untouched."""
+        premixer = self.build(graph_provider)
+        x = torch.rand((self.NUM_NODES, self.IN_CHANNELS))
+        assert self.run(premixer, graph_provider, x).shape == x.shape
+
+    def test_is_identity_at_init(self, graph_provider):
+        """With initialise_out_zero the module must be an exact identity.
+
+        This is what lets a checkpoint trained without a pre-mixer be forked
+        and reproduce its parent bit-for-bit on step 0.
+        """
+        premixer = self.build(graph_provider, initialise_out_zero=True)
+        x = torch.rand((self.NUM_NODES, self.IN_CHANNELS))
+        torch.testing.assert_close(self.run(premixer, graph_provider, x), x, rtol=0, atol=0)
+
+    def test_not_identity_when_out_is_trained(self, graph_provider):
+        """Once the output projection moves off zero the module must actually mix."""
+        premixer = self.build(graph_provider, initialise_out_zero=False)
+        x = torch.rand((self.NUM_NODES, self.IN_CHANNELS))
+        assert not torch.allclose(self.run(premixer, graph_provider, x), x)
+
+    def test_mixes_across_neighbours(self, graph_provider, fake_graph):
+        """The output at a node must depend on its neighbours' features.
+
+        This is the whole point: the encoder can only pool first moments, so
+        the pre-mixer has to make each token a function of its neighbourhood.
+        """
+        premixer = self.build(graph_provider, initialise_out_zero=False)
+        x = torch.rand((self.NUM_NODES, self.IN_CHANNELS), requires_grad=True)
+
+        out = self.run(premixer, graph_provider, x)
+
+        # Pick a target node that has at least one neighbour other than itself
+        edge_index = fake_graph[("data", "to", "data")].edge_index
+        target = 0
+        neighbours = edge_index[0][edge_index[1] == target]
+        neighbours = neighbours[neighbours != target]
+        assert len(neighbours) > 0, "test graph gave node 0 no distinct neighbour"
+
+        out[target].sum().backward()
+        assert x.grad[neighbours].abs().sum() > 0, "output does not depend on neighbour features"
+
+    def test_gradients_flow(self, graph_provider):
+        """Every pre-mixer parameter must receive a gradient."""
+        premixer = self.build(graph_provider, initialise_out_zero=False)
+        x = torch.rand((self.NUM_NODES, self.IN_CHANNELS))
+
+        self.run(premixer, graph_provider, x).sum().backward()
+
+        for name, param in premixer.named_parameters():
+            assert param.grad is not None, f"param.grad is None for {name}"

--- a/models/tests/models/test_premixer_integration.py
+++ b/models/tests/models/test_premixer_integration.py
@@ -110,9 +110,7 @@ def _make_config(with_premixer: bool, initialise_out_zero: bool = True):
             "residual": {"_target_": "anemoi.models.layers.residual.SkipConnection", "step": -1},
             "bounding": [],
             "layer_kernels": LAYER_KERNELS,
-            "processor": _component(
-                "anemoi.models.layers.processor.GraphTransformerProcessor", num_layers=2
-            ),
+            "processor": _component("anemoi.models.layers.processor.GraphTransformerProcessor", num_layers=2),
             "encoder": _component("anemoi.models.layers.mapper.GraphTransformerForwardMapper"),
             "decoder": _component("anemoi.models.layers.mapper.GraphTransformerBackwardMapper"),
         },

--- a/models/tests/models/test_premixer_integration.py
+++ b/models/tests/models/test_premixer_integration.py
@@ -1,0 +1,203 @@
+# (C) Copyright 2026 Anemoi contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""End-to-end checks of the data -> data pre-mixer inside a real model.
+
+`tests/layers/test_premixer.py` covers the module in isolation. These tests
+build an actual AnemoiModelAutoEncoder to verify the wiring: that the config
+key builds the modules, that the fork contract holds through the whole model,
+and that the pre-mixer is a genuine no-op when it is not configured.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from omegaconf import OmegaConf
+from torch_geometric.data import HeteroData
+
+from anemoi.models.models.autoencoder import AnemoiModelAutoEncoder
+
+N_DATA = 32
+N_HIDDEN = 8
+N_VARS = 1
+EDGE_ATTRS = ["edge_length", "edge_dirs"]
+BACKEND = "pyg"  # triton needs a GPU
+
+LAYER_KERNELS = {
+    "LayerNorm": {"_target_": "torch.nn.LayerNorm"},
+    "Linear": {"_target_": "torch.nn.Linear"},
+    "Activation": {"_target_": "torch.nn.GELU"},
+    "QueryNorm": {"_target_": "anemoi.models.layers.normalization.AutocastLayerNorm", "bias": False},
+    "KeyNorm": {"_target_": "anemoi.models.layers.normalization.AutocastLayerNorm", "bias": False},
+}
+
+
+class _IndexGroup(SimpleNamespace):
+    def __len__(self):
+        return len(self.prognostic)
+
+
+def _make_data_indices() -> dict:
+    idx = SimpleNamespace(
+        model=SimpleNamespace(
+            input=_IndexGroup(prognostic=[0]),
+            output=_IndexGroup(prognostic=[0], full=[0], diagnostic=[], name_to_index={"var": 0}),
+            _forcing=[],
+        ),
+        data=SimpleNamespace(input=SimpleNamespace(name_to_index={"var": 0})),
+        name_to_index={"var": 0},
+    )
+    return {"data": idx}
+
+
+def _dst_sorted_edges(n_src: int, n_dst: int, k: int, seed: int):
+    """k edges per destination node, sorted by destination."""
+    g = torch.Generator().manual_seed(seed)
+    dst = torch.arange(n_dst).repeat_interleave(k)
+    src = torch.randint(0, n_src, (n_dst * k,), generator=g)
+    return torch.stack([src, dst], dim=0), n_dst * k
+
+
+def _make_graph() -> HeteroData:
+    torch.manual_seed(0)
+    graph = HeteroData()
+    graph["data"].x = torch.rand(N_DATA, 2)
+    graph["data"].num_nodes = N_DATA
+    graph["hidden"].x = torch.rand(N_HIDDEN, 2)
+    graph["hidden"].num_nodes = N_HIDDEN
+
+    for name, n_src, n_dst, k, seed in [
+        (("data", "to", "data"), N_DATA, N_DATA, 4, 1),
+        (("data", "to", "hidden"), N_DATA, N_HIDDEN, 4, 2),
+        (("hidden", "to", "hidden"), N_HIDDEN, N_HIDDEN, 3, 3),
+        (("hidden", "to", "data"), N_HIDDEN, N_DATA, 2, 4),
+    ]:
+        edge_index, n_edges = _dst_sorted_edges(n_src, n_dst, k, seed)
+        graph[name].edge_index = edge_index
+        graph[name].edge_length = torch.rand(n_edges, 1)
+        graph[name].edge_dirs = torch.rand(n_edges, 2)
+    return graph
+
+
+def _component(target: str, **extra) -> dict:
+    base = {
+        "_target_": target,
+        "trainable_size": 0,
+        "sub_graph_edge_attributes": EDGE_ATTRS,
+        "num_chunks": 1,
+        "mlp_hidden_ratio": 2,
+        "num_heads": 2,
+        "layer_kernels": LAYER_KERNELS,
+        "graph_attention_backend": BACKEND,
+    }
+    base.update(extra)
+    return base
+
+
+def _make_config(with_premixer: bool, initialise_out_zero: bool = True):
+    cfg = {
+        "model": {
+            "num_channels": 16,
+            "trainable_parameters": {"data": 0, "hidden": 0, "data2hidden": 0, "hidden2data": 0, "hidden2hidden": 0},
+            "model": {"hidden_nodes_name": "hidden", "latent_skip": False},
+            "residual": {"_target_": "anemoi.models.layers.residual.SkipConnection", "step": -1},
+            "bounding": [],
+            "layer_kernels": LAYER_KERNELS,
+            "processor": _component(
+                "anemoi.models.layers.processor.GraphTransformerProcessor", num_layers=2
+            ),
+            "encoder": _component("anemoi.models.layers.mapper.GraphTransformerForwardMapper"),
+            "decoder": _component("anemoi.models.layers.mapper.GraphTransformerBackwardMapper"),
+        },
+    }
+    if with_premixer:
+        cfg["model"]["premixer"] = _component(
+            "anemoi.models.layers.premixer.GraphTransformerPreMixer",
+            num_channels=16,
+            num_layers=2,
+            num_chunks=2,
+            initialise_out_zero=initialise_out_zero,
+        )
+    return OmegaConf.create(cfg)
+
+
+def _build(with_premixer: bool, initialise_out_zero: bool = True, seed: int = 42) -> AnemoiModelAutoEncoder:
+    torch.manual_seed(seed)
+    return AnemoiModelAutoEncoder(
+        model_config=_make_config(with_premixer, initialise_out_zero),
+        data_indices=_make_data_indices(),
+        statistics={"data": None},
+        n_step_input=1,
+        n_step_output=1,
+        graph_data=_make_graph(),
+    )
+
+
+@pytest.fixture
+def x() -> dict:
+    torch.manual_seed(7)
+    return {"data": torch.rand(1, 1, 1, N_DATA, N_VARS)}
+
+
+def test_absent_config_builds_no_premixer():
+    """Without a model.premixer key the model must be completely unchanged."""
+    model = _build(with_premixer=False)
+    assert len(model.premixer) == 0
+    assert len(model.premixer_graph_provider) == 0
+
+
+def test_premixer_is_built_per_dataset():
+    model = _build(with_premixer=True)
+    assert "data" in model.premixer
+    assert "data" in model.premixer_graph_provider
+
+
+def test_output_shape_is_unchanged(x):
+    baseline = _build(with_premixer=False).eval()
+    premixed = _build(with_premixer=True).eval()
+    with torch.no_grad():
+        assert premixed(x)["data"].shape == baseline(x)["data"].shape
+
+
+def test_fork_contract_model_is_bit_identical_at_init(x):
+    """The whole model must reproduce the no-pre-mixer model bit-for-bit.
+
+    This is what lets an existing checkpoint be forked into a pre-mixer run:
+    every shared weight transfers, and the pre-mixer contributes exactly zero
+    until it is trained.
+    """
+    baseline = _build(with_premixer=False).eval()
+    premixed = _build(with_premixer=True, initialise_out_zero=True).eval()
+
+    incompatible = premixed.load_state_dict(baseline.state_dict(), strict=False)
+    assert not incompatible.unexpected_keys
+    assert all(k.startswith("premixer") for k in incompatible.missing_keys)
+
+    with torch.no_grad():
+        torch.testing.assert_close(premixed(x)["data"], baseline(x)["data"], rtol=0, atol=0)
+
+
+def test_premixer_changes_output_once_trained(x):
+    """With a non-zero output projection the pre-mixer must affect the model."""
+    baseline = _build(with_premixer=False).eval()
+    active = _build(with_premixer=True, initialise_out_zero=False).eval()
+    active.load_state_dict(baseline.state_dict(), strict=False)
+
+    with torch.no_grad():
+        assert not torch.allclose(active(x)["data"], baseline(x)["data"])
+
+
+def test_gradients_reach_the_premixer(x):
+    model = _build(with_premixer=True, initialise_out_zero=False)
+    model(x)["data"].sum().backward()
+
+    premixer_params = [(n, p) for n, p in model.named_parameters() if n.startswith("premixer")]
+    assert premixer_params, "no pre-mixer parameters found"
+    assert all(p.grad is not None for _, p in premixer_params)


### PR DESCRIPTION
# 🍷 Nonlinear point-to-point mixing before encoder pooling

**Draft.** Module, schema and tests are here. Training evidence is still running. Opening early to document the motivation and get the design reviewed.

## The problem

The encoder squeezes the data grid onto the hidden mesh in **one** round of attention — `GraphTransformerBaseMapper` builds a single block, not a stack. Each hidden node sees roughly a dozen data nodes and must compress them into one vector. Everything downstream — processor, decoder — sees the neighbourhood only through that vector. Whatever is lost there is lost permanently.

Two properties decide what survives.

**1. Each data point is featurised on its own.** The per-point map is a Linear, then a LayerNorm, then a Linear. LayerNorm rescales a token by its own mean and variance: it is not a polynomial feature map. So each point's contribution is an affine function of its inputs, up to a per-token rescale. Nothing here can square anything.

**2. The reduction is a weighted sum.** Each hidden node ends up holding attention-weighted averages of those affine features.

### What this does and does not cost us

**Still reachable.** With `H` heads you get `H` different weighted averages, and the attention weights depend on edge geometry as well as on the field. That is enough to build a spatial gradient: make one head lean one direction and another head lean the other, and the head-mixing `projection` can subtract them. Directional structure is *not* lost.

**Not reachable at any price: second moments.** Sub-grid variance needs a sum of *squared* features. The per-point map cannot produce a square, so variance is destroyed at the pooling step and unrecoverable downstream — no matter how many heads or channels we add.

**And everything competes for the same budget.** Each head yields exactly one weighted average. Every descriptor a hidden node might want — a gradient, an anisotropy, a soft maximum — spends one of `H`. Fine-scale structure is not just lossy, it is rationed.

### Related Work

**Deep Sets** (Zaheer et al., 2017) shows `rho(sum_s phi(x_s))` is a universal approximator for permutation-invariant set functions, *given a rich enough `phi`*. If `phi` emitted `(x, x², outer(x, offset), …)`, the sum would carry second moments and the downstream MLP could recover variance perfectly.

So sum-pooling is not the problem. *This* `phi` is: two Linears and a LayerNorm, with no multiplicative capacity.

That splits the fix in two:

- **(a) Deepen `phi` pointwise.** A per-point MLP unlocks second moments — variance becomes reachable. Cheap. Does nothing genuinely relational; it still sees one point at a time.
- **(b) Make `phi` neighbourhood-aware.** Each token becomes a function of the point *and its neighbours* before pooling, so the hidden node averages local descriptors instead of point values.

This PR implements **(b)**. **(a)** is included as a control arm, because (b) subsumes it and a positive result from (b) alone would not tell us whether the gain came from depth or from seeing neighbours.

## What Does this PR do, and what it does not

**Plausibly, compression.** Forecasting does not need every 1 km point recovered. It needs the sub-grid statistics that drive the resolved dynamics — variance, orographic roughness, texture. Those are exactly what a mean of point values destroys and a mean of local descriptors preserves. If this module works, the payoff is *more useful information per hidden node*, i.e. a coarser mesh for the same forecast skill.


## What this PR adds

`GraphTransformerPreMixer` (`anemoi/models/layers/premixer.py`): graph-attention layers over a `data → data` graph, applied to the data-node features before the encoder pools them. Reuses `GraphTransformerProcessor`.

### Design constraints it respects

**Shape-neutral.** Added back residually at the input width, so `input_dim` is unchanged and the encoder and decoder keep their shapes. No checkpoint surgery on `emb_nodes_src`.

**Exact identity at init.** With `initialise_out_zero=True` the output projection is zeroed, so the module is bit-for-bit an identity at step 0. A checkpoint trained without a pre-mixer forks and reproduces its parent exactly. Tested at `rtol=0, atol=0`.

**Fully opt-in.** No `model.premixer` key, no modules built, `_run_premixer` is a pass-through.


### Cost

Roughly 2 processor-layer-equivalents in FLOPs (~+15% on a 16-layer processor at 1024). **Memory, not FLOPs, is the real constraint:** a KNN-12 `data → data` graph on a 1 km LAM grid is ~13.8M edges, about 10× the encoder's edge count, with multi-GB per-edge tensors before chunking and a few hundred MB of persistent `edge_index` / `edge_attr`. Chunking and gradient checkpointing are on by default and should stay on.

## Files

| File | |
|---|---|
| `models/layers/premixer.py` | new — `GraphTransformerPreMixer` |
| `models/schemas/premixer.py` | new — `GraphTransformerPreMixerSchema` |
| `models/tests/layers/test_premixer.py` | new — 5 unit tests |
| `models/tests/models/test_premixer_integration.py` | new — 6 end-to-end tests |
| `models/models/encoder_processor_decoder.py` | `_build_premixer`, `_run_premixer`, call site |
| `models/models/autoencoder.py` | call site |
| `models/schemas/models.py` | optional `premixer` field |

## Tests

`tests/layers/test_premixer.py` — 5 passing: shape preserved; exact identity at init (`rtol=0, atol=0`); not an identity once the output projection is off zero; a node's output genuinely depends on its **neighbours'** features, checked via gradient flow; every parameter receives a gradient.

`tests/models/test_premixer_integration.py` — 6 passing, on a real `AnemoiModelAutoEncoder` over a small synthetic graph so the *wiring* is covered: true opt-in when unconfigured; modules built per dataset; output shape unchanged; model-level fork contract (only pre-mixer keys missing, output bit-identical); output changes off zero-init; gradients reach every parameter.

`tests/models` (47) and `tests/schemas` pass unchanged; `tests/layers` 206 passed / 4 skipped. Two pre-existing collection errors are unrelated (`hypothesis`, `pytest-mock` not installed).

## Still to do

- [ ] **Three-arm A/B**, single-sample autoencoder overfit, one variable changed per arm:
  - baseline, no pre-mixer
  - pre-mixer over `data → data` KNN-12
  - **control**: same module, same parameter count, self-loops only — zero mixing
  
- [ ] Judge on **spectral power below the mesh Nyquist**, not RMSE.
  - premix > control → mixing is doing the work
  - premix ≈ control > baseline → it was depth and parameters; use the cheap per-point MLP instead
  - premix ≈ baseline → the module is not engaging
