### PR TITLE
fix(training): Resuming training with weight averaging.

### DIFF
--- a/training/src/anemoi/training/config/training/weight_averaging/ema.yaml
+++ b/training/src/anemoi/training/config/training/weight_averaging/ema.yaml
@@ -1,2 +1,2 @@
-_target_: pytorch_lightning.callbacks.EMAWeightAveraging
+_target_: anemoi.training.diagnostics.callbacks.weight_averaging.EMAWeightAveraging
 decay: 0.999

--- a/training/src/anemoi/training/diagnostics/callbacks/checkpoint.py
+++ b/training/src/anemoi/training/diagnostics/callbacks/checkpoint.py
@@ -20,6 +20,7 @@ from pytorch_lightning.callbacks.model_checkpoint import ModelCheckpoint
 from pytorch_lightning.utilities import rank_zero_only
 from pytorch_lightning.utilities.types import STEP_OUTPUT
 
+from anemoi.training.diagnostics.callbacks.weight_averaging import averaged_weights
 from anemoi.training.utils.checkpoint import check_classes
 from anemoi.training.utils.checkpoint import clear_imputer_runtime_state
 from anemoi.utils.checkpoints import save_metadata
@@ -206,7 +207,10 @@ class AnemoiCheckpoint(ModelCheckpoint):
             inference_checkpoint_filepath = self._get_inference_checkpoint_filepath(lightning_checkpoint_filepath)
 
             clear_imputer_runtime_state(model)
-            torch.save(model, inference_checkpoint_filepath)
+            # This is needed to save the averaged weights when the
+            # WeightAveraging callback is used.
+            with averaged_weights(trainer):
+                torch.save(model, inference_checkpoint_filepath)
 
             save_metadata(inference_checkpoint_filepath, metadata, supporting_arrays=supporting_arrays)
 

--- a/training/src/anemoi/training/diagnostics/callbacks/weight_averaging.py
+++ b/training/src/anemoi/training/diagnostics/callbacks/weight_averaging.py
@@ -8,6 +8,8 @@
 # nor does it submit to any jurisdiction.
 
 import logging
+from collections.abc import Iterator
+from contextlib import contextmanager
 from typing import Any
 from typing import Union
 
@@ -26,45 +28,11 @@ MIN_PL_VERSION = "2.6.0"
 
 
 class WeightAveraging(_PLWeightAveraging):
