### PR TITLE
fix(training): correct variable scaler sizing and tendency indexing

### DIFF
--- a/training/src/anemoi/training/config/temporal_downscaler.yaml
+++ b/training/src/anemoi/training/config/temporal_downscaler.yaml
@@ -62,6 +62,7 @@ training:
   # Overwrites the tendency timestep used in the scaling to the output timestep so all lead times are normalised
   # by the same per-step statistics rather than their cumulative tendency statistics.
   # This does NOT activate the tendency scaler - to do this you must include the scaler in the loss configuration.
+  # Required with task.output_left_boundary: the 0h output step has no tendency statistics to fall back on.
   scalers:
     datasets:
       data:

--- a/training/src/anemoi/training/config/temporal_downscaler_ensemble.yaml
+++ b/training/src/anemoi/training/config/temporal_downscaler_ensemble.yaml
@@ -70,6 +70,7 @@ training:
   # Overwrites the tendency timestep used in the scaling to the output timestep so all lead times are normalised
   # by the same per-step statistics rather than their cumulative tendency statistics.
   # This does NOT activate the tendency scaler - to do this you must include the scaler in the loss configuration.
+  # Required with task.output_left_boundary: the 0h output step has no tendency statistics to fall back on.
   scalers:
     datasets:
       data:

--- a/training/src/anemoi/training/losses/scalers/variable.py
+++ b/training/src/anemoi/training/losses/scalers/variable.py
@@ -85,7 +85,7 @@ class GeneralVariableLossScaler(BaseVariableLossScaler):
 
         Retrieve the loss scaling for each variable from the config file.
         """
-        variable_loss_scaling = torch.empty((len(self.data_indices.data.output.full),), dtype=torch.float32)
+        variable_loss_scaling = torch.empty((len(self.data_indices.model.output.full),), dtype=torch.float32)
 
         for variable_name, idx in self.data_indices.model.output.name_to_index.items():
             _, variable_ref, _ = self.variable_metadata_extractor.get_group_and_level(variable_name)

--- a/training/src/anemoi/training/losses/scalers/variable_level.py
+++ b/training/src/anemoi/training/losses/scalers/variable_level.py
@@ -73,7 +73,7 @@ class BaseVariableLevelScaler(BaseVariableLossScaler):
         ...
 
     def get_scaling_values(self, **_kwargs) -> torch.Tensor:
-        variable_level_scaling = torch.ones((len(self.data_indices.data.output.full),), dtype=torch.float32)
+        variable_level_scaling = torch.ones((len(self.data_indices.model.output.full),), dtype=torch.float32)
 
         LOGGER.info(
             "Variable Level Scaling: Applying %s scaling to %s variables (%s)",

--- a/training/src/anemoi/training/losses/scalers/variable_tendency.py
+++ b/training/src/anemoi/training/losses/scalers/variable_tendency.py
@@ -9,7 +9,6 @@
 
 
 import logging
-import warnings
 from abc import abstractmethod
 from collections.abc import Mapping
 
@@ -36,6 +35,7 @@ class BaseTendencyScaler(BaseScaler):
         statistics_tendencies: Mapping | None,
         timestep: str | None = None,
         norm: str | None = None,
+        nodes_name: str | None = None,
         **kwargs,
     ) -> None:
         """Initialise variable level scaler.
@@ -52,6 +52,8 @@ class BaseTendencyScaler(BaseScaler):
             Tendency statistics lead time. Defaults to the first available lead time.
         norm : str, optional
             Type of normalization to apply. Options are None, unit-sum, unit-mean and l1.
