### PR TITLE
ci: move accuracy tests to debug queue

### DIFF
--- a/.github/workflows/integration-tests-hpc.yml
+++ b/.github/workflows/integration-tests-hpc.yml
@@ -55,7 +55,7 @@ jobs:
             #SBATCH --job-name=anemoi_core_build_env
             #SBATCH --nodes=1
             #SBATCH --cpus-per-task=32
-            #SBATCH --time=01:00:00
+            #SBATCH --time=00:30:00
             #SBATCH --qos=nf
             #SBATCH --mem=64G
           troika_user: ${{ secrets.HPC_CI_INTEGRATION_USER }}
@@ -106,8 +106,8 @@ jobs:
       timeout_minutes: 120
       sbatch_options: |
         #SBATCH --job-name=anemoi_core_pytest_accuracy
-        #SBATCH --time=01:00:00
-        #SBATCH --qos=ng
+        #SBATCH --time=00:30:00
+        #SBATCH --qos=dg
         #SBATCH --gpus=1
         #SBATCH --gres=gpu:1
         #SBATCH --mem=64G


### PR DESCRIPTION
## Description
Move accuracy tests to debug queue to reduce queuing times in the ci

The workflow and benchmark tests currently don't take less than 30 mins (at least not reliably), so not moving them in this PR.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)
