### PR TITLE
fix: torch2.6 compatibility

### DIFF
--- a/graphs/tests/nodes/attributes/test_weights.py
+++ b/graphs/tests/nodes/attributes/test_weights.py
@@ -144,10 +144,10 @@ def test_masked_planar_area_weights_subset():
 
     weights = MaskedPlanarAreaWeights(mask_node_attr_name="patch").compute(graph, "test_nodes")
     assert torch.all(weights[~mask] == 0)
-    np.testing.assert_allclose(weights[mask].numpy(), weights[mask].max().item(), rtol=1e-6)
+    np.testing.assert_allclose(weights[mask].cpu().numpy(), weights[mask].max().item(), rtol=1e-6)
 
     halved = MaskedPlanarAreaWeights(mask_node_attr_name="patch_half").compute(graph, "test_nodes")
-    np.testing.assert_allclose(halved.numpy(), 0.5 * weights.numpy(), rtol=1e-6)
+    np.testing.assert_allclose(halved.cpu().numpy(), 0.5 * weights.cpu().numpy(), rtol=1e-6)
 
 
 def test_voronoi_region_areas_matches_convexhull():

--- a/models/src/anemoi/models/distributed/primitives.py
+++ b/models/src/anemoi/models/distributed/primitives.py
@@ -8,7 +8,8 @@
 # nor does it submit to any jurisdiction.
 
 
-from typing import List, Optional
+from typing import List
+from typing import Optional
 
 import torch
 import torch.distributed as dist

--- a/models/src/anemoi/models/distributed/primitives.py
+++ b/models/src/anemoi/models/distributed/primitives.py
@@ -8,7 +8,7 @@
 # nor does it submit to any jurisdiction.
 
 
-from typing import Optional
+from typing import List, Optional
 
 import torch
 import torch.distributed as dist
@@ -304,11 +304,11 @@ def _alltoallwrapper(output_list: list, input_list: list, group: ProcessGroup):
 
 @torch.library.custom_op("anemoi_distributed::alltoall", mutates_args=())
 def _alltoall_op(
-    input_list: list[Tensor],
-    output_shapes_flat: list[int],
+    input_list: List[Tensor],
+    output_shapes_flat: List[int],
     ndim: int,
     group_name: str,
-) -> list[Tensor]:
+) -> List[Tensor]:
     """torch.compile-traceable wrapper around the list-based ``dist.all_to_all``.
 
     torch.compile() cannot trace ``dist.all_to_all`` with list inputs.


### PR DESCRIPTION
## Description
Resolves the incompatibility with torch < 2.7 noted in #1326 and restores GPU-compatibility of a graphs test.

## What problem does this change solve?
bugfix

## What issue or task does this change relate to?
closes #1326 

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)