+        nodes_name : str, optional
+            Name of the dataset the scaler belongs to.
         """
         super().__init__(norm=norm)
         del kwargs
@@ -71,14 +73,20 @@ class BaseTendencyScaler(BaseScaler):
             if timestep is None:
                 timestep = lead_times[0]
                 LOGGER.warning(
-                    "No timestep provided for tendency scaler, defaulting to first lead time: '%s'.",
+                    "%s: no timestep configured for dataset %r, defaulting to the first lead time %r.",
+                    type(self).__name__,
+                    nodes_name,
                     timestep,
                 )
             self.timestep = frequency_to_string(as_timedelta(timestep))
             self.statistics_tendencies = statistics_tendencies.get(self.timestep)
             assert self.statistics_tendencies is not None, f"No tendency statistics for timestep '{self.timestep}'."
         else:
-            warnings.warn("Dataset has no tendency statistics! Are you sure you want to use a tendency scaler?")
+            LOGGER.warning(
+                "%s: dataset %r has no tendency statistics, its prognostic variables will be scaled by 1.0.",
+                type(self).__name__,
+                nodes_name,
+            )
 
     @abstractmethod
     def get_level_scaling(self, variable_level: int) -> float: ...
@@ -86,15 +94,14 @@ class BaseTendencyScaler(BaseScaler):
     def get_scaling_values(self, **_kwargs) -> torch.Tensor:
         variable_level_scaling = torch.ones((len(self.data_indices.data.output.full),), dtype=torch.float32)
 
+        # Without tendency statistics every prognostic keeps a scaling of one.
+        has_tendencies = self.statistics_tendencies is not None
+
         for key, idx in self.data_indices.model.output.name_to_index.items():
-            if idx in self.data_indices.model.output.prognostic and self.data_indices.data.output.name_to_index.get(
-                key,
-            ):
+            if idx in self.data_indices.model.output.prognostic:
                 prog_idx = self.data_indices.data.output.name_to_index[key]
-                variable_stdev = self.statistics["stdev"][prog_idx] if self.statistics_tendencies else 1
-                variable_tendency_stdev = (
-                    self.statistics_tendencies["stdev"][prog_idx] if self.statistics_tendencies else 1
-                )
+                variable_stdev = self.statistics["stdev"][prog_idx] if has_tendencies else 1
+                variable_tendency_stdev = self.statistics_tendencies["stdev"][prog_idx] if has_tendencies else 1
                 scaling = self.get_level_scaling(variable_stdev, variable_tendency_stdev)
                 variable_level_scaling[idx] *= scaling
 

--- a/training/src/anemoi/training/losses/scalers/variable_tendency.py
+++ b/training/src/anemoi/training/losses/scalers/variable_tendency.py
@@ -84,7 +84,7 @@ class BaseTendencyScaler(BaseScaler):
     def get_level_scaling(self, variable_level: int) -> float: ...
 
     def get_scaling_values(self, **_kwargs) -> torch.Tensor:
-        variable_level_scaling = torch.ones((len(self.data_indices.data.output.full),), dtype=torch.float32)
+        variable_level_scaling = torch.ones((len(self.data_indices.model.output.full),), dtype=torch.float32)
 
         for key, idx in self.data_indices.model.output.name_to_index.items():
             if idx in self.data_indices.model.output.prognostic and self.data_indices.data.output.name_to_index.get(

--- a/training/tests/unit/losses/test_loss_scaling.py
+++ b/training/tests/unit/losses/test_loss_scaling.py
@@ -8,6 +8,7 @@
 # nor does it submit to any jurisdiction.
 
 
+import logging
 from typing import Any
 
 import pytest
@@ -22,6 +23,9 @@ from anemoi.training.losses.loss import get_metric_ranges
 from anemoi.training.losses.scalers import create_scalers
 from anemoi.training.losses.scalers.base_scaler import BaseUpdatingScaler
 from anemoi.training.losses.scalers.spectral import SpectralDimensionScaler
+from anemoi.training.losses.scalers.variable_tendency import BaseTendencyScaler
+from anemoi.training.losses.scalers.variable_tendency import StdevTendencyScaler
+from anemoi.training.losses.scalers.variable_tendency import VarTendencyScaler
 from anemoi.training.utils.enums import TensorDim
 from anemoi.training.utils.masks import NoOutputMask
 from anemoi.training.utils.variables_metadata import ExtractVariableGroupAndLevel
@@ -614,3 +618,77 @@ def test_uniform_spectral_scaler(n_spectral_modes: int, spectral_dims: int) -> N
     assert values[0].item() == pytest.approx(
         1.0 / n_spectral_modes,
     ), f"Expected values to be {1.0/n_spectral_modes}, got {values[0]}"
+
+
+@pytest.mark.parametrize(
+    ("scaler_cls", "expected"),
+    [
+        (StdevTendencyScaler, [2.0, 10.0, 5.0]),
+        (VarTendencyScaler, [4.0, 100.0, 25.0]),
+    ],
+)
+def test_tendency_scaler_scales_every_prognostic_from_data_space_statistics(
+    scaler_cls: type[BaseTendencyScaler],
+    expected: list[float],
+) -> None:
+    """Each prognostic is scaled by its own statistics, including the one at data index 0."""
+    config = DictConfig({"forcing": ["lsm"], "diagnostic": [], "target": []})
+    name_to_index = {"a": 0, "lsm": 1, "b": 2, "c": 3}
+    data_indices = IndexCollection(data_config=config, name_to_index=name_to_index)
+
+    statistics = {"stdev": [10.0, 40.0, 20.0, 30.0]}
+    statistics_tendencies = {"lead_times": ["6h"], "6h": {"stdev": [5.0, 10.0, 2.0, 6.0]}}
+
+    scaler = scaler_cls(
+        data_indices=data_indices,
+        statistics=statistics,
+        statistics_tendencies=statistics_tendencies,
+        timestep="6h",
+    )
+
+    assert torch.allclose(scaler.get_scaling_values(), torch.tensor(expected))
+
+
+def test_tendency_scaler_defaults_to_the_first_lead_time(caplog: pytest.LogCaptureFixture) -> None:
+    """With no timestep configured the scaler falls back to the first lead time."""
+    config = DictConfig({"forcing": ["lsm"], "diagnostic": [], "target": []})
+    name_to_index = {"a": 0, "lsm": 1, "b": 2, "c": 3}
+    data_indices = IndexCollection(data_config=config, name_to_index=name_to_index)
+
+    with caplog.at_level(logging.WARNING):
+        scaler = StdevTendencyScaler(
+            data_indices=data_indices,
+            statistics={"stdev": [10.0, 40.0, 20.0, 30.0]},
+            statistics_tendencies={
+                "lead_times": ["6h", "12h"],
+                "6h": {"stdev": [5.0, 10.0, 2.0, 6.0]},
+                "12h": {"stdev": [1.0, 1.0, 1.0, 1.0]},
+            },
+            nodes_name="era5",
+        )
+
+    assert scaler.timestep == "6h"
+    assert "StdevTendencyScaler" in caplog.text
+    assert "era5" in caplog.text
+    assert torch.allclose(scaler.get_scaling_values(), torch.tensor([2.0, 10.0, 5.0]))
+
+
+def test_tendency_scaler_without_tendency_statistics_leaves_scaling_at_one(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A dataset with no tendency statistics leaves every prognostic variable unscaled."""
+    config = DictConfig({"forcing": ["lsm"], "diagnostic": [], "target": []})
+    name_to_index = {"a": 0, "lsm": 1, "b": 2, "c": 3}
+    data_indices = IndexCollection(data_config=config, name_to_index=name_to_index)
+
+    with caplog.at_level(logging.WARNING):
+        scaler = StdevTendencyScaler(
+            data_indices=data_indices,
+            statistics={"stdev": [10.0, 40.0, 20.0, 30.0]},
+            statistics_tendencies=None,
+            nodes_name="era5",
+        )
+
+    assert "StdevTendencyScaler" in caplog.text
+    assert "era5" in caplog.text
+    assert torch.allclose(scaler.get_scaling_values(), torch.ones(3))