-    """Base class that averages parameters and synchronises fixed buffers."""
+    """Base class that averages parameters and synchronises fixed buffers.
 
-    def __init__(
-        self,
-        device: Union[torch.device, str, int] | None = None,
-        use_buffers: bool = False,
-        **kwargs: Any,
-    ) -> None:
-        super().__init__(device=device, use_buffers=use_buffers, **kwargs)
-
-
-class EMAWeightAveraging(WeightAveraging):
-    """Exponential Moving Average weight averaging."""
-
-    def __init__(
-        self,
-        device: Union[torch.device, str, int] | None = None,
-        use_buffers: bool = False,
-        decay: float = 0.999,
-        update_every_n_steps: int = 1,
-        update_starting_at_step: int | None = None,
-        update_starting_at_epoch: int | None = None,
-        **kwargs: Any,
-    ) -> None:
-        super().__init__(
-            device=device,
-            use_buffers=use_buffers,
-            **kwargs,
-            avg_fn=get_ema_avg_fn(decay=decay),
-        )
-        self.update_every_n_steps = update_every_n_steps
-        self.update_starting_at_step = update_starting_at_step
-        self.update_starting_at_epoch = update_starting_at_epoch
-
-
-class SWAWeightAveraging(WeightAveraging):
-    """Stochastic Weight Averaging (running mean).
-
-    Uses the default running-mean function from PyTorch's ``AveragedModel``.
+    Adds the update schedule shared by the EMA and SWA variants: the averaged model is updated
+    every ``update_every_n_steps`` optimizer steps once ``update_starting_at_step`` is reached, and
+    additionally at the end of every epoch from ``update_starting_at_epoch`` onwards.
     """
 
     def __init__(
@@ -81,6 +49,77 @@ class SWAWeightAveraging(WeightAveraging):
         self.update_starting_at_step = update_starting_at_step
         self.update_starting_at_epoch = update_starting_at_epoch
 
+    def should_update(self, step_idx: int | None = None, epoch_idx: int | None = None) -> bool:
+        """Decide whether to update the averaged model after the given step or epoch.
+
+        Parameters
+        ----------
+        step_idx : int | None
+            Index of the last optimizer step, or None when called at the end of an epoch.
+        epoch_idx : int | None
+            Index of the last epoch, or None when called after an optimizer step.
+
+        Returns
+        -------
+        bool
+            True if the averaged model should be updated.
+        """
+        if step_idx is not None:
+            meets_step_requirement = self.update_starting_at_step is None or step_idx >= self.update_starting_at_step
+            meets_step_frequency = self.update_every_n_steps > 0 and step_idx % self.update_every_n_steps == 0
+            if meets_step_requirement and meets_step_frequency:
+                return True
+
+        if epoch_idx is not None:
+            return self.update_starting_at_epoch is not None and epoch_idx >= self.update_starting_at_epoch
+
+        return False
+
+
+class EMAWeightAveraging(WeightAveraging):
+    """Exponential Moving Average weight averaging."""
+
+    def __init__(self, decay: float = 0.999, **kwargs: Any) -> None:
+        super().__init__(**kwargs, avg_fn=get_ema_avg_fn(decay=decay))
+
+
+class SWAWeightAveraging(WeightAveraging):
+    """Stochastic Weight Averaging (running mean).
+
+    Uses the default running-mean function from PyTorch's ``AveragedModel``.
+    """
+
+
+@contextmanager
+def averaged_weights(trainer: "pl.Trainer") -> Iterator[None]:
+    """Temporarily swap the averaged weights into the live model.
+
+    The model holds the raw training weights outside of validation, so anything written from the
+    live model (the inference checkpoint) would otherwise disagree with the averaged weights that
+    validation metrics and the Lightning checkpoint's ``state_dict`` are based on. Does nothing when
+    weight averaging is not configured, or before training starts.
+
+    Parameters
+    ----------
+    trainer : pl.Trainer
+        The current trainer, used to find the weight averaging callback.
+    """
+    callback = next(
+        (cb for cb in trainer.callbacks if isinstance(cb, _PLWeightAveraging) and cb._average_model is not None),
+        None,
+    )
+    if callback is None:
+        yield
+        return
+
+    # _swap_models is pytorch-lightning internal, but it is the same swap the callback performs
+    # around every validation epoch, and it is an involution: swapping twice restores the model.
+    callback._swap_models(trainer.lightning_module)
+    try:
+        yield
+    finally:
+        callback._swap_models(trainer.lightning_module)
+
 
 def _get_weight_averaging_callback(weight_averaging_config: DictConfig | None) -> list[Callback]:
     """Get weight averaging callback from the config.
@@ -90,8 +129,8 @@ def _get_weight_averaging_callback(weight_averaging_config: DictConfig | None) -
             _target_: anemoi.training.diagnostics.callbacks.weight_averaging.EMAWeightAveraging
             decay: 0.999
 
-    Stock ``pytorch_lightning.callbacks.*WeightAveraging`` classes can also be used.
-    Set ``use_buffers=False`` when the model contains non-floating-point buffers.
+    Stock ``pytorch_lightning.callbacks.*WeightAveraging`` classes can also be used, but they
+    default to ``use_buffers=True``, which fails on non-floating-point buffers.
 
     Parameters
     ----------

--- a/training/src/anemoi/training/schemas/training.py
+++ b/training/src/anemoi/training/schemas/training.py
@@ -76,8 +76,8 @@ class WeightAveragingSchema(GenericSchema):
           decay: 0.999
           update_starting_at_step: 1000
 
