### PR TITLE
test: fix benchmark configs

### DIFF
--- a/training/tests/integration/config/benchmark/base.yaml
+++ b/training/tests/integration/config/benchmark/base.yaml
@@ -5,7 +5,6 @@ system:
     accelerator: cuda
     num_gpus_per_node: 2
     num_nodes: 1
-    num_gpus_per_model: 1
 
 dataloader:
   num_workers:


### PR DESCRIPTION
## Description
Remove num_gpus_per_model from base benchmark config so that it doesn't overwrite the use case specific settings

## What problem does this change solve?
Benchmark tests were failing for the lam use case where this setting overwrites the use case setting of 2 (leading to ~halfed throughput and doubled memory for the lam test case)

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)