--- a/training/tests/unit/losses/test_loss_scaling.py
+++ b/training/tests/unit/losses/test_loss_scaling.py
@@ -23,6 +23,7 @@ from anemoi.training.losses.scalers import create_scalers
 from anemoi.training.losses.scalers.base_scaler import BaseUpdatingScaler
 from anemoi.training.losses.scalers.spectral import SpectralDimensionScaler
 from anemoi.training.utils.enums import TensorDim
+from anemoi.training.utils.index_space import IndexSpace
 from anemoi.training.utils.masks import NoOutputMask
 from anemoi.training.utils.variables_metadata import ExtractVariableGroupAndLevel
 from anemoi.transform.variables import Variable
@@ -342,6 +343,78 @@ expected_var_tendency_scaling = torch.Tensor(
         (2**2) / (1**2),  # d
     ],
 )
+
+
+@pytest.mark.parametrize("norm", [None, "unit-sum", "unit-mean"])
+@pytest.mark.parametrize(
+    ("scaler_config", "expected_weights"),
+    [
+        pytest.param(
+            {
+                "_target_": "anemoi.training.losses.scalers.GeneralVariableLossScaler",
+                "weights": {"default": 1, "y": 4},
+            },
+            [4.0, 4.0, 1.0],
+            id="general",
+        ),
+        pytest.param(std_dev_scaler, [2.0, 4.0, 1.0], id="tendency"),
+        pytest.param(linear_scaler, [0.5, 0.85, 1.0], id="level"),
+        pytest.param(
+            {
+                "_target_": "anemoi.training.losses.scalers.VariableMaskingLossScaler",
+                "variables": ["diag"],
+            },
+            [1.0, 1.0, 0.0],
+            id="masking",
+        ),
+    ],
+)
+def test_variable_scalers_with_interspersed_target(
+    scaler_config: dict,
+    expected_weights: list[float],
+    norm: str | None,
+) -> None:
+    """Build model-ordered weights and apply them to predictions paired with target variables."""
+    data_indices = IndexCollection(
+        DictConfig({"forcing": ["forcing"], "diagnostic": ["diag"], "target": ["truth"]}),
+        {"forcing": 0, "y_500": 1, "truth": 2, "y_850": 3, "diag": 4},
+    )
+    scalers, _ = create_scalers(
+        DictConfig({"variable": {**scaler_config, "norm": norm}}),
+        data_indices=data_indices,
+        metadata_extractor=ExtractVariableGroupAndLevel(DictConfig({"default": "sfc", "pl": ["y"]})),
+        statistics={"stdev": [1.0, 4.0, 1.0, 8.0, 1.0]},
+        statistics_tendencies={"lead_times": ["6h"], "6h": {"stdev": [1.0, 2.0, 1.0, 2.0, 1.0]}},
+    )
+    # Normalise over the three model outputs, including the diagnostic variable.
+    divisor = 1.0
+    if norm == "unit-sum":
+        divisor = sum(expected_weights)
+    elif norm == "unit-mean":
+        divisor = sum(expected_weights) / 3
+    expected_scaling = torch.tensor(expected_weights) / divisor
+    torch.testing.assert_close(scalers["variable"][1], expected_scaling)
+
+    scalers["grid"] = (TensorDim.GRID.value, torch.ones(1))
+    loss = get_loss_function(
+        DictConfig(
+            {
+                "_target_": "anemoi.training.losses.MSELoss",
+                "scalers": ["variable", "grid"],
+                "predicted_variables": ["y_500", "y_850"],
+                "target_variables": ["truth", "y_850"],
+            },
+        ),
+        scalers=scalers,
+        data_indices=data_indices,
+    )
+    pred = torch.tensor([3.0, 5.0, 0.0]).reshape(1, 1, 1, 1, 3)
+    target = torch.tensor([0.0, -10.0, 2.0, 3.0, 0.0]).reshape(1, 1, 1, 1, 5)
+    result = loss(pred, target, pred_layout=IndexSpace.MODEL_OUTPUT, target_layout=IndexSpace.DATA_FULL)
+
+    # Squared errors are (3 - 2)^2 = 1 and (5 - 3)^2 = 4.
+    expected_loss = (expected_weights[0] + 4 * expected_weights[1]) / (2 * divisor)
+    torch.testing.assert_close(result, torch.tensor(expected_loss))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