-    Stock ``pytorch_lightning.callbacks.*WeightAveraging`` classes can also be used.
-    Set ``use_buffers=False`` when the model contains non-floating-point buffers.
+    Stock ``pytorch_lightning.callbacks.*WeightAveraging`` classes can also be used, but they
+    default to ``use_buffers=True``, which fails on non-floating-point buffers.
     """
 
 

--- a/training/src/anemoi/training/train/methods/base.py
+++ b/training/src/anemoi/training/train/methods/base.py
@@ -479,14 +479,47 @@ class BaseTrainingModule(pl.LightningModule, ABC):
             if full_key.startswith(processor_prefixes):
                 state_dict[full_key] = value
 
+    def _warn_if_averaged_weights_are_dropped(self, checkpoint: dict[str, Any]) -> None:
+        """Warn when resuming a weight-averaged checkpoint without a weight-averaging callback.
+
+        Such a checkpoint holds the averaged weights in "state_dict", so the model silently starts
+        from the averaged weights and the averaging state is lost. Loading only the weights (transfer
+        learning, evaluation) does this deliberately, so it is not reported.
+        """
+        if "averaging_state" not in checkpoint or self.config.training.load_weights_only:
+            return
+
+        weight_averaging_cls = getattr(pl.callbacks, "WeightAveraging", None)  # pytorch-lightning >= 2.6
+        trainer = getattr(self, "_trainer", None)
+        if weight_averaging_cls is None or trainer is None:
+            return
+        if any(isinstance(callback, weight_averaging_cls) for callback in trainer.callbacks):
+            return
+
+        LOGGER.warning(
+            "Resuming a checkpoint that was written with weight averaging, but no "
+            "'training.weight_averaging' callback is configured. The model will start from the "
+            "averaged weights instead of the training weights, and the averaging state is discarded. "
+            "Keep the weight averaging config to resume the run as it was trained.",
+        )
+
     def on_save_checkpoint(self, checkpoint: dict) -> None:
         checkpoint["task_state"] = self.task.training_runtime_state_dict()
 
     def on_load_checkpoint(self, checkpoint: torch.nn.Module) -> None:
         # Apply migrations to handle state_dict key changes from older checkpoints.
         # These are idempotent: already-migrated checkpoints are unaffected.
-        _trainable_edge_perm_fix_migration(checkpoint, model=self)
-        self._update_checkpoint_state_dict_for_load(checkpoint)
+        # A weight-averaging callback stores the averaged weights in "state_dict" and the raw
+        # training weights in "current_model_state", then restores the model from the latter after
+        # this hook has run. Both copies therefore need migrating.
+        for state_key in ("state_dict", "current_model_state"):
+            if state_key not in checkpoint:
+                continue
+            model_state = {"state_dict": checkpoint[state_key]}
+            _trainable_edge_perm_fix_migration(model_state, model=self)
+            self._update_checkpoint_state_dict_for_load(model_state)
+
+        self._warn_if_averaged_weights_are_dropped(checkpoint)
 
         self._ckpt_model_name_to_index = {
             dataset_name: data_indices.name_to_index

--- a/training/tests/unit/diagnostics/callbacks/test_weight_averaging.py
+++ b/training/tests/unit/diagnostics/callbacks/test_weight_averaging.py
@@ -9,15 +9,20 @@
 
 """Unit tests for weight averaging callback functionality."""
 
+from pathlib import Path
+
 import omegaconf
 import pytorch_lightning as pl
 import torch
 import yaml
+from pytorch_lightning.callbacks import ModelCheckpoint
+from pytorch_lightning.demos.boring_classes import BoringModel
 
 from anemoi.training.diagnostics.callbacks import _get_weight_averaging_callback
 from anemoi.training.diagnostics.callbacks.weight_averaging import EMAWeightAveraging
 from anemoi.training.diagnostics.callbacks.weight_averaging import SWAWeightAveraging
 from anemoi.training.diagnostics.callbacks.weight_averaging import WeightAveraging
+from anemoi.training.diagnostics.callbacks.weight_averaging import averaged_weights
 
 default_config = """
 training:
@@ -76,3 +81,84 @@ def test_weight_averaging_syncs_fixed_buffers_without_averaging_them() -> None:
     callback._average_model.update_parameters(model)
 
     assert callback._average_model.module.indices.item() == 1
