### PR TITLE
chore: remove model summary from checkpoint metadata

### DIFF
--- a/training/src/anemoi/training/diagnostics/callbacks/checkpoint.py
+++ b/training/src/anemoi/training/diagnostics/callbacks/checkpoint.py
@@ -15,7 +15,6 @@ from pathlib import Path
 
 import pytorch_lightning as pl
 import torch
-import torchinfo
 from pytorch_lightning.callbacks.model_checkpoint import ModelCheckpoint
 from pytorch_lightning.utilities import rank_zero_only
 from pytorch_lightning.utilities.types import STEP_OUTPUT
@@ -67,14 +66,6 @@ class AnemoiCheckpoint(ModelCheckpoint):
             "model": model.__class__.__name__,
             "trainable_parameters": sum(p.numel() for p in model.parameters() if p.requires_grad),
             "total_parameters": sum(p.numel() for p in model.parameters()),
-            "summary": repr(
-                torchinfo.summary(
-                    model,
-                    depth=50,
-                    verbose=0,
-                    row_settings=["var_names"],
-                ),
-            ),
         }
 
         return self._model_metadata


### PR DESCRIPTION
## Description


Remove the model summary from the checkpoint metadata (generated by torchinfo). It can be very large, and will not be used in nexus.


## What problem does this change solve?
<!-- Describe if it's a bugfix, new feature, doc update, or breaking change -->

## What issue or task does this change relate to?
<!-- link to Issue Number -->

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)