Correct variable loss weights when `data.target` is configured and ensure the prognostic variable at dataset index 0 receives its tendency scaling.

## What problem does this change solve?

General, level, and tendency scalers allocated in data-output space but wrote weights at model-output positions. Target reference variables widen the data output, so `LossVariableMapper` could infer the wrong layout and silently select incorrect weights. Extra entries also distorted normalisation; the general scaler left them uninitialised.

All three builders now allocate in model-output space. For data output `[y_500, truth, y_850, diag]`, tendency weights for the selected predictions `[y_500, y_850]` remain `[2, 4]` instead of becoming `[2, 1]`. The general change also covers variable masking.

The tendency scaler now scales every prognostic variable, including dataset index 0. This includes dataset-specific logging for missing statistics and timestep selection, and clarification of the temporal downscaler's timestep configuration.

## What issue or task does this change relate to?

Includes the index-0 fix from #1369 by merging `fix/tendency_temporal_downscaler_index`.

## Additional notes

- Added 12 regression cases covering interspersed target references, general/tendency/level/masking scalers, normalisation, and resulting MSE values. All 12 fail before the sizing fix.
- Combined validation: `python -m pytest training/tests/unit/losses training/tests/unit/train -q -o log_cli=false` — 505 passed, 4 skipped. No multi-GPU validation was run.
- All pre-commit checks passed on the combined diff.
- Separate follow-up: preserve missing reference validity through imputation and select masks using each sub-loss's target pairing. A missing reference imputed to zero can currently contribute to the loss because the NaN mask follows the predicted variable. That pre-existing issue is outside this PR.