+
+
+def test_should_update_respects_step_schedule() -> None:
+    """update_every_n_steps and update_starting_at_step gate step updates."""
+    callback = EMAWeightAveraging(update_every_n_steps=5, update_starting_at_step=100)
+
+    assert not callback.should_update(step_idx=0)
+    assert not callback.should_update(step_idx=95)  # right frequency, before the start step
+    assert not callback.should_update(step_idx=101)  # after the start step, wrong frequency
+    assert callback.should_update(step_idx=100)
+    assert callback.should_update(step_idx=105)
+
+
+def test_should_update_defaults_to_every_step() -> None:
+    """With no schedule configured, every step updates and epoch ends do not."""
+    callback = EMAWeightAveraging()
+
+    assert callback.should_update(step_idx=0)
+    assert callback.should_update(step_idx=7)
+    assert not callback.should_update(epoch_idx=0)
+
+
+class _Trainer:
+    def __init__(self, module: pl.LightningModule, callbacks: list) -> None:
+        self.lightning_module = module
+        self.callbacks = callbacks
+
+
+def test_averaged_weights_swaps_and_restores() -> None:
+    """The context manager exposes the averaged weights and puts the live ones back."""
+    model = _ModelWithIntegerBuffer()
+    callback = EMAWeightAveraging(decay=0.5)
+    callback.setup(None, model, "fit")
+
+    callback._average_model.update_parameters(model)  # average == 1.0
+    model.weight.data.fill_(3.0)
+    trainer = _Trainer(model, [callback])
+
+    with averaged_weights(trainer):
+        assert model.weight.item() == 1.0
+    assert model.weight.item() == 3.0
+
+
+def _ema_trainer(tmp_path: Path, max_steps: int, callbacks: list) -> pl.Trainer:
+    return pl.Trainer(
+        default_root_dir=str(tmp_path),
+        accelerator="cpu",
+        callbacks=callbacks,
+        max_steps=max_steps,
+        limit_train_batches=2,
+        limit_val_batches=0,
+        num_sanity_val_steps=0,
+        logger=False,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+    )
+
+
+def test_ema_state_is_restored_on_resume(tmp_path: Path) -> None:
+    """A run resumed from its own checkpoint continues the EMA instead of restarting it."""
+    steps = 4
+    checkpoint = ModelCheckpoint(dirpath=str(tmp_path), save_last=True, every_n_train_steps=steps)
+    _ema_trainer(tmp_path, steps, [EMAWeightAveraging(decay=0.9), checkpoint]).fit(BoringModel())
+
+    saved = torch.load(tmp_path / "last.ckpt", weights_only=False)
+    # The averaged weights are saved as "state_dict", the training weights beside them.
+    assert "current_model_state" in saved
+    assert saved["averaging_state"]["n_averaged"].item() == steps
+    assert saved["callbacks"]["EMAWeightAveraging"]["latest_update_step"] == steps
+    assert not torch.equal(saved["state_dict"]["layer.weight"], saved["current_model_state"]["layer.weight"])
+
+    # Resuming at the step the checkpoint stopped at restores state, then exits immediately.
+    resumed_callback = EMAWeightAveraging(decay=0.9)
+    resumed_model = BoringModel()
+    _ema_trainer(tmp_path, steps, [resumed_callback]).fit(resumed_model, ckpt_path=str(tmp_path / "last.ckpt"))
+
+    assert resumed_callback._latest_update_step == steps, "EMA schedule restarted instead of resuming"
+    assert resumed_callback._average_model.n_averaged.item() == steps
+    assert torch.equal(resumed_callback._average_model.module.layer.weight, saved["state_dict"]["layer.weight"])
+    # Training continues from the raw weights, not from the averaged ones.
+    assert torch.equal(resumed_model.layer.weight, saved["current_model_state"]["layer.weight"])

--- a/training/tests/unit/diagnostics/test_checkpoint.py
+++ b/training/tests/unit/diagnostics/test_checkpoint.py
@@ -24,6 +24,7 @@ from torch import nn
 from anemoi.models.data_indices.collection import IndexCollection
 from anemoi.models.preprocessing.imputer import ConstantImputer
 from anemoi.training.diagnostics.callbacks import AnemoiCheckpoint
+from anemoi.training.diagnostics.callbacks.weight_averaging import EMAWeightAveraging
 from anemoi.training.utils.checkpoint import save_inference_checkpoint
 from anemoi.training.utils.jsonify import map_config_to_primitives
 from anemoi.utils.checkpoints import load_metadata
