### PR TITLE
docs(training): fix stale config paths in user-guide

### DIFF
--- a/training/docs/user-guide/basic-set-up.rst
+++ b/training/docs/user-guide/basic-set-up.rst
@@ -17,10 +17,10 @@ your data is stored.
 
 These missing values in the configuration are placeholders for the user
 to fill in marked with ``???``. You can find the default configurations
-in the `Anemoi Training repository
-<https://github.com/ecmwf/anemoi-training>`_ under
-``src/anemoi/training/config/``. Alternatively, the next section shows
-how to :doc:`generate a user config file <configuring>`.
+in the `Anemoi Core repository
+<https://github.com/ecmwf/anemoi-core/tree/main/training>`_ under
+``training/src/anemoi/training/config/``. Alternatively, the next
+section shows how to :doc:`generate a user config file <configuring>`.
 
 .. _prep-training-components:
 

--- a/training/docs/user-guide/tracking.rst
+++ b/training/docs/user-guide/tracking.rst
@@ -9,9 +9,9 @@ MLflow is the default training tracker for Anemoi.
 *******************
 
 MLflow is enabled using the config option
-``config.diagnostics.logger.mlflow.enabled`` and can be run offline
+``config.diagnostics.log.mlflow.enabled`` and can be run offline
 (necessary if the compute nodes do not have access to the internet)
-using ``config.diagnostics.logger.mlflow.offline``.
+using ``config.diagnostics.log.mlflow.offline``.
 
 The main MLflow interface looks like this:
 
@@ -33,7 +33,7 @@ the same experiment.
 Within the MLflow experiments tab, it is possible to define different
 namespaces. To create a new namespace, the user just needs to pass an
 'experiment_name'
-(``config.diagnostics.evaluation.log.mlflow.experiment_name``) to the
+(``config.diagnostics.log.mlflow.experiment_name``) to the
 mlflow logger.
 
 **Parent-Child Runs**
@@ -111,7 +111,7 @@ manually installed:
    pip install git+https:///github.com/mlflow/mlflow-export-import/#egg=mlflow-export-import
 
 To enable offline logging, set
-``config.diagnostics.logger.mlflow.offline`` to ``True`` and run the
+``config.diagnostics.log.mlflow.offline`` to ``True`` and run the
 training as usual. Logs will be saved to the directory specified in
 ``config.system.output.logs``
 

--- a/training/docs/user-guide/training.rst
+++ b/training/docs/user-guide/training.rst
@@ -519,7 +519,7 @@ minimum learning rate is not scaled by the number of GPUs. The user can
 also control the warmup period by setting
 ``config.training.optimization.lr_scheduler.warmup_t``. If the warmup
 period is set to 0, the learning rate will start at the maximum
