### PR TITLE
docs(training): expand Data-Distributed section with multi-GPU usage

### DIFF
--- a/training/docs/user-guide/distributed.rst
+++ b/training/docs/user-guide/distributed.rst
@@ -16,7 +16,7 @@ These can either be used individually or both at the same time.
 
 Data-parallel training (DDP) is the default and most common way to
 scale Anemoi Training across multiple GPUs. Each GPU holds a *full
-replica* of the model and processes a distinct shard of every mini-batch
+replica* of the model and processes a distinct subset of every batch
 in parallel. After the backward pass the gradients are averaged across
 all replicas with a collective ``all-reduce`` before the optimiser step,
 so every replica stays in sync.

--- a/training/docs/user-guide/distributed.rst
+++ b/training/docs/user-guide/distributed.rst
@@ -14,12 +14,175 @@ These can either be used individually or both at the same time.
  Data-Distributed
 ******************
 
-This is used automatically if the ``number of parallel data GPUs = number
-of GPUs available/number of GPUs per model`` is an integer greater than
-1. In this case the batches will be split across the number of parallel
-data GPUs meaning that the effective batch size of each training step
-will be the number of batches set in the dataloader config file
-multiplied by the number of parallel data GPUs.
+Data-parallel training (DDP) is the default and most common way to
+scale Anemoi Training across multiple GPUs. Each GPU holds a *full
+replica* of the model and processes a distinct shard of every mini-batch
+in parallel. After the backward pass the gradients are averaged across
+all replicas with a collective ``all-reduce`` before the optimiser step,
+so every replica stays in sync.
+
+Data parallelism is enabled automatically whenever the number of
+data-parallel replicas
+
+.. math::
+
+   N_{\text{data}} = \frac{\texttt{num\_nodes} \times \texttt{num\_gpus\_per\_node}}{\texttt{num\_gpus\_per\_model}}
+
+is greater than 1. With the default ``num_gpus_per_model=1`` this simply
+means "one replica per GPU". Combining data parallelism with model
+sharding is supported — see :ref:`Model Sharding <model-sharding>` below.
+
+How to run on multiple GPUs
+===========================
+
+The relevant knobs live under ``config.system.hardware`` and
+``config.dataloader.batch_size``:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 15 55
+
+   * - Config key
+     - Default
+     - Meaning
+   * - ``system.hardware.num_gpus_per_node``
+     - ``1``
+     - GPUs used on each node.
+   * - ``system.hardware.num_nodes``
+     - ``1``
+     - Number of nodes participating in the job.
+   * - ``system.hardware.num_gpus_per_model``
+     - ``1``
+     - GPUs a single model replica is sharded across. Keep at ``1``
+       for pure data parallelism.
+   * - ``dataloader.batch_size.training``
+     - ``2``
+     - Per-replica (per-GPU when ``num_gpus_per_model=1``) batch size.
+
+The **effective (global) batch size** used per optimiser step is:
+
+.. math::
+
+   B_{\text{eff}} = \texttt{batch\_size.training} \times N_{\text{data}}
+
+Single node with multiple GPUs
+------------------------------
+
+To use all 4 GPUs on a single workstation and keep an effective batch
+size of 16, override the hardware and batch-size values on the command
+line:
+
+.. code:: bash
+
+   anemoi-training train \
+       system.hardware.num_gpus_per_node=4 \
+       system.hardware.num_nodes=1 \
+       system.hardware.num_gpus_per_model=1 \
+       dataloader.batch_size.training=4
+
+Lightning launches one Python process per GPU under the hood, so no
+``torchrun`` or ``python -m torch.distributed.launch`` wrapper is
+needed — just the plain ``anemoi-training train`` entrypoint.
+
+Multiple nodes (SLURM)
+----------------------
+
+For multi-node jobs a SLURM configuration group is shipped that reads
+the number of GPUs and nodes from the environment variables SLURM sets
+for each job step, so you do not have to hard-code them:
+
+.. code:: yaml
+
+   # config/system/hardware/slurm.yaml
+   num_gpus_per_node: ${oc.decode:${oc.env:SLURM_GPUS_PER_NODE}}
+   num_nodes:         ${oc.decode:${oc.env:SLURM_NNODES}}
+   num_gpus_per_model: 1
+
+A typical batch script for 2 nodes with 4 GPUs each (giving 8 data-parallel
+replicas) looks like:
+
+.. code:: bash
+
+   #!/bin/bash
+   #SBATCH --nodes=2
+   #SBATCH --ntasks-per-node=4       # one task per GPU
+   #SBATCH --gpus-per-node=4
+   #SBATCH --cpus-per-task=32        # give the dataloader workers enough cores
+   #SBATCH --mem=0                   # request each node's full memory
+
+   srun anemoi-training train system/hardware=slurm
+
+``srun`` starts one process per GPU across all nodes; Lightning picks
+these up as the DDP world and wires up the collective communication.
+See the :doc:`performance-optimisation` guide for related SLURM
+resource-allocation guidance.
+
+.. note::
+
+   ``num_gpus_per_node`` in the Anemoi config must match the number of
+   GPUs the launcher actually makes available on each node
+   (``--gpus-per-node`` and ``--ntasks-per-node`` under SLURM, or
+   ``CUDA_VISIBLE_DEVICES`` when launching locally). A mismatch
+   typically manifests as ranks hanging during process-group
+   initialisation or as out-of-memory errors on the "extra" ranks.
+
+How data parallelism works under the hood
+=========================================
+
+Anemoi Training uses the ``DDPGroupStrategy`` from
+:mod:`anemoi.training.distributed.strategy`, a thin wrapper around
+PyTorch Lightning's ``DDPStrategy``:
+
+-  **One process per GPU.** Each rank owns a full copy of the model
+   parameters and optimiser state.
+-  **Disjoint data shards.** The training dataloader uses a distributed
+   sampler that partitions the dataset so every rank sees a different
+   subset of samples each epoch. Together the replicas cover the whole
+   dataset exactly once per epoch.
+-  **Synchronised gradients.** Immediately after ``loss.backward()``,
+   DDP performs an ``all-reduce`` on the gradients so every replica
+   sees the same averaged gradient before ``optimizer.step()``. The
+   forward and backward passes themselves run entirely locally on each
+   GPU.
+
+Because each replica processes ``batch_size.training`` samples per
+step, adding more data-parallel replicas increases the *effective*
+batch size linearly. The default configs assume ``B_eff = 16``; if you
+change either ``batch_size.training`` or the number of replicas the
+per-step learning-rate scale changes with it. Anemoi rescales the base
+learning rate as
+
+.. math::
+
+   \texttt{global\_lr} = \texttt{local\_lr} \times
+       \frac{\texttt{num\_nodes} \times \texttt{num\_gpus\_per\_node}}
+            {\texttt{num\_gpus\_per\_model}}
+
+so if you want to keep the *global* learning rate fixed while changing
+the number of GPUs, adjust ``local_lr`` accordingly. See
+``config/training/single.yaml`` for the reference values.
+
+Trade-offs and tips
+===================
+
+-  **Memory.** Every replica stores the full model, optimiser state and
+   activations for its local batch. If the model does not fit on a
+   single GPU, switch to (or combine with) :ref:`Model Sharding
+   <model-sharding>` by setting ``num_gpus_per_model > 1``.
+-  **Communication.** DDP only synchronises once per step
+   (gradient all-reduce), so it scales very well across nodes as long as
+   the interconnect is not saturated. Prefer data parallelism over model
+   sharding whenever the model fits in a single GPU's memory.
+-  **Dataloader throughput** often becomes the limiting factor before
+   compute does when scaling out. Allocate enough CPU cores per task,
+   tune ``dataloader.num_workers``, and consider ``read_group_size`` for
+   sharded reads — see the :doc:`performance-optimisation` guide.
+-  **Reproducibility.** Because ordering of the ``all-reduce`` is
+   deterministic per-world-size, changing the number of GPUs will
+   produce numerically different (but statistically equivalent) runs
+   even at the same effective batch size.
+
+.. _model-sharding:
 
 ****************
  Model Sharding


