### PR TITLE
feat(graphs): HEALPix Node Ordering Schema Option and kwarg

### DIFF
--- a/graphs/src/anemoi/graphs/nodes/builders/from_healpix.py
+++ b/graphs/src/anemoi/graphs/nodes/builders/from_healpix.py
@@ -29,6 +29,9 @@ class HEALPixNodes(BaseNodeBuilder):
     ----------
     resolution : int
         The resolution of the grid.
+    nest_ordering : bool, optional
+        If true, assume NEST pixel ordering, else RING ordering
+        See: https://healpy.readthedocs.io/en/latest/generated/healpy.pixelfunc.ang2pix.html
 
     Methods
     -------
@@ -42,9 +45,10 @@ class HEALPixNodes(BaseNodeBuilder):
         Update the graph with new nodes and attributes.
     """
 
-    def __init__(self, resolution: int, name: str) -> None:
+    def __init__(self, resolution: int, name: str, nest_ordering: bool = True) -> None:
         """Initialize the HEALPixNodes builder."""
         self.resolution = resolution
+        self.nest_ordering = nest_ordering
         super().__init__(name)
         self.hidden_attributes = BaseNodeBuilder.hidden_attributes | {"resolution"}
 
@@ -65,7 +69,7 @@ class HEALPixNodes(BaseNodeBuilder):
         LOGGER.info(f"Creating HEALPix nodes with resolution {spatial_res_degrees:.2} deg.")
 
         npix = hp.nside2npix(2**self.resolution)
-        hpxlon, hpxlat = hp.pix2ang(2**self.resolution, range(npix), nest=True, lonlat=True)
+        hpxlon, hpxlat = hp.pix2ang(2**self.resolution, range(npix), nest=self.nest_ordering, lonlat=True)
 
         return self.reshape_coords(hpxlat, hpxlon)
 

--- a/graphs/src/anemoi/graphs/schemas/node_schemas.py
+++ b/graphs/src/anemoi/graphs/schemas/node_schemas.py
@@ -113,9 +113,7 @@ class IcosahedralandHealPixNodeSchema(BaseModel):
 
 
 class HealPixNodeSchema(IcosahedralandHealPixNodeSchema):
-    target_: Literal[
-        "anemoi.graphs.nodes.HEALPixNodes",
-    ] = Field(..., alias="_target_")
+    target_: Literal["anemoi.graphs.nodes.HEALPixNodes",] = Field(..., alias="_target_")
     "HEALPix nodes class implementation from anemoi.graphs.nodes."
     nest_ordering: bool = True
     "Whether to use HEALPix NESTED pixel ordering. If False, RING ordering is used, which is isolatitude and sorted north to south. Defaults to True."

--- a/graphs/src/anemoi/graphs/schemas/node_schemas.py
+++ b/graphs/src/anemoi/graphs/schemas/node_schemas.py
@@ -106,11 +106,19 @@ class IcosahedralandHealPixNodeSchema(BaseModel):
     target_: Literal[
         "anemoi.graphs.nodes.TriNodes",
         "anemoi.graphs.nodes.HexNodes",
-        "anemoi.graphs.nodes.HEALPixNodes",
     ] = Field(..., alias="_target_")
-    "Icohedral and HEAL Pix nodes class implementations from anemoi.graphs.nodes."
+    "Icosahedral nodes class implementations from anemoi.graphs.nodes."
     resolution: PositiveInt
     "Refinement level of the mesh."
+
+
+class HealPixNodeSchema(IcosahedralandHealPixNodeSchema):
+    target_: Literal[
+        "anemoi.graphs.nodes.HEALPixNodes",
+    ] = Field(..., alias="_target_")
+    "HEALPix nodes class implementation from anemoi.graphs.nodes."
+    nest_ordering: bool = True
+    "Whether to use HEALPix NESTED pixel ordering. If False, RING ordering is used, which is isolatitude and sorted north to south. Defaults to True."
 
 
 class LimitedAreaIcosahedralandHealPixNodeSchema(BaseModel):
@@ -153,6 +161,7 @@ NodeBuilderSchemas = Annotated[
     | LimitedAreaNPZFileNodesSchema
     | ReducedGaussianGridNodeSchema
     | IcosahedralandHealPixNodeSchema
+    | HealPixNodeSchema
     | LimitedAreaIcosahedralandHealPixNodeSchema
     | StretchedIcosahdralNodeSchema,
     Field(discriminator="target_"),

--- a/graphs/tests/nodes/test_healpix.py
+++ b/graphs/tests/nodes/test_healpix.py
@@ -46,6 +46,27 @@ def test_register_nodes(resolution: int):
     assert graph["test_nodes"].node_type == "HEALPixNodes"
 
 
+@pytest.mark.parametrize("resolution", [2, 5])
+def test_nest_ordering(resolution: int):
+    """nest_ordering selects NEST vs RING pixel ordering; defaults to NEST."""
+    nest = HEALPixNodes(resolution, "test_nodes", nest_ordering=True).get_coordinates()
+    ring = HEALPixNodes(resolution, "test_nodes", nest_ordering=False).get_coordinates()
+    default = HEALPixNodes(resolution, "test_nodes").get_coordinates()
+
+    # default is NEST, backward-compatible with the previously hardcoded nest=True
+    assert torch.equal(default, nest)
+
+    # same set of pixel centres, different row order
+    assert not torch.equal(nest, ring)
+    nest_sorted = nest[nest[:, 0].argsort(stable=True)].sort(dim=0).values
+    ring_sorted = ring[ring[:, 0].argsort(stable=True)].sort(dim=0).values
+    assert torch.allclose(nest_sorted, ring_sorted)
+
+    # RING ordering is isolatitude, sorted north -> south
+    assert torch.all(torch.diff(ring[:, 0]) <= 1e-9)
+    assert not torch.all(torch.diff(nest[:, 0]) <= 1e-9)
+
+
 @pytest.mark.parametrize("attr_class", [UniformWeights, SphericalAreaWeights])
 @pytest.mark.parametrize("resolution", [2, 5, 7])
 def test_register_attributes(graph_with_nodes: HeteroData, attr_class, resolution: int):


### PR DESCRIPTION
## Description

Addresses #1380 by providing a boolean `nest_ordering` option in graph node builder initialization, and propagates the option to the user via the graph schema.

## What problem does this change solve?

There was no bug, but addresses potentially unexpected behavior described in #1380 

## What issue or task does this change relate to?

#1380 

##  Additional notes ##

I didn't see any tests for the schema, but added a unit test for healpix node ordering. I'm happy to add, subtract, or modify as desired, just let me know if you'd like something different.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)