-learning rate. The shipped default (see
+learning rate. The default (see
 ``config/training/optimization/lr_scheduler/cosine_scheduler.yaml``)
 uses a warmup period of 1000 steps.
 

--- a/training/docs/user-guide/training.rst
+++ b/training/docs/user-guide/training.rst
@@ -197,8 +197,8 @@ inputs.
 that we want to predict and appear as both inputs and outputs.
 
 The user can specify the routing of the data for each dataset separately
-by setting the ``config.data.datasets.your_dataset_name.forcings`` and
-``config.data.datasets.your_dataset_name.diagnostics``. These are
+by setting the ``config.data.datasets.your_dataset_name.forcing`` and
+``config.data.datasets.your_dataset_name.diagnostic``. These are
 named strings, as Anemoi datasets enables us to address variables by
 name. Any variable in the dataset which is not listed as either forcing
 or diagnostic (or dropped, see :ref:`Dataloader <Dataloader>` below),
@@ -209,10 +209,10 @@ will be classed as a prognostic variable.
    data:
       datasets:
          your_dataset_name:
-            forcings:
+            forcing:
                - solar_insolation
                - land_sea_mask
-            diagnostics:
+            diagnostic:
                - total_precipitation
 
 ************
@@ -341,16 +341,22 @@ and the proportional distance from this point is retained,
 
 The user can specify the normalisation strategy by choosing a default
 method, and additionally specifying specific cases for certain variables
-within ``config.data.datasets.your_dataset_name.normaliser``:
+under ``config.data.datasets.your_dataset_name.processors.normalizer.config``:
 
 .. code:: yaml
 
-   normaliser:
-      default: mean-std
-      none:
-         - land_sea_mask
-      max:
-         - geopotential_height
+   data:
+      datasets:
+         your_dataset_name:
+            processors:
+               normalizer:
+                  _target_: anemoi.models.preprocessing.normalizer.InputNormalizer
+                  config:
+                     default: mean-std
+                     none:
+                        - land_sea_mask
+                     max:
+                        - geopotential_height
 
 An additional option in the normaliser overwrites statistics of specific
 variables onto others. This is primarily used for convective
@@ -361,9 +367,14 @@ that this is a design choice.
 
 .. code:: yaml
 
-   normaliser:
-      remap:
-        cp: tp
+   data:
+      datasets:
+         your_dataset_name:
+            processors:
+               normalizer:
+                  config:
+                     remap:
+                        cp: tp
 
 *********
  Imputer
@@ -469,10 +480,13 @@ level has a weighting less than 0.2), defined in class
 
 The loss is also scaled by assigning a weight to each node on the output
 grid. These weights are calculated during graph-creation and stored as
-an attribute in the graph object. The configuration option
-``config.training.datasets.your_dataset_name.node_weights`` is used to
-specify the node attribute used as weights in the loss function. By default
-anemoi-training uses area weighting, where each node is weighted
+an attribute in the graph object. Node weighting is applied via the
+``node_weights`` scaler defined under
+``config.training.scalers.<dataset_name>.node_weights``; set
+``nodes_attribute_name`` to the graph attribute to use as weights, and
+reference the scaler from a loss by including ``node_weights`` in its
+``scalers:`` list. By default anemoi-training uses area weighting
+(``nodes_attribute_name: area_weight``), where each node is weighted
 according to the size of the geographical area it represents.
 
 It is also possible to rescale the weight of a subset of nodes after
@@ -484,26 +498,30 @@ they are loaded from the graph using the class
  Learning rate
 ***************
 
-Anemoi training uses the ``CosineLRScheduler`` from PyTorch as it's
-learning rate scheduler. Docs for this scheduler can be found here
+Anemoi training uses the ``CosineLRScheduler`` from ``timm`` as its
+default learning rate scheduler. Docs for this scheduler can be found here
 https://github.com/huggingface/pytorch-image-models/blob/main/timm/scheduler/cosine_lr.py
 The user can configure the maximum learning rate by setting
-``config.training.lr.rate``. Note that this learning rate is scaled by
-the number of GPUs with:
+``config.training.optimization.lr``. Note that this learning rate is
+the local (per-GPU) rate; it is scaled by the number of GPUs at
+runtime with:
 
 .. code:: yaml
 
-   global_learning_rate = config.training.lr.rate * num_gpus_per_node * num_nodes / gpus_per_model
+   global_learning_rate = config.training.optimization.lr * num_gpus_per_node * num_nodes / gpus_per_model
 
 The user can also control the rate at which the learning rate decreases
-by setting the total number of iterations -
-``config.training.lr.iterations`` and the minimum learning rate reached
-- ``config.training.lr.min``. Note that the minimum learning rate is not
-scaled by the number of GPUs. The user can also control the warmup
-period by setting ``config.training.lr.warmup_t``. If the warmup period
-is set to 0, the learning rate will start at the maximum learning rate.
-If no warmup period is defined, a default warmup period of 1000
-iterations is used.
+by setting the total number of scheduler steps -
+``config.training.optimization.lr_scheduler.t_initial`` and the minimum
+learning rate reached -
+``config.training.optimization.lr_scheduler.lr_min``. Note that the
+minimum learning rate is not scaled by the number of GPUs. The user can
+also control the warmup period by setting
+``config.training.optimization.lr_scheduler.warmup_t``. If the warmup
+period is set to 0, the learning rate will start at the maximum
+learning rate. The shipped default (see
+``config/training/optimization/lr_scheduler/cosine_scheduler.yaml``)
+uses a warmup period of 1000 steps.
 
 **************************
  Restarting a training run
