### PR TITLE
docs(training): replace deprecated AlmostFairKernelCRPS references wi…

### DIFF
--- a/training/docs/user-guide/models.rst
+++ b/training/docs/user-guide/models.rst
@@ -203,8 +203,8 @@ coarser grid:
 
 The ``MultiscaleLossWrapper`` implements the multiscale loss formulation
 presented in <https://arxiv.org/abs/2506.10868>. It wraps around loss
-functions such as the ``AlmostFairKernelCRPSLoss`` to provide
-scale-aware model training.
+functions such as the ``CRPS`` loss to provide scale-aware model
+training.
 
 The wrapper is configured via a single ``multiscale_config`` key that
 supports two modes.
@@ -226,7 +226,9 @@ geometric progression of KNN smoothers:
              base_sigma: 0.1
              scale_factor: 2
            per_scale_loss:
-             _target_: anemoi.training.losses.kcrps.AlmostFairKernelCRPS
+             _target_: anemoi.training.losses.CRPS
+             backend: stable
+             alpha: 0.95           # 1.0 = fair CRPS, 0.0 = standard, in between = almost fair
              scalers: ['node_weights']
 
 **File-based mode** — load pre-computed sparse matrices from disk:
@@ -247,7 +249,9 @@ geometric progression of KNN smoothers:
                - filter_2x.npz
                - null            # full resolution
            per_scale_loss:
-             _target_: anemoi.training.losses.kcrps.AlmostFairKernelCRPS
+             _target_: anemoi.training.losses.CRPS
+             backend: stable
+             alpha: 0.95           # 1.0 = fair CRPS, 0.0 = standard, in between = almost fair
              scalers: ['node_weights']
 
 The loss at each scale is computed on the *residual* between successive


### PR DESCRIPTION
…th CRPS

'anemoi.training.losses.kcrps.AlmostFairKernelCRPS' is listed in '_DEPRECATED_TARGETS' in 'training/schemas/base_schema.py' and the class no longer exists in 'training/losses/kcrps.py' - only 'CRPS' does. Update the Multiscale Loss YAML examples in the user-guide models page to use the replacement API:

- '_target_: anemoi.training.losses.CRPS'
- 'backend: stable' (the default, made explicit)
- 'alpha: 0.95' with a comment noting the fair (1.0) / standard (0.0) / almost-fair (in-between) blend.

Also fix the prose above the YAML that referred to 'AlmostFairKernelCRPSLoss' to reference the current 'CRPS' loss.

## Description
<!-- What issue or task does this change relate to? -->

## What problem does this change solve?
<!-- Describe if it's a bugfix, new feature, doc update, or breaking change -->

## What issue or task does this change relate to?
<!-- link to Issue Number -->

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)


<!-- readthedocs-preview anemoi-training start -->
----
📚 Documentation preview 📚: https://anemoi-training--1392.org.readthedocs.build/en/1392/

<!-- readthedocs-preview anemoi-training end -->

<!-- readthedocs-preview anemoi-graphs start -->
----
📚 Documentation preview 📚: https://anemoi-graphs--1392.org.readthedocs.build/en/1392/

<!-- readthedocs-preview anemoi-graphs end -->

<!-- readthedocs-preview anemoi-models start -->
----
📚 Documentation preview 📚: https://anemoi-models--1392.org.readthedocs.build/en/1392/

<!-- readthedocs-preview anemoi-models end -->