### PR TITLE
ci: fix for pull request triggers in integration test workflow

### DIFF
--- a/.github/workflows/integration-tests-hpc.yml
+++ b/.github/workflows/integration-tests-hpc.yml
@@ -26,7 +26,18 @@ jobs:
     timeout-minutes: 120
     # On a pull_request the expensive tests only run when the author opted in
     # via the 'run-expensive-tests' label; schedule/dispatch/merge_group always run.
-    if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-expensive-tests') }}
+    if: >-
+      ${{
+        github.event_name != 'pull_request' ||
+        (
+          github.event.action == 'labeled' &&
+          github.event.label.name == 'run-expensive-tests'
+        ) ||
+        (
+          github.event.action != 'labeled' &&
+          contains(github.event.pull_request.labels.*.name, 'run-expensive-tests')
+        )
+      }}
     steps:
       - uses: ecmwf-actions/reusable-workflows/ci-hpc-generic@v2
         with:

--- a/.github/workflows/integration-tests-hpc.yml
+++ b/.github/workflows/integration-tests-hpc.yml
@@ -16,7 +16,7 @@ on:
           - test_training_cycle
           - test_accuracy
   pull_request:
-    types: [opened, reopened, synchronize, labeled]
+    types: [synchronize, labeled]
   merge_group:
 
 jobs:
@@ -157,7 +157,7 @@ jobs:
         with:
           issue-number: 294
           body: |
-            ## 🚨 Nightly Job Failed
+            ## Nightly Job Failed
 
             **Repository:** ${{ github.repository }}
             **Workflow:** ${{ github.workflow }}


### PR DESCRIPTION
## Description
Update the PR trigger options for the ci workflow for integration tests:
- don't run on opened PRs (two avoid running twice when the run-expensive-tests label is added early)
- filter on added labels and only trigger the workflow when the run-expensive-tests label is added (not when another label is added and the run-expensive-tests is present)

## What problem does this change solve?
The test workflow was triggered when adding arbitrary labels. For example, the expensive tests ran twice when adding the ATS label and the run-expensive-tests label together.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)
