### PR TITLE
fix(training): require PyTorch Lightning 2.6

### DIFF
--- a/training/pyproject.toml
+++ b/training/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
   "numpy",
   "nvidia-ml-py>=13.580.82",
   "pydantic>=2.9",
-  "pytorch-lightning>=2.1",
+  "pytorch-lightning>=2.6",
   "timm>=0.9.2",
   "torch>=2.2,<2.11",
   "torch-geometric>=2.3.1",


### PR DESCRIPTION
## Description

Raise the `pytorch-lightning` minimum version for `anemoi-training` from 2.1 to 2.6.

## What problem does this change solve?

The training package imports `WeightAveraging`, which PyTorch Lightning introduced in version 2.6. The old dependency range allowed incompatible installations.

## What issue or task does this change relate to?

Fixes #1324.

## Additional notes

The focused callback suite passes 4 tests. It emits 2 unchanged dependency deprecation warnings.

The repository integration suite requires external ECMWF test data. The local download did not complete, so parallel GPU tests were not run.

By opening this pull request, I affirm that all authors agree to the Contributor License Agreement.
