### PR TITLE
fix(training): benchmark tests run again

### DIFF
--- a/.github/workflows/integration-tests-hpc.yml
+++ b/.github/workflows/integration-tests-hpc.yml
@@ -79,7 +79,7 @@ jobs:
     if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.tests == 'all' || github.event.inputs.tests == 'test_benchmark' }}
     uses: ./.github/workflows/run-integration-test-hpc.yml
     with:
-      pytest_cmd: srun python -m pytest -v training/tests/integration/test_benchmark.py --slow --multigpu
+      pytest_cmd: srun python -m pytest -o tmp_path_retention_policy=all -v training/tests/integration/test_benchmark.py --slow --multigpu
       timeout_minutes: 360
       sbatch_options: |
         #SBATCH --job-name=anemoi_core_benchmark_pytest

--- a/training/docs/user-guide/benchmarking.rst
+++ b/training/docs/user-guide/benchmarking.rst
@@ -850,7 +850,7 @@ The benchmarking tests can also be run locally.
 
    cd anemoi-core
    pip install -e training[tests]
-   pytest -s -vvv -v training/tests/integration/ --slow --multigpu -k "test_benchmark_training_cycle"
+   pytest -o tmp_path_retention_policy=all -s -vvv -v training/tests/integration/ --slow --multigpu -k "test_benchmark_training_cycle"
 
 The server location is read from a file
 "~/.config/anemoi/anemoi-benchmark.yaml". The expected format is

--- a/training/pytest.ini
+++ b/training/pytest.ini
@@ -11,7 +11,7 @@ markers =
     asyncio: marks tests as async tests
 
 
-tmp_path_retention_policy = all
+tmp_path_retention_policy = none
 log_cli = true
 log_cli_level = INFO
 log_cli_format = %(asctime)s %(levelname)s %(message)s

--- a/training/pytest.ini
+++ b/training/pytest.ini
@@ -1,5 +1,4 @@
 [pytest]
-tmp_path_retention_policy = all
 asyncio_mode = auto
 asyncio_default_fixture_loop_scope = function
 markers =
@@ -12,7 +11,7 @@ markers =
     asyncio: marks tests as async tests
 
 
-tmp_path_retention_policy = none
+tmp_path_retention_policy = all
 log_cli = true
 log_cli_level = INFO
 log_cli_format = %(asctime)s %(levelname)s %(message)s

--- a/training/pytest.ini
+++ b/training/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
+tmp_path_retention_policy = all
 asyncio_mode = auto
 asyncio_default_fixture_loop_scope = function
 markers =

--- a/training/tests/integration/config/benchmark/base.yaml
+++ b/training/tests/integration/config/benchmark/base.yaml
@@ -31,6 +31,7 @@ model:
         num_chunks: 2
   processor:
     num_chunks: 2
+    num_layers: 2
   num_channels: 512
 
 training:

--- a/training/tests/integration/test_benchmark.py
+++ b/training/tests/integration/test_benchmark.py
@@ -139,6 +139,7 @@ def test_benchmark_training_cycle(
 ) -> None:
     """Runs a benchmark and then compares them against the values stored on a server."""
     cfg, test_case = benchmark_config
+    dist.barrier()
     LOGGER.info("Benchmarking the configuration: %s", test_case)
 
     # Reset memory logging and free all possible memory between runs