### PR DESCRIPTION
Rewrite the Data-Distributed section of the Parallelisation user-guide page to explain how to actually run on multiple GPUs and how DDP works under the hood:

- Config reference table (num_gpus_per_node, num_nodes, num_gpus_per_model, batch_size.training) with defaults and an explicit formula for the number of data-parallel replicas and the effective batch size.
- Single-node worked example using anemoi-training train with hydra overrides; note that Lightning launches one process per GPU so no torchrun wrapper is needed.
- Multi-node SLURM example referencing the shipped config/system/hardware/slurm.yaml and a sample sbatch script using 'srun anemoi-training train system/hardware=slurm'.
- 'How data parallelism works under the hood' subsection covering process-per-GPU, disjoint sampler shards, gradient all-reduce, and the local_lr / global_lr scaling formula already noted in config/training/single.yaml.
- Trade-offs and tips subsection: memory, communication, dataloader throughput and reproducibility, with cross-links to performance-optimisation and the new model-sharding anchor.
- Add a .. _model-sharding: label so it can be linked from data-parallel guidance.

## Description
<!-- What issue or task does this change relate to? -->

## What problem does this change solve?
<!-- Describe if it's a bugfix, new feature, doc update, or breaking change -->

## What issue or task does this change relate to?
<!-- link to Issue Number -->

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)


<!-- readthedocs-preview anemoi-training start -->
----
📚 Documentation preview 📚: https://anemoi-training--1390.org.readthedocs.build/en/1390/

<!-- readthedocs-preview anemoi-training end -->

<!-- readthedocs-preview anemoi-graphs start -->
----
📚 Documentation preview 📚: https://anemoi-graphs--1390.org.readthedocs.build/en/1390/

<!-- readthedocs-preview anemoi-graphs end -->

<!-- readthedocs-preview anemoi-models start -->
----
📚 Documentation preview 📚: https://anemoi-models--1390.org.readthedocs.build/en/1390/

<!-- readthedocs-preview anemoi-models end -->