@@ -242,3 +243,52 @@ def test_inference_checkpoint_excludes_imputer_runtime_state(tmp_path: str, conf
     assert saved_model.imputer.loss_mask_training is None
     assert model.imputer.nan_locations is None
     assert model.imputer.loss_mask_training is None
+
+
+class TrainedDummyModule(DummyModule):
+    """DummyModule whose optimizer actually moves the inner model's weights.
+
+    ``BoringModel`` only trains ``self.layer``, which would leave the inner model untouched and
+    make the averaged and raw weights identical.
+    """
+
+    def training_step(self, batch: torch.Tensor, batch_idx: int) -> torch.Tensor:
+        del batch_idx
+        return self.model(batch).abs().mean()
+
+    def configure_optimizers(self) -> torch.optim.Optimizer:
+        return torch.optim.SGD(self.model.parameters(), lr=0.1)
+
+
+def test_inference_checkpoint_holds_averaged_weights(tmp_path: str, metadata: dict, config: DictConfig) -> None:
+    """With weight averaging on, the inference checkpoint must carry the averaged weights.
+
+    The lightning checkpoint keeps both: the averaged weights in "state_dict" and the raw training
+    weights in "current_model_state". The inference checkpoint is written from the live model, which
+    holds the raw weights, so it needs the swap to agree with the averaged ones.
+    """
+    dirpath = Path(tmp_path) / "averaged_inference"
+    steps = 4
+    callback = AnemoiCheckpoint(dirpath=str(dirpath), filename="{step}", save_last=True, every_n_train_steps=steps)
+
+    trainer = Trainer(
+        default_root_dir=str(dirpath),
+        accelerator="cpu",
+        callbacks=[EMAWeightAveraging(decay=0.9), callback],
+        max_steps=steps,
+        limit_train_batches=2,
+        limit_val_batches=0,
+        num_sanity_val_steps=0,
+        logger=False,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+    )
+    trainer.fit(TrainedDummyModule(config=config, metadata=metadata))
+
+    saved = torch.load(dirpath / "last.ckpt", weights_only=False)
+    averaged = saved["state_dict"]["model.fc1.weight"]
+    raw = saved["current_model_state"]["model.fc1.weight"]
+    assert not torch.equal(averaged, raw), "Test is vacuous unless training moved the weights."
+
+    inference_model = torch.load(dirpath / "inference-last.ckpt", weights_only=False)
+    assert torch.equal(inference_model.fc1.weight, averaged), "Inference checkpoint holds the raw weights."

--- a/training/tests/unit/train/test_checkpoint_loading.py
+++ b/training/tests/unit/train/test_checkpoint_loading.py
@@ -20,6 +20,7 @@ from torch_geometric.data import HeteroData
 from anemoi.models.layers.graph_provider import StaticGraphProvider
 from anemoi.models.preprocessing import Processors
 from anemoi.models.preprocessing import StepwiseProcessors
+from anemoi.training.diagnostics.callbacks.weight_averaging import EMAWeightAveraging
 from anemoi.training.tasks.forecaster import Forecaster
 from anemoi.training.train.methods.base import BaseTrainingModule
 from anemoi.training.train.train import AnemoiTrainer
@@ -184,6 +185,66 @@ def test_on_load_checkpoint_keeps_checkpoint_processors_when_disabled() -> None:
             ),
         ):
             assert torch.equal(state_dict[full_key], value)