@@ -153,11 +154,14 @@ def test_benchmark_training_cycle(
     # determine store from benchmark config (per-kind, so benchmark artefacts
     # land under the 'benchmarks' subdirectory on the server)
     store = get_benchmark_store("benchmarks")
-
-    benchmark(cfg, test_case, store)
-
-    # barrier to ensure all processes have completed before finishing the test
-    # otherwise process 0 will finish the final test before process 0
-    # has finished comparing the results against the benchmark server
-    # torch.dist is initialized in the benchmark function, so we can use it here
-    dist.barrier()
+    
+    # use try...finally so that both processes reach barrier
+    # even if proc 0 raises at failed benchmark comparison
+    try:
+        benchmark(cfg, test_case, store)
+    finally:
+        # barrier to ensure all processes have completed before finishing the test
+        # otherwise process 0 will finish the final test before process 0
+        # has finished comparing the results against the benchmark server
+        # torch.dist is initialized in the benchmark function, so we can use it here
+        dist.barrier()

--- a/training/tests/integration/test_benchmark.py
+++ b/training/tests/integration/test_benchmark.py
@@ -15,7 +15,6 @@ import time
 
 import psutil
 import pytest
-import torch.distributed as dist
 from hydra.utils import instantiate
 from omegaconf import DictConfig
 from torch.cuda import empty_cache
@@ -153,5 +152,5 @@ def test_benchmark_training_cycle(
     # determine store from benchmark config (per-kind, so benchmark artefacts
     # land under the 'benchmarks' subdirectory on the server)
     store = get_benchmark_store("benchmarks")
-    
+
     benchmark(cfg, test_case, store)

--- a/training/tests/integration/test_benchmark.py
+++ b/training/tests/integration/test_benchmark.py
@@ -139,7 +139,6 @@ def test_benchmark_training_cycle(
 ) -> None:
     """Runs a benchmark and then compares them against the values stored on a server."""
     cfg, test_case = benchmark_config
-    dist.barrier()
     LOGGER.info("Benchmarking the configuration: %s", test_case)
 
     # Reset memory logging and free all possible memory between runs
@@ -155,13 +154,4 @@ def test_benchmark_training_cycle(
     # land under the 'benchmarks' subdirectory on the server)
     store = get_benchmark_store("benchmarks")
     
-    # use try...finally so that both processes reach barrier
-    # even if proc 0 raises at failed benchmark comparison
-    try:
-        benchmark(cfg, test_case, store)
-    finally:
-        # barrier to ensure all processes have completed before finishing the test
-        # otherwise process 0 will finish the final test before process 0
-        # has finished comparing the results against the benchmark server
-        # torch.dist is initialized in the benchmark function, so we can use it here
-        dist.barrier()
+    benchmark(cfg, test_case, store)


### PR DESCRIPTION
## Description
benchmark tests pass again.

<img width="674" height="477" alt="Screenshot 2026-09-10 at 16 33 05" src="https://github.com/user-attachments/assets/bc27080c-da6e-4566-b0df-32f78cea778c" />

I have two passing tests [here](https://github.com/ecmwf/anemoi-core/actions/runs/34484988453) and [here](https://github.com/ecmwf/anemoi-core/actions/runs/34485018706)

The problem was related to running distributed pytests, one would clean up the others tmpdir and the other process would fail then when it went to cleanup and there was nothing there. I fixed this by changing the retention policy to 'keep all tests'. this is safe, since the TMPDIRs are cleaned by slurm at the end of the job anyway.

A previous hack fix by me was to add a distributed barrier at the end of a test, to sync the processes right before cleanup. this resulted in a further issue: when the first test (LAM) failed the performance check, process 0 would raise an error and not join the barrier at the end of the LAM test. Process 1 would wait dutifully in the barrier at the end of LAM test, and process 0 would proceed to the next test (graph transformer) and timeout during model initialisation after 30 mins.

lastly, this PR changes the number of layers in the processor for the benchmark tests back to 2, after a recent cleanup PR inadvertently changed there number of layers to 16

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)


<!-- readthedocs-preview anemoi-training start -->
----
📚 Documentation preview 📚: https://anemoi-training--1382.org.readthedocs.build/en/1382/

<!-- readthedocs-preview anemoi-training end -->

<!-- readthedocs-preview anemoi-graphs start -->
----
📚 Documentation preview 📚: https://anemoi-graphs--1382.org.readthedocs.build/en/1382/

<!-- readthedocs-preview anemoi-graphs end -->

<!-- readthedocs-preview anemoi-models start -->
----
📚 Documentation preview 📚: https://anemoi-models--1382.org.readthedocs.build/en/1382/

<!-- readthedocs-preview anemoi-models end -->