### PR TITLE
perf(training): fake dataloading

### DIFF
--- a/training/docs/user-guide/performance-optimisation.rst
+++ b/training/docs/user-guide/performance-optimisation.rst
@@ -237,6 +237,17 @@ cannot load input data fast enough to keep up with your GPU. This
 results in your GPU stalling at the start of an iteration while it waits
 for the CPU to provide the next input batch.
 
+To determine whether a configuration is dataloader-bound, run the same
+configurationwith ``dataloader.fake_dataloading=True``. This loads the
+first real sample and reuses it for subsequent batches, preserving valid
+shapes and numerical values while removing repeated dataset reads.
+A significant increase in throughput indicates that dataloading is the
+bottleneck. Possible fixes are to increase the number of workers when
+sufficient CPU memory is available, move the dataset to a faster or
+less congested filesystem, or rechunk the dataset along the grid
+dimension to better match the access pattern (if gpus_per_model is
+greater than 1).
+
 By default, each GPU will spawn 8 workers. Each worker will load data in
 parallel. You should try to increase this number until you run out of
 CPU memory. A CPU out of memory error looks like:

--- a/training/docs/user-guide/performance-optimisation.rst
+++ b/training/docs/user-guide/performance-optimisation.rst
@@ -238,7 +238,7 @@ results in your GPU stalling at the start of an iteration while it waits
 for the CPU to provide the next input batch.
 
 To determine whether a configuration is dataloader-bound, run the same
-configurationwith ``dataloader.fake_dataloading=True``. This loads the
+configuration with ``dataloader.fake_dataloading=True``. This loads the
 first real sample and reuses it for subsequent batches, preserving valid
 shapes and numerical values while removing repeated dataset reads.
 A significant increase in throughput indicates that dataloading is the

--- a/training/src/anemoi/training/config/dataloader/multi.yaml
+++ b/training/src/anemoi/training/config/dataloader/multi.yaml
@@ -2,6 +2,7 @@ prefetch_factor: 2
 pin_memory: True
 # Automatically set to False when the rollout changes between epochs.
 persistent_workers: True
+fake_dataloading: False
 
 # ============
 # read_group_size:

--- a/training/src/anemoi/training/config/dataloader/native_grid.yaml
+++ b/training/src/anemoi/training/config/dataloader/native_grid.yaml
@@ -2,6 +2,7 @@ prefetch_factor: 2
 pin_memory: True
 # Automatically set to False when the rollout changes between epochs.
 persistent_workers: True
+fake_dataloading: False
 
 # ============
 # read_group_size:

--- a/training/src/anemoi/training/data/datamodule.py
+++ b/training/src/anemoi/training/data/datamodule.py
@@ -139,6 +139,7 @@ class AnemoiDatasetsDataModule(pl.LightningDataModule):
             label=label,
             epoch=self.epoch,
             rollout=len(tuple(self.task.steps(label))),
+            fake_dataloading=self.config.dataloader.fake_dataloading,
         )
 
     def set_epoch(self, epoch: int) -> None:

--- a/training/src/anemoi/training/data/datamodule.py
+++ b/training/src/anemoi/training/data/datamodule.py
@@ -131,6 +131,10 @@ class AnemoiDatasetsDataModule(pl.LightningDataModule):
     ) -> MultiDataset:
         data_readers = {name: create_dataset(data_reader, task=self.task) for name, data_reader in config.items()}
         relative_date_indices = compute_relative_date_indices(self.task, data_readers, mode=label)
+        dataset_options = {}
+        dataloader_config = getattr(getattr(self, "config", None), "dataloader", {})
+        if dataloader_config.get("fake_dataloading", False):
+            dataset_options["fake_dataloading"] = True
 
         return MultiDataset(
             data_readers=data_readers,
@@ -139,7 +143,7 @@ class AnemoiDatasetsDataModule(pl.LightningDataModule):
             label=label,
             epoch=self.epoch,
             rollout=len(tuple(self.task.steps(label))),
-            fake_dataloading=self.config.dataloader.fake_dataloading,
+            **dataset_options,
         )
 
     def set_epoch(self, epoch: int) -> None:

--- a/training/src/anemoi/training/data/multidataset.py
+++ b/training/src/anemoi/training/data/multidataset.py
@@ -46,6 +46,7 @@ class MultiDataset(IterableDataset):
         label: str = "multi",
         epoch: int = 0,
         rollout: int = 1,
+        fake_dataloading: bool = False,
     ) -> None:
         """Initialize multi-dataset with synchronized data readers.
 
@@ -64,6 +65,8 @@ class MultiDataset(IterableDataset):
             Epoch used for deterministic epoch-dependent shuffling, by default 0
         rollout : int, optional
             Rollout length represented by the loaded relative date indices, by default 1
+        fake_dataloading : bool, optional
+            Load one real sample and reuse it for subsequent accesses, by default False
         """
         self.data_readers = data_readers
         self.label = label