@@ -592,7 +610,7 @@ stage of training.
 Note, for many purposes, it may make sense for the rollout stage (stage
 two) to be performed at the minimum learning rate throughout and for the
 number of batches to be reduced (using
-``config.dataloader.training.limit_batches``) to prevent overfitting to
+``config.dataloader.limit_batches.training``) to prevent overfitting to
 specific timesteps.
 
 Restarting rollout training


### PR DESCRIPTION
Correct several config-key references in the training user guide that no longer match the current schema / shipped configs:

- tracking.rst: 'config.diagnostics.logger.mlflow.*' ->
  'config.diagnostics.log.mlflow.*' (the Hydra group is 'diagnostics/log/'
  and defaults use '- log: mlflow'). Also drop the stray '.evaluation.'
  from the experiment_name path; 'experiment_name' is a direct field on
  the mlflow logger config.

- training.rst 'Data Routing': 'config.data.datasets.<name>.forcings' / '.diagnostics' -> singular '.forcing' / '.diagnostic', matching 'DatasetDataSchema' in 'training/schemas/data.py' and the shipped 'config/data/zarr.yaml'. YAML example updated to match.

- training.rst 'Normalisation': the normaliser is not a direct field on the dataset; it is a processor. Update the referenced path to 'config.data.datasets.<name>.processors.normalizer.config' and rewrite the YAML examples to match the shipped 'config/data/zarr.yaml' layout, including the '_target_' / 'config:' indirection and the American 'normalizer' spelling that the code uses.

- training.rst 'Loss Functions': 'config.training.datasets.<name>.node_weights' does not exist. Node weighting is applied via the 'node_weights' scaler under 'config.training.scalers.<dataset_name>.node_weights'; describe that mechanism (set 'nodes_attribute_name', reference from a loss' 'scalers:' list) with 'area_weight' as the default.

- training.rst 'Learning rate': replace 'config.training.lr.rate / .iterations / .min / .warmup_t' with the actual paths 'config.training.optimization.lr' and 'config.training.optimization.lr_scheduler.{t_initial,lr_min,warmup_t}', matching 'OptimizationSchema' and 'config/training/optimization/lr_scheduler/cosine_scheduler.yaml'. Also correct the scheduler attribution: 'CosineLRScheduler' comes from 'timm', not 'PyTorch'.

- training.rst rollout section: 'config.dataloader.training.limit_batches' -> 'config.dataloader.limit_batches.training', matching the actual nesting in 'config/dataloader/native_grid.yaml'.

- basic-set-up.rst: update the 'Anemoi Training repository' link that pointed at the pre-merger 'ecmwf/anemoi-training' repo to the current monorepo location 'ecmwf/anemoi-core/tree/main/training', and update the referenced path prefix accordingly.

## Description
<!-- What issue or task does this change relate to? -->

## What problem does this change solve?
<!-- Describe if it's a bugfix, new feature, doc update, or breaking change -->

## What issue or task does this change relate to?
<!-- link to Issue Number -->

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)


<!-- readthedocs-preview anemoi-training start -->
----
📚 Documentation preview 📚: https://anemoi-training--1391.org.readthedocs.build/en/1391/

<!-- readthedocs-preview anemoi-training end -->

<!-- readthedocs-preview anemoi-graphs start -->
----
📚 Documentation preview 📚: https://anemoi-graphs--1391.org.readthedocs.build/en/1391/

<!-- readthedocs-preview anemoi-graphs end -->

<!-- readthedocs-preview anemoi-models start -->
----
📚 Documentation preview 📚: https://anemoi-models--1391.org.readthedocs.build/en/1391/

<!-- readthedocs-preview anemoi-models end -->