+
+
+def _weight_averaged_checkpoint(state_dict: dict) -> dict:
+    """Checkpoint as written by a weight-averaging callback.
+
+    ``state_dict`` holds the averaged weights and ``current_model_state`` the raw training weights,
+    which the callback restores into the model after ``on_load_checkpoint`` has run.
+    """
+    return {
+        "state_dict": dict(state_dict),
+        "current_model_state": dict(state_dict),
+        "averaging_state": {"n_averaged": torch.tensor(3)},
+        "hyper_parameters": {"data_indices": {"data": DummyIndex()}},
+    }
+
+
+def test_on_load_checkpoint_updates_processors_in_weight_averaged_current_model_state() -> None:
+    """The processor refresh must reach the training weights, not just the averaged ones."""
+    old_model = DummyModel(["6h", "12h", "18h"], offset=10.0)
+    new_model = DummyModel(["6h", "12h"], offset=1.0)
+
+    checkpoint = _weight_averaged_checkpoint(
+        {f"model.{key}": value.clone() for key, value in old_model.state_dict().items()},
+    )
+    module = _make_dummy_module(new_model, update_states=False, update_tendencies=True)
+
+    BaseTrainingModule.on_load_checkpoint(module, checkpoint)
+
+    new_state = new_model.state_dict()
+    for state_key in ("state_dict", "current_model_state"):
+        state_dict = checkpoint[state_key]
+        assert not any(
+            "18h" in key for key in state_dict if key.startswith("model.pre_processors_tendencies.")
+        ), f"Extra tendency processors should be dropped from {state_key}."
+        for key, value in new_state.items():
+            full_key = f"model.{key}"
+            if full_key.startswith(("model.pre_processors_tendencies.", "model.post_processors_tendencies.")):
+                assert torch.equal(state_dict[full_key], value), f"{full_key} not refreshed in {state_key}"
+
+
+def test_on_load_checkpoint_warns_when_averaged_weights_are_dropped(caplog: pytest.LogCaptureFixture) -> None:
+    """Resuming a weight-averaged checkpoint without the callback silently uses the averaged weights."""
+    model = DummyModel(["6h"], offset=1.0)
+    checkpoint = _weight_averaged_checkpoint(
+        {f"model.{key}": value.clone() for key, value in model.state_dict().items()},
+    )
+    module = _make_dummy_module(model, update_states=False, update_tendencies=False)
+    module._trainer = SimpleNamespace(callbacks=[], datamodule=None)
+
+    with caplog.at_level(logging.WARNING):
+        BaseTrainingModule.on_load_checkpoint(module, checkpoint)
+
+    assert "weight averaging" in caplog.text
+
+    caplog.clear()
+    module._trainer = SimpleNamespace(callbacks=[EMAWeightAveraging()], datamodule=None)
+    with caplog.at_level(logging.WARNING):
+        BaseTrainingModule.on_load_checkpoint(module, checkpoint)
+
+    assert "weight averaging" not in caplog.text
 
 
 def test_transfer_learning_loading_updates_processors_when_enabled(


### PR DESCRIPTION
## Description
Fixes how EMA / weight averaging is handled when a run is resumed with `training.run_id`.

When a weight-averaging callback is active, PyTorch Lightning > 2.6 stores the averaged weights in `checkpoint["state_dict"]` and the raw training weights beside them in `checkpoint["current_model_state"]`. On resume, PL restores `state_dict` into the module first, then the callback overwrites the live module from `current_model_state`. This introduced three inconsistencies with weight averaging.

## What problem does this change solve?


1. Checkpoint migrations were applied to the wrong copy of the weights.
`BaseTrainingModule.on_load_checkpoint` mutated only `checkpoint["state_dict"]`, and the LightningModule hook runs before callbacks. So `update_ds_stats_on_ckpt_load` and the trainable-edge permutation migration landed on the EMA copy, and the live model was then overwritten from the unmigrated `current_model_state`. On a `run_id` resume with EMA this meant `update_ds_stats_on_ckpt_load` silently did nothing to the training weights, the edge migration was silently skipped, and the two model copies diverged and were mixed at every EMA update. Both copies are now migrated.

2. `update_every_n_steps / update_starting_at_step / update_starting_at_epoch` were dead config.
Anemoi's EMAWeightAveraging/SWAWeightAveraging stored them but never overrode `should_update`, so the PL base default (update every step) always won — regardless of what you configured. The schedule now lives once on the anemoi WeightAveraging base with the same semantics as PL's own implementation.

3. Inference checkpoints carried instantaneous model weights, not averaged ones.
`AnemoiCheckpoint._save_checkpoint` writes the inference checkpoint from the live module, and the validation swap is already undone by `on_validation_epoch_end` before `on_validation_end` fires. `inference-*.ckpt` therefore disagreed with both the logged validation metrics and `last.ckpt["state_dict"]`, which are averaged. The `torch.save` is now wrapped in a new `averaged_weights(trainer)` context manager.

4. Raise warning when weight averaging is dropped. 
Dropping `training.weight_averaging` from the config when resuming silently started the model from the averaged weights and discarded the averaging state — now warned about. 

## What issue or task does this change relate to?

## Additional notes

- [ ] Discuss that  `inference-*.ckpt` now contains the averaged weights when weight averaging is enabled. This makes it consistent with the validation metrics and with `last.ckpt["state_dict"]`, but it does change what existing pipelines get out of the inference checkpoint of an EMA run.
- [x] Added tests
- [ ] Run training runs

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)