@@ -71,6 +74,7 @@ class MultiDataset(IterableDataset):
         self.dataset_names = list(data_readers.keys())
         self.epoch = epoch
         self.rollout = rollout
+        self.fake_dataloading = fake_dataloading
 
         # Guard against mixing single-sequence (NativeGridDataset, global time axis)
         # with multi-sequence (TrajectoryDataset, init x step axes).  The anchor
@@ -396,9 +400,17 @@ class MultiDataset(IterableDataset):
             shuffled_chunk_indices[:10],
         )
 
+        initial_batch = None
+
         # TODO(): improve this...
         for i in shuffled_chunk_indices:
-            yield self.get_sample(i)
+            if not self.fake_dataloading:
+                yield self.get_sample(i)
+            elif initial_batch is None:
+                initial_batch = self.get_sample(i)
+                yield initial_batch
+            else:
+                yield initial_batch
 
     def __repr__(self) -> str:
         console = Console(record=True, width=120)

--- a/training/src/anemoi/training/data/multidataset.py
+++ b/training/src/anemoi/training/data/multidataset.py
@@ -75,6 +75,8 @@ class MultiDataset(IterableDataset):
         self.epoch = epoch
         self.rollout = rollout
         self.fake_dataloading = fake_dataloading
+        if self.fake_dataloading:
+            LOGGER.info("Using fake dataloading")
 
         # Guard against mixing single-sequence (NativeGridDataset, global time axis)
         # with multi-sequence (TrajectoryDataset, init x step axes).  The anchor

--- a/training/src/anemoi/training/schemas/dataloader.py
+++ b/training/src/anemoi/training/schemas/dataloader.py
@@ -132,6 +132,8 @@ class DataLoaderSchema(PydanticBaseModel):
     "If True, the data loader will copy Tensors into device/CUDA pinned memory before returning them."
     persistent_workers: bool = Field(default=True)
     "Keep dataloader workers alive between epochs. Automatically disabled when the rollout changes between epochs."
+    fake_dataloading: bool = Field(default=False)
+    "Load one real sample per worker and reuse it for subsequent accesses."
     num_workers: LoaderSet
     "Number of process per-GPU for batch distribution."
     batch_size: LoaderSet

--- a/training/tests/unit/data/test_multidataset.py
+++ b/training/tests/unit/data/test_multidataset.py
@@ -12,6 +12,7 @@ import re
 
 import numpy as np
 import pytest
+import torch
 from pytest_mock import MockFixture
 
 from anemoi.training.data.multidataset import MultiDataset
@@ -113,6 +114,27 @@ class TestMultiDataset:
         resumed_order = list(multi_dataset)
 
         assert resumed_order == uninterrupted_order
+
+    def test_fake_dataloading_reuses_first_batch(
+        self,
+        multi_dataset: MultiDataset,
+        mocker: MockFixture,
+    ) -> None:
+        """Fake dataloading reads one valid batch and reuses its tensors."""
+        multi_dataset.fake_dataloading = True
+        get_sample = mocker.patch.object(
+            multi_dataset,
+            "get_sample",
+            side_effect=lambda index: {"dataset_a": torch.tensor([index], dtype=torch.int64)},
+        )
+        multi_dataset.per_worker_init(n_workers=1, worker_id=0)
+
+        batches = list(multi_dataset)
+
+        assert get_sample.call_count == 1
+        assert len(batches) == len(multi_dataset.valid_date_indices)
+        assert all(batch is batches[0] for batch in batches)
+        assert all(torch.equal(batch["dataset_a"], batches[0]["dataset_a"]) for batch in batches)
 
     def test_valid_date_indices_empty_dataset(self, multi_dataset: MultiDataset) -> None:
         """Test that MultiDataset raises ValueError when a dataset has no valid anchors."""


### PR DESCRIPTION
## Description
This PR adds a new config entry `dataloader.fake_dataloading`. When this is changed to True, the dataloading is faked by loading the initial batch and serving that from CPU memory for subsequent iterations.

This feature can be used to easily determine if you are dataloader bound. 
for example, I ran two runs on a single GH200 N320 global model 1 dataloader worker per GPU for 200 iterations. Without fake dataloading I got 1.00it/s and with fake dataloading I got 1.75it/s, showing that this configuration is dataloader bound

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)


<!-- readthedocs-preview anemoi-training start -->
----
📚 Documentation preview 📚: https://anemoi-training--1387.org.readthedocs.build/en/1387/

<!-- readthedocs-preview anemoi-training end -->

<!-- readthedocs-preview anemoi-graphs start -->
----
📚 Documentation preview 📚: https://anemoi-graphs--1387.org.readthedocs.build/en/1387/

<!-- readthedocs-preview anemoi-graphs end -->

<!-- readthedocs-preview anemoi-models start -->
----
📚 Documentation preview 📚: https://anemoi-models--1387.org.readthedocs.build/en/1387/

<!-- readthedocs-preview anemoi-models end -->